### PR TITLE
fix invalid character in REG_15, ^ is allowed, @ is not

### DIFF
--- a/src/harness/testcases/registration_testcase.py
+++ b/src/harness/testcases/registration_testcase.py
@@ -644,7 +644,7 @@ class RegistrationTestcase(unittest.TestCase):
 
     # Device 4 Cat A invalid userId - invalid char (RFC-7542 Section 2.2)
     self.assertEqual(device_f['cbsdCategory'], 'A')
-    device_f['userId'] = '^'
+    device_f['userId'] = '@'
 
     # Device 5 Cat A invalid latitude - invalid type
     self.assertEqual(device_g['cbsdCategory'], 'A')


### PR DESCRIPTION
Valid characters are defined in RFC-7542 Section 2.2 as below. For example, the '(' character is not one of the allowed characters. "^" is also allowed.

    Allowed characters are identified as
    Formal Syntax

       The grammar for the NAI is given below, described in Augmented
       Backus-Naur Form (ABNF) as documented in [RFC5234].

       nai            =   utf8-username
       nai            =/  "@" utf8-realm
       nai            =/  utf8-username "@" utf8-realm

       utf8-username  =  dot-string

       dot-string     = string *("." string)
       string         = 1*utf8-atext

       utf8-atext     =  ALPHA / DIGIT /
                         "!" / "#" /
                         "$" / "%" /
                         "&" / "'" /
                         "*" / "+" /
                         "-" / "/" /
                         "=" / "?" /
                         "^" / "_" /
                         "`" / "{" /
                         "|" / "}" /
                         "~" /
                         UTF8-xtra-char

       utf8-realm     =  1*( label "." ) label

       label          =  utf8-rtext *(ldh-str)
       ldh-str        =  *( utf8-rtext / "-" ) utf8-rtext
       utf8-rtext     =  ALPHA / DIGIT / UTF8-xtra-char