### PR TITLE
fixes to REG.4, REG.10, REG.12, REG.22

### DIFF
--- a/src/harness/testcases/registration_testcase.py
+++ b/src/harness/testcases/registration_testcase.py
@@ -182,6 +182,7 @@ class RegistrationTestcase(unittest.TestCase):
     request = {'registrationRequest': [device_b]}
     response = self._sas.Registration(request)['registrationResponse'][0]
     # Check registration response
+    self.assertTrue('cbsdId' in response)
     self.assertFalse('measReportConfig' in response)
     self.assertEqual(response['response']['responseCode'], 0)
 
@@ -195,7 +196,6 @@ class RegistrationTestcase(unittest.TestCase):
     self.assertTrue('cbsdId' in response)
     self.assertFalse('measReportConfig' in response)
     self.assertEqual(response['response']['responseCode'], 0)
-    self.assertTrue(cbsdId == response['cbsdId'])
 
   @winnforum_testcase
   def test_WINNF_FT_S_REG_5(self):

--- a/src/harness/testcases/registration_testcase.py
+++ b/src/harness/testcases/registration_testcase.py
@@ -182,7 +182,6 @@ class RegistrationTestcase(unittest.TestCase):
     request = {'registrationRequest': [device_b]}
     response = self._sas.Registration(request)['registrationResponse'][0]
     # Check registration response
-    self.assertTrue('cbsdId' in response)
     self.assertFalse('measReportConfig' in response)
     self.assertEqual(response['response']['responseCode'], 0)
 
@@ -417,6 +416,7 @@ class RegistrationTestcase(unittest.TestCase):
     request = {'registrationRequest': [device_a]}
     response = self._sas.Registration(request)['registrationResponse'][0]
     # Check registration response
+    self.assertFalse('cbsdId' in response)
     self.assertEqual(response['response']['responseCode'], 102)
 
   @winnforum_testcase
@@ -520,7 +520,7 @@ class RegistrationTestcase(unittest.TestCase):
     response = self._sas.Registration(request)['registrationResponse'][0]
     # Check registration response
     self.assertFalse('cbsdId' in response)
-    self.assertEqual(response['response']['responseCode'], 103)
+    self.assertEqual(response['response']['responseCode'], 200)
 
   @winnforum_testcase
   def test_WINNF_FT_S_REG_13(self):
@@ -877,7 +877,6 @@ class RegistrationTestcase(unittest.TestCase):
         self.assertEqual(resp['response']['responseCode'], 0)
         self.assertTrue('cbsdId' in resp)
     self.assertTrue(response['registrationResponse'][2]['response']['responseCode'] in (103, 201))
-    self.assertFalse('cbsdId' in response['registrationResponse'][2])
 
   @winnforum_testcase
   def test_WINNF_FT_S_REG_26(self):


### PR DESCRIPTION

    REG.4: test spec does not require us to check that it's the same CBSD ID (line 199)
    REG.10: should also check that there is no CBSD ID in the response
    REG.12: should the error code be 200 instead of 103?
    REG.22: according to the test spec, we don't need to check that there is no CBSD ID in the third response