### PR TITLE
fix REG.21 & allow more tests to pass with fake SAS

### DIFF
--- a/src/harness/fake_sas.py
+++ b/src/harness/fake_sas.py
@@ -192,12 +192,10 @@ class FakeSasHandler(BaseHTTPRequestHandler):
       response = FakeSas().Relinquishment(request)
     elif self.path == '/v1.0/deregistration':
       response = FakeSas().Deregistration(request)
-    elif self.path == '/admin/reset':
-      response = ''
-    elif self.path == '/admin/injectdata/fccId':
+    elif self.path in ('/admin/reset', '/admin/injectdata/fccId', '/admin/injectdata/registration'):
       response = ''
     else:
-      self.send_response(400)
+      self.send_response(404)
       return
     self.send_response(200)
     self.send_header('Content-type', 'application/json')

--- a/src/harness/testcases/registration_testcase.py
+++ b/src/harness/testcases/registration_testcase.py
@@ -835,7 +835,7 @@ class RegistrationTestcase(unittest.TestCase):
     self._sas_admin.InjectFccId({'fccId': device_a['fccId']})
 
     # Register device
-    request = {'registrationRequest': device_a}
+    request = {'registrationRequest': [device_a]}
     response = self._sas.Registration(request)['registrationResponse'][0]
     # Check response
     self.assertTrue(response['response']['responseCode'] in (103, 201))


### PR DESCRIPTION
1. fix REG.21 to pass array [device_a] for registrationRequest instead of device_a
2. Change line 200 to respond with 404 instead of 400 (it makes more sense *and* it will cause the "bad version number" tests to start passing).
Update if/else tree which starts on line 183 as follows (which will get rid of the errors in REG.{1,2,3,4,5,11,14,15,16,26}):
elif self.path in ('/admin/reset', '/admin/injectdata/fccId', '/admin/injectdata/registration'):
  response = ''