### PR TITLE
Add ITM and eHata routines for statistical propagation estimates

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,2 +1,2 @@
 *.pyc
-.DS_Store
+

--- a/src/prop/ehata/test/ehata_effheight_test.py
+++ b/src/prop/ehata/test/ehata_effheight_test.py
@@ -1,3 +1,17 @@
+#    Copyright 2016 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 import os,sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import ehata

--- a/src/prop/ehata/test/ehata_gen_slope_test.py
+++ b/src/prop/ehata/test/ehata_gen_slope_test.py
@@ -1,3 +1,17 @@
+#    Copyright 2016 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 import os,sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import ehata

--- a/src/prop/ehata/test/ehata_isolated_ridge_test.py
+++ b/src/prop/ehata/test/ehata_isolated_ridge_test.py
@@ -1,3 +1,17 @@
+#    Copyright 2016 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 import os,sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import ehata

--- a/src/prop/ehata/test/ehata_loc_var_test.py
+++ b/src/prop/ehata/test/ehata_loc_var_test.py
@@ -1,3 +1,17 @@
+#    Copyright 2016 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 import os,sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import ehata

--- a/src/prop/ehata/test/ehata_median_loss_test.py
+++ b/src/prop/ehata/test/ehata_median_loss_test.py
@@ -1,3 +1,17 @@
+#    Copyright 2016 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 import os,sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import ehata

--- a/src/prop/ehata/test/ehata_prop_loss_stat_test.py
+++ b/src/prop/ehata/test/ehata_prop_loss_stat_test.py
@@ -1,4 +1,4 @@
-#    Copyright 2016 SAS Project Authors. All Rights Reserved.
+#    Copyright 2017 SAS Project Authors. All Rights Reserved.
 #
 #    Licensed under the Apache License, Version 2.0 (the "License");
 #    you may not use this file except in compliance with the License.
@@ -40,15 +40,18 @@ for reg in region:
       profile[0] = int(profile[0])
       profile = profile[0:int(profile[0])+3]
 
-      loss_db = ehata.ExtendedHata_PropagationLoss(3500, 50, 3, reg, profile)
+      loss_db = ehata.ExtendedHata_PropagationLossStat(3500, 50, 3, reg, profile, [.01, .5, .99])
 
       delta = 0.15
       if target in [39, 44, 60, 65, 67, 70]:
         delta = 0.5
         # account for variances in rolling hill correction
 
-      if math.fabs(float(loss[0][target]) - loss_db) > delta:
-        print('FAIL prop loss on profile %d: %f vs %f' % (target, float(loss[0][target]), loss_db))
+      if math.fabs(float(loss[0][target]) - loss_db[1]) > delta:
+        print('FAIL prop loss stat test on profile %d: %f vs %f' % (target, float(loss[0][target]), loss_db[1]))
+        exit()
+      if loss_db[0] > loss_db[2]:
+        print('FAIL prop loss stat test on profile %d: %f vs %f' % (target, loss_db[0], loss_db[2]))
         exit()
       target = target + 1
 

--- a/src/prop/ehata/test/ehata_rollinghill_test.py
+++ b/src/prop/ehata/test/ehata_rollinghill_test.py
@@ -1,3 +1,17 @@
+#    Copyright 2016 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 import os,sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import ehata

--- a/src/prop/ehata/test/ehata_sea_corr_test.py
+++ b/src/prop/ehata/test/ehata_sea_corr_test.py
@@ -1,3 +1,17 @@
+#    Copyright 2016 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
 import os,sys
 sys.path.append(os.path.join(os.path.dirname(__file__), '..'))
 import ehata

--- a/src/prop/itm/itm.cpp
+++ b/src/prop/itm/itm.cpp
@@ -1022,6 +1022,102 @@ void point_to_point(double elev[], double tht_m, double rht_m,
 }
 
 
+//********************************************************
+//* Point-To-Point Statistics Mode Calculations          *
+//********************************************************
+
+// Takes a vector of rel values, returns statistical estimates of
+// the point-to-point loss given these values of reliability, putting
+// the results into the dbloss array, which must be sized the same
+// as the input rel array.
+void point_to_pointSTAT(double elev[], double tht_m, double rht_m,
+          double eps_dielect, double sgm_conductivity, double eno_ns_surfref,
+		  double frq_mhz, int radio_climate, int pol, double conf, double rel[],
+		  int num, double dbloss[], char *strmode, int &errnum)
+	// pol: 0-Horizontal, 1-Vertical
+	// radio_climate: 1-Equatorial, 2-Continental Subtropical, 3-Maritime Tropical,
+	//                4-Desert, 5-Continental Temperate, 6-Maritime Temperate, Over Land,
+	//                7-Maritime Temperate, Over Sea
+	// conf, rel: .01 to .99
+	// elev[]: [num points - 1], [delta dist(meters)], [height(meters) point 1], ..., [height(meters) point n]
+	// errnum: 0- No Error.
+	//         1- Warning: Some parameters are nearly out of range.
+	//                     Results should be used with caution.
+	//         2- Note: Default parameters have been substituted for impossible ones.
+	//         3- Warning: A combination of parameters is out of range.
+	//                     Results are probably invalid.
+	//         Other-  Warning: Some parameters are out of range.
+	//                          Results are probably invalid.
+{
+
+  prop_type   prop;
+  propv_type  propv;
+  propa_type  propa;
+  double zsys=0;
+  double zc, zr;
+  double eno, enso, q;
+  long ja, jb, i, np;
+  //double dkm;
+  //double xkm;
+  double fs;
+
+  prop.hg[0] = tht_m;   prop.hg[1] = rht_m;
+  propv.klim = radio_climate;
+  prop.kwx = 0;
+  propv.lvar = 5;
+  prop.mdp = -1;
+  zc = qerfi(conf);
+  np = (long)elev[0];
+  //dkm = (elev[1] * elev[0]) / 1000.0;
+  //xkm = elev[1] / 1000.0;
+  eno = eno_ns_surfref;
+  enso = 0.0;
+  q = enso;
+  if(q<=0.0)
+  {
+    ja = 3.0 + 0.1 * elev[0];
+	jb = np - ja + 6;
+	for(i=ja-1;i<jb;++i)
+      zsys+=elev[i];
+    zsys/=(jb-ja+1);
+	q=eno;
+  }
+
+  // Discussions with NIST: the value used for the mdvar parameter
+  // in NTIA model was 3 instead of 12.
+  //propv.mdvar=12;
+  //propv.mdvar=3;
+
+  // Further discussions in Winnforum Propagation TG: mdvar=13
+  // corresponds to the statistics we intend to use.
+  propv.mdvar=13;
+
+  qlrps(frq_mhz,zsys,q,pol,eps_dielect,sgm_conductivity,prop);
+  qlrpfl(elev,propv.klim,propv.mdvar,prop,propa,propv);
+  fs = 32.45 + 20.0 * log10(frq_mhz) + 20.0 * log10(prop.dist / 1000.0);
+  q = prop.dist - propa.dla;
+  if(int(q)<0.0)
+    strcpy(strmode,"Line-Of-Sight Mode");
+  else
+    { if(int(q)==0.0)
+        strcpy(strmode,"Single Horizon");
+      else if(int(q)>0.0)
+        strcpy(strmode,"Double Horizon");
+      if(prop.dist<=propa.dlsa || prop.dist <= propa.dx)
+        strcat(strmode,", Diffraction Dominant");
+      else if(prop.dist>propa.dx)
+        strcat(strmode, ", Troposcatter Dominant");
+    }
+  for (int inum = 0; inum < num; inum++) {
+    zr = qerfi(rel[inum]);
+    dbloss[inum] = avar(zr,0.0,zc,prop,propv) + fs;
+  }
+  errnum = prop.kwx;
+}
+
+
+
+
 void point_to_pointMDH (double elev[], double tht_m, double rht_m,
           double eps_dielect, double sgm_conductivity, double eno_ns_surfref,
 		  double frq_mhz, int radio_climate, int pol, double timepct, double locpct, double confpct, 

--- a/src/prop/itm/itm.h
+++ b/src/prop/itm/itm.h
@@ -107,6 +107,11 @@ void point_to_point(double elev[], double tht_m, double rht_m,
                     double conf, double rel,
                     double &dbloss, char *strmode, int &errnum);
 
+void point_to_pointSTAT(double elev[], double tht_m, double rht_m,
+                        double eps_dielect, double sgm_conductivity, double eno_ns_surfref,
+                        double frq_mhz, int radio_climate, int pol, double conf, double rel[],
+                        int num, double dbloss[], char *strmode, int &errnum);
+
 void point_to_pointMDH(double elev[], double tht_m, double rht_m,
                        double eps_dielect, double sgm_conductivity, double eno_ns_surfref,
                        double frq_mhz, int radio_climate, int pol,

--- a/src/prop/itm/itm_py.cpp
+++ b/src/prop/itm/itm_py.cpp
@@ -58,8 +58,76 @@ static PyObject* itm_point_to_point(PyObject* self, PyObject* args) {
   return Py_BuildValue("dis", dbloss, errnum, strmode);
 }
 
+static PyObject* itm_point_to_point_stat(PyObject* self, PyObject* args) {
+  PyObject* elev_obj = NULL;
+  double tht_m, rht_m;
+  double eps_dielect, sgm_conductivity, eno_ns_surfref;
+  double frq_mhz;
+  int radio_climate, pol;
+  double conf;
+  PyObject* rel_obj = NULL;
+  int num_rel;
+  if (!PyArg_ParseTuple(args, "OddddddiidOi:point_to_point",
+                        &elev_obj, &tht_m, &rht_m, &eps_dielect, &sgm_conductivity, &eno_ns_surfref,
+                        &frq_mhz, &radio_climate, &pol, &conf, &rel_obj, &num_rel)) {
+    return NULL;
+  }
+
+  if (!PyList_Check(elev_obj)) {
+    return NULL;
+  }
+ 
+  if (!PyList_Check(rel_obj)) {
+    return NULL;
+  }
+
+  Py_ssize_t size = PyList_Size(elev_obj);
+  double* elev = new double[size];
+  for (Py_ssize_t i = 0; i < size; i++) {
+    PyObject* i_obj = PyList_GetItem(elev_obj, i);
+    double elev_val = PyFloat_AsDouble(i_obj);
+    if (PyErr_Occurred()) {
+      delete[] elev;
+      return NULL;
+    }
+    elev[i] = elev_val;
+  }
+  elev[0] = size-3;
+
+  size = PyList_Size(rel_obj);
+  double* rel = new double[size];
+  for (Py_ssize_t i = 0; i < size; i++) {
+    PyObject* i_obj = PyList_GetItem(rel_obj, i);
+    double rel_val = PyFloat_AsDouble(i_obj);
+    if (PyErr_Occurred()) {
+      delete[] rel;
+      return NULL;
+    }
+    rel[i] = rel_val;
+  }
+
+  double* dbloss = new double[size];
+  char strmode[100];
+  int errnum;
+  point_to_pointSTAT(elev, tht_m, rht_m, eps_dielect, sgm_conductivity, eno_ns_surfref,
+                     frq_mhz, radio_climate, pol, conf, rel, num_rel,
+                     dbloss, strmode, errnum);
+  delete[] elev;
+  delete[] rel;
+
+  PyObject* loss = PyList_New(num_rel);
+  for (int i = 0; i < num_rel; i++) {
+    PyList_SetItem(loss, i, Py_BuildValue("d", dbloss[i]));
+  }
+  
+  delete[] dbloss;
+
+  return Py_BuildValue("Ois", loss, errnum, strmode);
+}
+
 static PyMethodDef ITMMethods[] = {
   {"point_to_point", itm_point_to_point, METH_VARARGS, "Point-to-point model"},
+  {"point_to_point_stat", itm_point_to_point_stat, METH_VARARGS, "Point-to-point model (stats)"},
   {NULL, NULL, 0, NULL}
 };
 

--- a/src/prop/itm/pytm.py
+++ b/src/prop/itm/pytm.py
@@ -94,10 +94,10 @@ def point_to_point(elevation, transmitter_height_meters, receiver_height_meters,
     raise Exception('Confidence greater than 1')
 
   if reliability < 0.0:
-    raise Exception('Confidence less than 0')
+    raise Exception('Reliability less than 0')
 
   if reliability > 1.0:
-    raise Exception('Confidence greater than 1')
+    raise Exception('Reliability greater than 1')
 
   loss, err, mode = itm.point_to_point(elevation, transmitter_height_meters, receiver_height_meters,
                                        dielectric_constant, soil_conductivity, refractivity,
@@ -108,5 +108,59 @@ def point_to_point(elevation, transmitter_height_meters, receiver_height_meters,
     print 'Warning: got an applicability warning [%d] in ITM for mode %s' % (err, mode)
 
   return loss
+
+def point_to_point_stat(elevation, transmitter_height_meters, receiver_height_meters,
+                   dielectric_constant, soil_conductivity, refractivity,
+                   frequency_mhz, radio_climate, polarization,
+                   confidence, reliability):
+  if transmitter_height_meters < 1.0:
+    print 'Transmitter height less than 1m'
+    return -1
+
+  if transmitter_height_meters > 1000.0:
+    raise Exception('Transmitter height greater than 1000m')
+
+  if receiver_height_meters < 1.0:
+    raise Exception('Receiver height less than 1m')
+
+  if receiver_height_meters > 1000.0:
+    raise Exception('Receiver height greater than 1000m')
+
+  if frequency_mhz < 40.0:
+    raise Exception('Frequency less than 40MHz')
+
+  if frequency_mhz > 10000.0:
+    raise Exception('Frequency greater than 10,000 MHz')
+
+  if refractivity < 250.0:
+    raise Exception('Refractivity less than 250')
+
+  if refractivity > 400.0:
+    raise Exception('Refractivity more than 400')
+
+  if polarization != 0 and polarization != 1:
+    raise Exception('Bad polarization value (not 0 or 1)')
+
+  if (radio_climate != 1 and radio_climate != 2 and
+      radio_climate != 3 and radio_climate != 4 and
+      radio_climate != 5 and radio_climate != 6 and radio_climate != 7):
+    raise Exception('Bad radio climate value (not 1, 2, 3, 4, 5, 6, 7)')
+
+  if confidence < 0.0:
+    raise Exception('Confidence less than 0')
+
+  if confidence > 1.0:
+    raise Exception('Confidence greater than 1')
+
+  loss, err, mode = itm.point_to_point_stat(elevation, transmitter_height_meters, receiver_height_meters,
+                                       dielectric_constant, soil_conductivity, refractivity,
+                                       frequency_mhz, radio_climate, polarization,
+                                       confidence, reliability, len(reliability))
+
+  if err != 0:
+    print 'Warning: got an applicability warning [%d] in ITM for mode %s' % (err, mode)
+
+  return loss
+
 
 # TODO: main method that takes freq/location and prints loss

--- a/src/prop/itm/test_itm.py
+++ b/src/prop/itm/test_itm.py
@@ -77,3 +77,10 @@ if abs(loss-135.8) > 0.2:
 else:
   print "SUCCESS: expected 135.8, got ", loss
 
+sloss, err, mode = itm.point_to_point_stat(path, 143.9, 8.5, 15, .005, 314, 41.5, 5, 0, .5,
+                                           [.1, .2, .5, .8, .9], 5)
+if abs(sloss[3] - loss) < 0.0001:
+  print "FAIL: expected ", loss
+if sloss[0] > sloss[4]:
+  print "FAIL: greater loss for lower reliability parameter", sloss
+


### PR DESCRIPTION
This code adds a method to the ITM implementation and to the eHata implementation which allow callers to specify arrays of reliability measures for which the model will compute estimated path loss.

The change also adds some tests for these statistical methods, as well as adding some licensing boilerplate to the eHata test code files.