### PR TITLE
add registration test WINFF.FT.S.REG.9

### DIFF
--- a/src/harness/testcases/registration_testcase.py
+++ b/src/harness/testcases/registration_testcase.py
@@ -142,9 +142,6 @@ class RegistrationTestcase(unittest.TestCase):
         self.assertTrue('cbsdId' in response['registrationResponse'][x])
         self.assertEqual(response['registrationResponse'][x]['response']['responseCode'], 0)
 
-    # Save CBSD IDs
-    cbsdId1 = response['registrationResponse'][0]['cbsdId']
-    cbsdId2 = response['registrationResponse'][1]['cbsdId']
     del devices, request, response
 
     # Re-register two devices, register third device
@@ -157,9 +154,6 @@ class RegistrationTestcase(unittest.TestCase):
         self.assertTrue('cbsdId' in response['registrationResponse'][x])
         self.assertFalse('measReportConfig' in response['registrationResponse'][x])
         self.assertEqual(response['registrationResponse'][x]['response']['responseCode'], 0)
-
-    self.assertTrue(cbsdId1 == response['registrationResponse'][0]['cbsdId'])
-    self.assertTrue(cbsdId2 == response['registrationResponse'][1]['cbsdId'])
 
   @winnforum_testcase
   def test_10_3_4_2_1(self):

--- a/src/harness/testcases/registration_testcase.py
+++ b/src/harness/testcases/registration_testcase.py
@@ -108,6 +108,61 @@ class RegistrationTestcase(unittest.TestCase):
     self.assertEqual(response['response']['responseCode'], 0)
 
   @winnforum_testcase
+  def test_WINFF_FT_S_REG_9(self):
+    """ Array Re-registration of Single-step-registered CBSD (CBSD ID exists)
+
+    The response should be SUCCESS.
+    """
+
+    # Register the device
+    device_a = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_a.json')))
+    device_b = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_b.json')))
+    device_c = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_c.json')))
+
+    # Inject FCC IDs
+    self._sas_admin.InjectFccId({'fccId': device_a['fccId']})
+    self._sas_admin.InjectFccId({'fccId': device_b['fccId']})
+    self._sas_admin.InjectFccId({'fccId': device_c['fccId']})
+
+    # Make sure measCapability contains no value for all array elements
+    device_a['measCapability'] = []
+    device_b['measCapability'] = []
+    device_c['measCapability'] = []
+
+    # Register two devices
+    devices = [device_a, device_b]
+    request = {'registrationRequest': devices}
+    response = self._sas.Registration(request)
+    
+    print(response)
+    # Check registration response
+    for x in range (0,2):
+        self.assertTrue('cbsdId' in response['registrationResponse'][x])
+        self.assertEqual(response['registrationResponse'][x]['response']['responseCode'], 0)
+
+    # Save CBSD IDs
+    cbsdId1 = response['registrationResponse'][0]['cbsdId']
+    cbsdId2 = response['registrationResponse'][1]['cbsdId']
+    del devices, request, response
+
+    # Re-register two devices, register third device
+    devices = [device_a, device_b, device_c]
+    request = {'registrationRequest': devices}
+    response = self._sas.Registration(request)
+
+    # Check registration response
+    for x in range (0,3):
+        self.assertTrue('cbsdId' in response['registrationResponse'][x])
+        self.assertFalse('measReportConfig' in response['registrationResponse'][x])
+        self.assertEqual(response['registrationResponse'][x]['response']['responseCode'], 0)
+
+    self.assertTrue(cbsdId1 == response['registrationResponse'][0]['cbsdId'])
+    self.assertTrue(cbsdId2 == response['registrationResponse'][1]['cbsdId'])
+
+  @winnforum_testcase
   def test_10_3_4_2_1(self):
     """CBSD registration request with missing required parameter.
 

--- a/src/harness/testcases/registration_testcase.py
+++ b/src/harness/testcases/registration_testcase.py
@@ -137,7 +137,6 @@ class RegistrationTestcase(unittest.TestCase):
     request = {'registrationRequest': devices}
     response = self._sas.Registration(request)
     
-    print(response)
     # Check registration response
     for x in range (0,2):
         self.assertTrue('cbsdId' in response['registrationResponse'][x])

--- a/src/harness/testcases/registration_testcase.py
+++ b/src/harness/testcases/registration_testcase.py
@@ -108,7 +108,7 @@ class RegistrationTestcase(unittest.TestCase):
     self.assertEqual(response['response']['responseCode'], 0)
 
   @winnforum_testcase
-  def test_WINFF_FT_S_REG_9(self):
+  def test_WINNF_FT_S_REG_9(self):
     """ Array Re-registration of Single-step-registered CBSD (CBSD ID exists)
 
     The response should be SUCCESS.
@@ -133,16 +133,15 @@ class RegistrationTestcase(unittest.TestCase):
     device_c['measCapability'] = []
 
     # Register two devices
-    devices = [device_a, device_b]
-    request = {'registrationRequest': devices}
+    request = {'registrationRequest': [device_a, device_b]}
     response = self._sas.Registration(request)
     
     # Check registration response
-    for x in range (0,2):
-        self.assertTrue('cbsdId' in response['registrationResponse'][x])
-        self.assertEqual(response['registrationResponse'][x]['response']['responseCode'], 0)
+    for resp in response['registrationResponse']:
+        self.assertTrue('cbsdId' in resp)
+        self.assertEqual(resp['response']['responseCode'], 0)
 
-    del devices, request, response
+    del request, response
 
     # Re-register two devices, register third device
     devices = [device_a, device_b, device_c]
@@ -150,10 +149,10 @@ class RegistrationTestcase(unittest.TestCase):
     response = self._sas.Registration(request)
 
     # Check registration response
-    for x in range (0,3):
-        self.assertTrue('cbsdId' in response['registrationResponse'][x])
-        self.assertFalse('measReportConfig' in response['registrationResponse'][x])
-        self.assertEqual(response['registrationResponse'][x]['response']['responseCode'], 0)
+    for resp in response['registrationResponse']:
+        self.assertTrue('cbsdId' in resp)
+        self.assertFalse('measReportConfig' in resp)
+        self.assertEqual(resp['response']['responseCode'], 0)
 
   @winnforum_testcase
   def test_10_3_4_2_1(self):


### PR DESCRIPTION
The test case does not compare the recorded CBSD IDs with the re-registered CBSD IDs, but I think it should. I will propose this change in the spec.

    self.assertTrue(cbsdId1 == response['registrationResponse'][0]['cbsdId'])
    self.assertTrue(cbsdId2 == response['registrationResponse'][1]['cbsdId'])