### PR TITLE
Updated PPA Record File

### DIFF
--- a/src/harness/testcases/testdata/ppa_record_0.json
+++ b/src/harness/testcases/testdata/ppa_record_0.json
@@ -3,8 +3,6 @@
   "creator": "admin_0",
   "usage": "PPA",
   "terminated": false,
-  "censusYear": 2010,
-  "fipsCode": 20041084200,
   "zone": {
     "type": "FeatureCollection",
     "features": [


### PR DESCRIPTION
Updated PPA Record File as censusYear and fipsCode is required in the Pal Record File based on the util.py(https://github.com/Wireless-Innovation-Forum/Spectrum-Access-System/blob/master/src/harness/util.py#L86)