### PR TITLE
Fix bug in eHata rolling hills correction; add py ITM wrapper

### DIFF
--- a/src/prop/ehata/ehata.py
+++ b/src/prop/ehata/ehata.py
@@ -76,22 +76,22 @@ def ExtendedHata_PropagationLoss(f, hb, hm, region, profile):
   distance = float(profile[0] * resolution)
 
   basic_loss_db, above_median_loss_db = ExtendedHata_MedianBasicPropLoss(f, distance, hb_eff, hm_eff, region)
-  print 'Basic loss = %f (%f)' % (basic_loss_db, above_median_loss_db)
+  #print 'Basic loss = %f (%f)' % (basic_loss_db, above_median_loss_db)
 
   Kir = IsolatedRidgeCorrection(profile)
-  print 'Kir = %f' % Kir
+  #print 'Kir = %f' % Kir
 
   # TODO: get better sea indicator than elevation==0
   Kmp = MixedPathCorrection(profile, [float(i) == 0.0 for i in profile])
-  print 'Kmp = %f' % Kmp
+  #print 'Kmp = %f' % Kmp
 
   # If isolated ridge applies, then don't do rolling hill and general slope corrections
   if Kir == 0.0:
     Krh, Kh, Khf = RollingHillyCorrection(profile)
-    print 'Krh=%f' % Krh
+    #print 'Krh=%f' % Krh
 
     Kgs = GeneralSlopeCorrection(profile)
-    print 'Kgs=%f' % Kgs
+    #print 'Kgs=%f' % Kgs
 
     return basic_loss_db + Krh - Kgs - Kmp
 
@@ -247,7 +247,7 @@ def RollingHillyCorrection(elev):
   prof = []
   reversed_prof = profile[::-1]
   for i in range(0, int(math.ceil(radiusKm/resolution))):
-    if i*resolution <= radiusKm:
+    if i*resolution <= radiusKm and i < len(reversed_prof):
       prof.append(reversed_prof[i])
 
   prof = sorted(prof)
@@ -259,7 +259,7 @@ def RollingHillyCorrection(elev):
   irregularity = highest - lowest
 
   if distance < 10000.0:
-    irregularity = irregularity*(1-0.8*math.exp(-.2))/(1-0.8(math.exp(-.02*distance)))
+    irregularity = irregularity*(1.0-0.8*math.exp(-.2))/(1.0-0.8*(math.exp(-.02*distance)))
 
   if irregularity < 10.0:
     return 0.0, 0.0, 0.0

--- a/src/prop/itm/itm.cpp
+++ b/src/prop/itm/itm.cpp
@@ -16,6 +16,7 @@
 #include <stdlib.h>
 #include <assert.h>
 #include <string.h>
+//#include <iostream>
 
 #include "itm.h"
 
@@ -388,25 +389,33 @@ void lrprop (double d,
 	  wscat=false;
 	  if(prop.wn<0.838 || prop.wn>210.0)
         	{ prop.kwx=mymax(prop.kwx,1);
+		  //std::cout << "freq out of range\n";
 		}
 	  for(j=0;j<2;j++)
 	    if(prop.hg[j]<1.0 || prop.hg[j]>1000.0)
           	{ prop.kwx=mymax(prop.kwx,1);
+	          //std::cout << "heights out of range [1, 1000]\n";
 		}
 	  for(j=0;j<2;j++)
 	    if( abs(prop.the[j]) >200e-3 || prop.dl[j]<0.1*propa.dls[j] ||
 		   prop.dl[j]>3.0*propa.dls[j] )
 		{ prop.kwx=mymax(prop.kwx,3);
+		  //std::cout << "the, dl-dls out of range\n";
+		  //if (abs(prop.the[j]) > 200e-3) { std::cout << "  the[j] oor " << prop.the[j] << "\n"; }
+		  //if (prop.dl[j]<0.1*propa.dls[j]) { std::cout << "  dl dls " << prop.dl[j] << " " << propa.dls[j] << "\n"; }
+	          //if (prop.dl[j]>3.0*propa.dls[j]) { std::cout << "     more than 3x\n"; }
 		}
 	  if( prop.ens < 250.0   || prop.ens > 400.0  || 
 	      prop.gme < 75e-9 || prop.gme > 250e-9 || 
 		  prop_zgnd.real() <= abs(prop_zgnd.imag()) || 
 		  prop.wn  < 0.419   || prop.wn  > 420.0 )
 	     	{ prop.kwx=4;
+		  //std::cout << "combination of freq, ens, gme, zgnd out of range\n";
 		}
           for(j=0;j<2;j++)
 	    if(prop.hg[j]<0.5 || prop.hg[j]>3000.0)
 		{ prop.kwx=4;
+		  //std::cout << "heights out of range [.5, 3000]\n";
 		}
 	  dmin=abs(prop.he[0]-prop.he[1])/200e-3;
 	  q=adiff(0.0,prop,propa);
@@ -426,12 +435,15 @@ void lrprop (double d,
     {
 	  if(prop.dist>1000e3)
 	    { prop.kwx=mymax(prop.kwx,1);
+	      //std::cout << "distance out of range 1000000";
 	    }
 	  if(prop.dist<dmin)
 	    { prop.kwx=mymax(prop.kwx,3);
+	      //std::cout << "distance less than dmin";
 	    }
 	  if(prop.dist<1e3 || prop.dist>2000e3)
 	    { prop.kwx=4;
+	      //std::cout << "distance less than 1km or more than 2000km";
 	    }
     }
   if(prop.dist<propa.dlsa)
@@ -557,6 +569,7 @@ double avar(double zzt, double zzl, double zzc,
 			   { propv.klim = 5;
 			     temp_klim = 4;
 			     { prop.kwx=mymax(prop.kwx,2);
+			       //std::cout << "klim out of range";
 				 }
 			   }
 			 cv1 = bv1[temp_klim];
@@ -593,6 +606,7 @@ double avar(double zzt, double zzl, double zzc,
 			 if(kdv<0 || kdv>3)
 			   { kdv=0;
 			     prop.kwx=mymax(prop.kwx,2);
+			     //std::cout << "kdv out of range";
 			   }
 		   case 3:
 		     q=log(0.133*prop.wn);
@@ -640,6 +654,7 @@ double avar(double zzt, double zzl, double zzc,
 	}
   if(fabs(zt)>3.1 || fabs(zl)>3.1 || fabs(zc)>3.1)
       { prop.kwx=mymax(prop.kwx,1);
+	//std::cout << "zt/zl/zc out of range";
 	  }
   if(zt<0.0)
     sgt=sgtm;

--- a/src/prop/itm/itm_py.cpp
+++ b/src/prop/itm/itm_py.cpp
@@ -55,12 +55,7 @@ static PyObject* itm_point_to_point(PyObject* self, PyObject* args) {
                  dbloss, strmode, errnum);
   delete[] elev;
 
-  // TODO: return a tuple with loss, err, strmode.
-  if (errnum == 0) {
-    return PyFloat_FromDouble(dbloss);
-  } else {
-    return PyFloat_FromDouble(-errnum);
-  }
+  return Py_BuildValue("dis", dbloss, errnum, strmode);
 }
 
 static PyMethodDef ITMMethods[] = {

--- a/src/prop/itm/pytm.py
+++ b/src/prop/itm/pytm.py
@@ -1,0 +1,112 @@
+# Copyright 2017 SAS Project Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This module wraps the ITM implementation, checking validity of
+# input parameters and returning error messages if there are any
+# out-of-bounds values.
+
+import itm
+
+# Calculate the point-to-point predicted loss for a path.
+# Arguments:
+#       elevations,
+#            The first item in the list is the number of elevation points
+#            minus one. The second is the distance in meters between elevation
+#            points in the profile. Thus the total distance is (first)*(second)
+#            and there should be (first+1) profile elevations supplied in the
+#            vector following those initial values.
+#       transmitter_height_meters,  (above ground level)
+#       receiver_height_meters,     (above ground level)
+#       dielectric_constant,
+#            Typical value is 15 for ground, 81 for water.
+#       soil_conductivity,
+#            Typical value is 0.005 for ground, 0.01 for fresh water, 5.0 for
+#            sea water.
+#       refractivity,
+#            From 250 to 400. Typical value is 314. There are maps of usual
+#            values based on geography available from ITU.
+#       frequency_mhz,              (frequency of the emission)
+#       radio_climate,
+#            Values are Equatorial=1, Continental Subtropical=2, Maritime
+#            Tropical=3, Desert=4, Continental Temperate (typical)=5,
+#            Maritime Temperate (over land)=6, Maritime Temperate (over sea)=7
+#       polarization,
+#            0=horizontal, 1=vertical
+#       confidence,                  (value between 0.001 and 0.999)
+#            This value indicates a fraction of situations in which the actual
+#            loss will not exceed the modeled loss in similar situations.
+#       reliability)
+#            This value indicates a fraction of the time in which the actual
+#            loss will not exceed the modeled loss for a particular radio
+#            station.
+def point_to_point(elevation, transmitter_height_meters, receiver_height_meters,
+                   dielectric_constant, soil_conductivity, refractivity,
+                   frequency_mhz, radio_climate, polarization,
+                   confidence, reliability):
+  if transmitter_height_meters < 1.0:
+    print 'Transmitter height less than 1m'
+    return -1
+
+  if transmitter_height_meters > 1000.0:
+    raise Exception('Transmitter height greater than 1000m')
+
+  if receiver_height_meters < 1.0:
+    raise Exception('Receiver height less than 1m')
+
+  if receiver_height_meters > 1000.0:
+    raise Exception('Receiver height greater than 1000m')
+
+  if frequency_mhz < 40.0:
+    raise Exception('Frequency less than 40MHz')
+
+  if frequency_mhz > 10000.0:
+    raise Exception('Frequency greater than 10,000 MHz')
+
+  if refractivity < 250.0:
+    raise Exception('Refractivity less than 250')
+
+  if refractivity > 400.0:
+    raise Exception('Refractivity more than 400')
+
+  if polarization != 0 and polarization != 1:
+    raise Exception('Bad polarization value (not 0 or 1)')
+
+  if (radio_climate != 1 and radio_climate != 2 and
+      radio_climate != 3 and radio_climate != 4 and
+      radio_climate != 5 and radio_climate != 6 and radio_climate != 7):
+    raise Exception('Bad radio climate value (not 1, 2, 3, 4, 5, 6, 7)')
+
+  if confidence < 0.0:
+    raise Exception('Confidence less than 0')
+
+  if confidence > 1.0:
+    raise Exception('Confidence greater than 1')
+
+  if reliability < 0.0:
+    raise Exception('Confidence less than 0')
+
+  if reliability > 1.0:
+    raise Exception('Confidence greater than 1')
+
+  loss, err, mode = itm.point_to_point(elevation, transmitter_height_meters, receiver_height_meters,
+                                       dielectric_constant, soil_conductivity, refractivity,
+                                       frequency_mhz, radio_climate, polarization,
+                                       confidence, reliability)
+
+  if err != 0:
+    print 'Warning: got an applicability warning [%d] in ITM for mode %s' % (err, mode)
+
+  return loss
+
+# TODO: main method that takes freq/location and prints loss

--- a/src/prop/itm/test_itm.py
+++ b/src/prop/itm/test_itm.py
@@ -67,7 +67,11 @@ path = [ 156, 499,
          94,   91,  105,  122,  122,  122,  122,  122,  137,  137,  137,  137,  137,  137,  137,
          137, 140,  144,  147,  150,  152,  159 ]
 
-loss = itm.point_to_point(path, 143.9, 8.5, 15, .005, 314, 41.5, 5, 0, .5, .5)
+loss, err, mode = itm.point_to_point(path, 143.9, 8.5, 15, .005, 314, 41.5, 5, 0, .5, .5)
+
+if err != 0:
+  print "FAIL: expected err=0"
+
 if abs(loss-135.8) > 0.2:
   print "FAIL: expected 135.8, got ", loss
 else:


### PR DESCRIPTION
Also add changes to ITM wrapper to do better bounds checking
and bad values detection, and accept output from cases where
warnings are found with parameter values (ITM marks a pretty
wide variety of inputs as resulting in less accurate output.)