### PR TITLE
Only CBSD effective height considered

### DIFF
--- a/src/prop/model.py
+++ b/src/prop/model.py
@@ -138,7 +138,7 @@ class PropagationLossModel:
     profile = self.nedIndx.Profile(lat1, lng1, lat2, lng2)
     h1eff, h2eff = EffectiveHeights(h1, h2, profile)
     
-    if land_cat == 'RURAL' or h1eff >= 200 or h2eff >= 200:
+    if land_cat == 'RURAL' or h1eff >= 200: # Only h1eff (CBSD effective height) counts
       itm_loss = self.ITM_AdjustedPropagationLoss(lat1, lng1, h1, lat2, lng2, h2, f, 0.5)
       print 'Returning itm_loss for rural > 200: ', itm_loss
       return itm_loss


### PR DESCRIPTION
The effective height of the CBSD is the only criterion, not the effective height of the other end, according to R2-SGN-04. Note that this means that the first point (lat1, lon1, h1) must always correspond to the CBSD, not the PPA or GWPZ.