### PR TITLE
Antenna reference code.

### DIFF
--- a/src/harness/reference_models/antenna/antenna.py
+++ b/src/harness/reference_models/antenna/antenna.py
@@ -75,7 +75,7 @@ def GetAntennaPatternGains(hor_dirs, ant_azimuth,
   return gains
 
 
-def GetStandardAntennaGains(hor_dirs, ant_azimuth, ant_beamwidth, ant_gain):
+def GetStandardAntennaGains(hor_dirs, ant_azimuth=0, ant_beamwidth=None, ant_gain=0):
   """Computes the antenna gains from a standard antenna defined by beamwidth.
 
   See R2-SGN-20.
@@ -89,6 +89,7 @@ def GetStandardAntennaGains(hor_dirs, ant_azimuth, ant_beamwidth, ant_gain):
                     Either a scalar or an iterable.
     ant_azimut:     Antenna azimuth (degrees).
     ant_beamwidth:  Antenna 3dB curoff beamwidth (degrees).
+                    If None, then antenna is isotropic (default).
     ant_gain:       Antenna gain (dBi).
 
   Returns:
@@ -98,12 +99,15 @@ def GetStandardAntennaGains(hor_dirs, ant_azimuth, ant_beamwidth, ant_gain):
   is_scalar = np.isscalar(hor_dirs)
   hor_dirs = np.atleast_1d(hor_dirs)
 
-  bore_angle = hor_dirs - ant_azimuth
-  bore_angle[bore_angle > 180] -= 360
-  bore_angle[bore_angle < -180] += 360
-  gains = -12 * (bore_angle / float(ant_beamwidth))**2
-  gains[gains < -20] = -20.
-  gains += ant_gain
+  if ant_beamwidth is None:
+    gains = ant_gain * np.ones(hor_dirs.shape)
+  else:
+    bore_angle = hor_dirs - ant_azimuth
+    bore_angle[bore_angle > 180] -= 360
+    bore_angle[bore_angle < -180] += 360
+    gains = -12 * (bore_angle / float(ant_beamwidth))**2
+    gains[gains < -20] = -20.
+    gains += ant_gain
 
   if is_scalar: return gains[0]
   return gains

--- a/src/harness/reference_models/antenna/antenna.py
+++ b/src/harness/reference_models/antenna/antenna.py
@@ -75,7 +75,7 @@ def GetAntennaPatternGains(hor_dirs, ant_azimuth,
   return gains
 
 
-def GetStandardAntennaGains(hor_dirs, ant_azimuth=0, ant_beamwidth=None, ant_gain=0):
+def GetStandardAntennaGains(hor_dirs, ant_azimuth=None, ant_beamwidth=None, ant_gain=0):
   """Computes the antenna gains from a standard antenna defined by beamwidth.
 
   See R2-SGN-20.
@@ -99,7 +99,7 @@ def GetStandardAntennaGains(hor_dirs, ant_azimuth=0, ant_beamwidth=None, ant_gai
   is_scalar = np.isscalar(hor_dirs)
   hor_dirs = np.atleast_1d(hor_dirs)
 
-  if ant_beamwidth is None:
+  if ant_beamwidth is None or ant_azimuth is None:
     gains = ant_gain * np.ones(hor_dirs.shape)
   else:
     bore_angle = hor_dirs - ant_azimuth

--- a/src/harness/reference_models/antenna/antenna.py
+++ b/src/harness/reference_models/antenna/antenna.py
@@ -1,0 +1,221 @@
+#    Copyright 2017 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""Antenna gain routines for SAS.
+
+Typical usage:
+  # Get the gains for a given antenna horizontal pattern.
+  # To be used for ESC and CBSD with actual antenna patterns.
+  gains = GetAntennaPatternGains(hor_dirs, ant_azimuth, pattern)
+
+  # Get CBSD antenna gain (from antenna defined by beamwidth and gain only).
+  gains = GetStandardAntennaGains(hor_dirs, ant_azimuth, beamwidth, ant_gain)
+
+  # Get Radar normalized antenna gain for DPA protection.
+  gains = GetRadarNormalizedAntennaGains(hor_dirs, radar_azimuth)
+
+  # Get FSS earth station antenna gains
+  gains = GetFssAntennaGains(hor_dirs, ver_dirs,
+                             fss_azimuth, fss_elevation, fss_ant_gain)
+"""
+
+import numpy as np
+
+
+def GetAntennaPatternGains(hor_dirs, ant_azimuth,
+                           hor_pattern,
+                           ant_gain=0):
+  """Computes the gain for a given antenna pattern.
+
+  Directions and azimuth are defined compared to the north in clockwise
+  direction and shall be within [0..360] degrees.
+
+  Inputs:
+    hor_dirs:       Ray directions in horizontal plane (degrees).
+                    Either a scalar or an iterable.
+    ant_azimuth:    Antenna azimuth (degrees).
+    hor_pattern:    The antenna horizontal pattern defined as a ndarray of
+                    360 values with the following conventions:
+                     - clockwise increments of 1 degree.
+                     - 0 degree corresponds to the antenna boresight.
+                     - values are 'gain' (and not attenuation)
+    ant_gain:       Optional additional antenna gain (dBi).
+                    To be used if not included in the pattern (ie when using
+                    a normalized pattern).
+
+  Returns:
+    The antenna gains (in dB): either a scalar if hor_dirs is scalar,
+    or an ndarray otherwise.
+  """
+  is_scalar = np.isscalar(hor_dirs)
+  hor_dirs = np.atleast_1d(hor_dirs)
+
+  bore_angle = hor_dirs - ant_azimuth
+  bore_angle[bore_angle >= 360] -= 360
+  bore_angle[bore_angle < 0] += 360
+  idx0 = bore_angle.astype(np.int)
+  alpha = bore_angle - idx0
+  idx1 = idx0 + 1
+  idx1[idx1 >= 360] -= 360
+  gains = (1-alpha) * hor_pattern[idx0] + alpha * hor_pattern[idx1]
+  gains += ant_gain
+
+  if is_scalar: return gains[0]
+  return gains
+
+
+def GetStandardAntennaGains(hor_dirs, ant_azimuth, ant_beamwidth, ant_gain):
+  """Computes the antenna gains from a standard antenna defined by beamwidth.
+
+  See R2-SGN-20.
+  This uses the standard 3GPP formula for pattern derivation from a given
+  antenna 3dB cutoff beamwidth.
+  Directions and azimuth are defined compared to the north in clockwise
+  direction and shall be within [0..360] degrees.
+
+  Inputs:
+    hor_dirs:       Ray directions in horizontal plane (degrees).
+                    Either a scalar or an iterable.
+    ant_azimut:     Antenna azimuth (degrees).
+    ant_beamwidth:  Antenna 3dB curoff beamwidth (degrees).
+    ant_gain:       Antenna gain (dBi).
+
+  Returns:
+    The CBSD antenna gains (in dB).
+    Either a scalar if hor_dirs is scalar or an ndarray otherwise.
+  """
+  is_scalar = np.isscalar(hor_dirs)
+  hor_dirs = np.atleast_1d(hor_dirs)
+
+  bore_angle = hor_dirs - ant_azimuth
+  bore_angle[bore_angle > 180] -= 360
+  bore_angle[bore_angle < -180] += 360
+  gains = -12 * (bore_angle / float(ant_beamwidth))**2
+  gains[gains < -20] = -20.
+  gains += ant_gain
+
+  if is_scalar: return gains[0]
+  return gains
+
+
+def GetRadarNormalizedAntennaGains(hor_dirs,
+                                   radar_azimuth):
+  """Computes the DPA radar normalized antenna gain.
+
+  See R2-SGN-24.
+  Directions and azimuth are defined compared to the north in clockwise
+  direction and shall be within [0..360] degrees.
+  Note that the DPA antenna gain is normalized to 0dBi at boresight:
+  actual radar antenna gain is implicitely included in the target interference
+  thresholds.
+
+  Inputs:
+    hor_dirs:       Ray directions in horizontal plane (degrees).
+                    Either a scalar or an iterable.
+    radar_azimuth:  The radar antenna azimuth (degrees).
+
+  Returns:
+    The normalized antenna gains (in dB).
+    Either a scalar if hor_dirs is scalar or an ndarray otherwise.
+
+  """
+  is_scalar = np.isscalar(hor_dirs)
+  hor_dirs = np.atleast_1d(hor_dirs)
+
+  bore_angle = hor_dirs - radar_azimuth
+  bore_angle[bore_angle > 180] -= 360
+  bore_angle[bore_angle < -180] += 360
+  bore_angle = np.abs(bore_angle)
+  gains = -25 * np.ones(len(bore_angle))
+  gains[bore_angle < 1.5] = 0
+
+  if is_scalar: return gains[0]
+  return gains
+
+
+def GetFssAntennaGains(hor_dirs, ver_dirs,
+                       fss_pointing_azimuth, fss_pointing_elevation,
+                       fss_antenna_gain,
+                       w1=0, w2=1.0):
+  """Computes the FSS earth station antenna gain.
+
+  See R2-SGN-21.
+  Horizontal directions and azimuth are defined compared to the north in
+  clockwise fashion and shall be within [0..360] degrees.
+  Vertical directions are positive for above horizon, and negative below.
+
+  Inputs:
+    hor_dirs:               Ray directions in horizontal plane (degrees).
+                            Either a scalar or an iterable.
+    ver_dirs:               Ray directions in vertical plane (degrees).
+                            Either a scalar or an iterable (same dimension
+                            as hor_dirs)
+    fss_pointing_azimuth:   FSS earth station azimuth angle (degrees).
+    fss_pointing_elevation: FSS earth station vertical angle (degrees).
+    fss_antenna_gain:       FSS earth station nominal antenna gain (dBi).
+    w1, w2:                 Weights on the tangent and perpendicular
+                            components. Optional: by default only use the
+                            perpendicular component.
+  Returns:
+    The FSS gains on the incoming ray (in dB).
+    Either a scalar if hor_dirs is scalar, or an ndarray otherwise.
+  """
+  is_scalar = np.isscalar(hor_dirs)
+  hor_dirs = np.atleast_1d(np.radians(hor_dirs))
+  ver_dirs = np.atleast_1d(np.radians(ver_dirs))
+  fss_pointing_elevation = np.radians(fss_pointing_elevation)
+  fss_pointing_azimuth = np.radians(fss_pointing_azimuth)
+
+  # Compute the satellite antenna off-axis angle - see formula in R2-SGN-21, iii
+  theta = 180/np.pi * np.arccos(
+      np.cos(ver_dirs) * np.cos(fss_pointing_elevation)
+      * np.cos(fss_pointing_azimuth - hor_dirs) +
+      np.sin(ver_dirs) * np.sin(fss_pointing_elevation))
+
+  gain_gso_t, gain_gso_p = _GetGsoGains(theta, fss_antenna_gain)
+  gains = w1 * gain_gso_t + w2 * gain_gso_p
+
+  if is_scalar: return gains[0]
+  return gains
+
+
+def _GetGsoGains(theta, nominal_gain):
+  """Returns FSS earth station gains from the off-axis angle.
+
+  GSO means the 'Geostationary Satellite Orbit'.
+
+  Inputs:
+    theta:        Off-axis angles (degrees), as a ndarray
+    nominal_gain: Nominal antenna gain (dBi)
+  Returns:
+    a tuple of ndarray:
+      gain_gso_t: Gains in the tangent plane of the GSO (dB).
+      gain_gso_p: Gains in the perpendicular plane of the GSO (dB).
+  """
+  theta = np.abs(theta)
+  gain_gso_t = -10 * np.ones(len(theta))
+  gain_gso_p = gain_gso_t.copy()
+
+  gain_gso_p[theta <= 3] = nominal_gain
+  idx_3_to_48 = np.where((theta > 3) & (theta <= 48))[0]
+  gain_gso_p[idx_3_to_48] = 32 - 25 * np.log10(theta[idx_3_to_48])
+
+  gain_gso_t[theta <= 1.5] = nominal_gain
+  idx_1_5_to_7 = np.where((theta > 1.5) & (theta <= 7))[0]
+  gain_gso_t[idx_1_5_to_7] = 29 - 25 * np.log10(theta[idx_1_5_to_7])
+  gain_gso_t[(theta > 7) & (theta <= 9.2)] = 8
+  idx_9_2_to_48 = np.where((theta > 9.2) & (theta <= 48))[0]
+  gain_gso_t[idx_9_2_to_48] = 32 - 25 * np.log10(theta[idx_9_2_to_48])
+
+  return gain_gso_t, gain_gso_p

--- a/src/harness/reference_models/antenna/antenna_test.py
+++ b/src/harness/reference_models/antenna/antenna_test.py
@@ -51,6 +51,11 @@ class TestAntenna(unittest.TestCase):
                                            0, None, 5)
     self.assertEqual(np.max(np.abs(
         gains - 5 * np.ones(4))), 0)
+    gains = antenna.GetStandardAntennaGains([0, 90, 180, 270],
+                                           None, 90, 5)
+    self.assertEqual(np.max(np.abs(
+        gains - 5 * np.ones(4))), 0)
+
     # Back lobe: maximum attenuation
     gain = antenna.GetStandardAntennaGains(180, 0, 120, 10)
     self.assertEqual(gain, -10)

--- a/src/harness/reference_models/antenna/antenna_test.py
+++ b/src/harness/reference_models/antenna/antenna_test.py
@@ -1,0 +1,133 @@
+#    Copyright 2017 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import numpy as np
+import unittest
+
+import antenna
+
+
+class TestAntenna(unittest.TestCase):
+
+  def test_pattern_gain(self):
+    pattern = np.arange(360)
+    gain = antenna.GetAntennaPatternGains(40, 0, pattern)
+    self.assertAlmostEqual(gain, 40)
+    gain = antenna.GetAntennaPatternGains(40.5, 0, pattern)
+    self.assertAlmostEqual(gain, 40.5)
+    gain = antenna.GetAntennaPatternGains(40.2, 20, pattern)
+    self.assertAlmostEqual(gain, 20.2)
+    hor_dirs = [10.5, 42.2, 25]
+    gains = antenna.GetAntennaPatternGains(hor_dirs, 0, pattern)
+    self.assertAlmostEqual(np.max(np.abs(
+        gains - np.array([10.5, 42.2, 25]))), 0)
+    gains = antenna.GetAntennaPatternGains(hor_dirs, 20, pattern)
+    self.assertAlmostEqual(np.max(np.abs(
+        gains - np.array([350.5, 22.2, 5]))), 0)
+    gains = antenna.GetAntennaPatternGains(hor_dirs, 20, pattern, 10)
+    self.assertAlmostEqual(np.max(np.abs(
+        gains - np.array([360.5, 32.2, 15]))), 0)
+    # Vectorized vs scalar
+    hor_dirs = [3.5, 47.3, 342]
+    gains = antenna.GetAntennaPatternGains(hor_dirs, 123.3, pattern, 12.4)
+    for k, hor in enumerate(hor_dirs):
+      gain = antenna.GetAntennaPatternGains(hor, 123.3, pattern, 12.4)
+      self.assertEqual(gain, gains[k])
+
+  def test_standard_gain(self):
+    # Back lobe: maximum attenuation
+    gain = antenna.GetStandardAntennaGains(180, 0, 120, 10)
+    self.assertEqual(gain, -10)
+    # At beamwidth, cutoff by 3dB (by definition)
+    gain = antenna.GetStandardAntennaGains(60, 0, 120, 10)
+    self.assertEqual(gain, 10-3)
+    gain = antenna.GetStandardAntennaGains(5.5, 50.5, 90, 10)
+    self.assertEqual(gain, 10-3)
+    # Bore sight: full gain
+    gain = antenna.GetStandardAntennaGains(50.5, 50.5, 90, 10)
+    self.assertEqual(gain, 10)
+    # At half beamwidth, -0.75dB + integer values well managed
+    gain = antenna.GetStandardAntennaGains(25, 50, 100, 10)
+    self.assertEqual(gain, 10-0.75)
+    # At twice beamwidth, -12dB
+    gain = antenna.GetStandardAntennaGains(310, 50, 100, 10)
+    self.assertEqual(gain, 10-12)
+
+    # Vectorized vs scalar
+    hor_dirs = [3.5, 47.3, 342]
+    gains = antenna.GetStandardAntennaGains(hor_dirs, 123.3, 90, 12.4)
+    for k, hor in enumerate(hor_dirs):
+      gain = antenna.GetStandardAntennaGains(hor, 123.3, 90, 12.4)
+      self.assertEqual(gain, gains[k])
+
+  def test_dpa_gain(self):
+    hor_dirs = [0, 1.49, 360-1.49, 1.51, 360-1.51, 90, 320]
+    gains = antenna.GetRadarNormalizedAntennaGains(hor_dirs, 0)
+    self.assertEqual(np.max(np.abs(
+        gains - np.array([0, 0, 0, -25, -25, -25, -25]))), 0)
+    for k, hor in enumerate(hor_dirs):
+      gain = antenna.GetRadarNormalizedAntennaGains(hor, 0)
+      self.assertEqual(gain, gains[k])
+
+    gains = antenna.GetRadarNormalizedAntennaGains([5, 8.6, 11.4, 20], 10)
+    self.assertEqual(np.max(np.abs(
+        gains - np.array([-25, 0, 0, -25]))), 0)
+
+  def test_fss_gain(self):
+    # Test the internal GSO gains
+    # - diff in hor plane only
+    hor_dirs = [20, 21, 21.4, 21.6, 22.9, 23.1, 26.9, 27.1, 29.1, 29.3, 67, 69]
+    ver_dirs = np.zeros(len(hor_dirs))
+    #   * perpendicular
+    gains = antenna.GetFssAntennaGains(hor_dirs, ver_dirs,
+                                       20, 0, 30, 0, 1)
+    self.assertAlmostEqual(np.max(np.abs(
+        gains - np.array([30, 30, 30, 30, 30,
+                          32-25*np.log10(3.1),
+                          32-25*np.log10(6.9),
+                          32-25*np.log10(7.1),
+                          32-25*np.log10(9.1),
+                          32-25*np.log10(9.3),
+                          32-25*np.log10(47),
+                          -10]))), 0)
+    #   * tangential
+    gains = antenna.GetFssAntennaGains(hor_dirs, ver_dirs,
+                                       20, 0, 30, 1, 0)
+    self.assertAlmostEqual(np.max(np.abs(
+        gains - np.array([30, 30, 30,
+                          29-25*np.log10(1.6),
+                          29-25*np.log10(2.9),
+                          29-25*np.log10(3.1),
+                          29-25*np.log10(6.9),
+                          8,
+                          8,
+                          32-25*np.log10(9.3),
+                          32-25*np.log10(47),
+                          -10]))), 0)
+    # - diff in ver plane only
+    gains = antenna.GetFssAntennaGains(ver_dirs, hor_dirs,
+                                       0, 20, 30, 0, 1)
+    self.assertAlmostEqual(np.max(np.abs(
+        gains - np.array([30, 30, 30, 30, 30,
+                          32-25*np.log10(3.1),
+                          32-25*np.log10(6.9),
+                          32-25*np.log10(7.1),
+                          32-25*np.log10(9.1),
+                          32-25*np.log10(9.3),
+                          32-25*np.log10(47),
+                          -10]))), 0)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/src/harness/reference_models/antenna/antenna_test.py
+++ b/src/harness/reference_models/antenna/antenna_test.py
@@ -46,6 +46,11 @@ class TestAntenna(unittest.TestCase):
       self.assertEqual(gain, gains[k])
 
   def test_standard_gain(self):
+    # Isotropic antenna
+    gains = antenna.GetStandardAntennaGains([0, 90, 180, 270],
+                                           0, None, 5)
+    self.assertEqual(np.max(np.abs(
+        gains - 5 * np.ones(4))), 0)
     # Back lobe: maximum attenuation
     gain = antenna.GetStandardAntennaGains(180, 0, 120, 10)
     self.assertEqual(gain, -10)

--- a/src/harness/reference_models/antenna/fss_pointing.py
+++ b/src/harness/reference_models/antenna/fss_pointing.py
@@ -1,0 +1,189 @@
+#    Copyright 2017 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""GSO (Geostationary Satellite Orbit) utility library.
+
+Allows to obtain the actual pointing directions of a FSS earth station
+towards all licensed orbital slot.
+See an example of FSS earth station license at:
+  http://licensing.fcc.gov/myibfs/displayLicense.do?filingKey=-205179
+
+Typical usage:
+  # Get the list of possible pointing direction according to license limitations
+  pointings = GsoPossiblePointings(fss_lat, fss_lon,
+                                   west_sat_lon, east_sat_lon,
+                                   west_elevation_limit, east_elevation_limit,
+                                   west_azimuth_limit, east_azimuth_limit)
+"""
+
+import math
+
+_GSO_SPHERICAL_CST = 0.1512
+
+
+def GsoElevation(fss_lat, fss_lon, sat_lon):
+  """Computes the elevation angle from earth station towards GSO satellite.
+
+  Based on Appendix D of FCC 05-56.
+
+  Inputs:
+    fss_lat:   Latitude of earth station (degrees)
+    fss_lon:   Longitude of earth station (degrees)
+    sat_lon:   Longitude of satellite (degrees)
+
+  Returns:
+    the elevation angle of the pointing arc from earth station to GSO satellite.
+  """
+  fss_lat = math.radians(fss_lat)
+  fss_lon = math.radians(fss_lon)
+  sat_lon = math.radians(sat_lon)
+
+  delta = sat_lon - fss_lon
+  elevation = math.atan2(math.cos(delta) * math.cos(fss_lat) - _GSO_SPHERICAL_CST,
+                         math.sqrt(1 - math.cos(delta)**2 * math.cos(fss_lat)**2))
+
+  return math.degrees(elevation)
+
+
+def GsoAzimuth(fss_lat, fss_lon, sat_lon):
+  """Computes the azimuth angle from earth station toward GSO satellite.
+
+  Based on Appendix D of FCC 05-56.
+
+  Inputs:
+    fss_lat:   Latitude of earth station (degrees)
+    fss_lon:   Longitude of earth station (degrees)
+    sat_lon:   Longitude of satellite (degrees)
+
+  Returns:
+    the azimuth angle of the pointing arc from earth station to GSO satellite.
+  """
+  fss_lat = math.radians(fss_lat)
+  fss_lon = math.radians(fss_lon)
+  sat_lon = math.radians(sat_lon)
+  if fss_lat > 0:
+    azimuth = math.pi - math.atan2(math.tan(sat_lon-fss_lon),
+                                   math.sin(fss_lat))
+  else:
+    azimuth = math.atan2(math.tan(sat_lon-fss_lon),
+                         math.sin(-fss_lat))
+    if azimuth < 0: azimuth += 2*math.pi
+
+  return math.degrees(azimuth)
+
+
+def _GsoExtent(fss_lat, fss_min_elevation=5):
+  """Computes the longitude extent for GSO arc visibility.
+
+  The GSO orbit is visible between FSS longitude plus/minus the extent.
+  Based on Appendix D of FCC 05-56.
+
+  Inputs:
+    fss_lat:   Latitude of earth station (degrees).
+    fss_min_elevation:  Minimum elevation of angle of the FSS
+                        earth station (degrees).
+
+  Returns:
+    the longitudinal extend in degrees of GSO arc visibility.
+  """
+  if fss_lat > 81: return 0  # visibility limited to latitude 81 degree
+
+  fss_lat = math.radians(fss_lat)
+  fss_min_elevation = math.radians(fss_min_elevation)
+
+  tan_el2 = math.tan(fss_min_elevation)**2
+  a = 1 + tan_el2
+  b = -2 * _GSO_SPHERICAL_CST
+  c = _GSO_SPHERICAL_CST**2 - tan_el2
+  x = (-b + math.sqrt(b**2 - 4 * a * c)) / (2 * a)
+  extent = math.acos(x / math.cos(fss_lat))
+  return math.degrees(math.abs(extent))
+
+
+def GsoPossiblePointings(fss_lat, fss_lon,
+                         west_sat_lon=None, east_sat_lon=None,
+                         west_elevation_limit=0, east_elevation_limit=0,
+                         west_azimuth_limit=None, east_azimuth_limit=None):
+
+  """Computes all possible pointings of FSS earth station to allowed GSO slots.
+
+  C-band satellites are only licensed for odd-degree orbital slots (61, 63..).
+  Further constraints are used to restrict the extent of possible orbital slots.
+
+  Inputs:
+    fss_lat:   Latitude of FSS earth station (degrees).
+    fss_lon:   Longitude of FSS earth station (degrees).
+    west_sat_lon: West bound allowed satellite longitude (degrees) - optional
+    east_sat_lon: East bound allowed satellite longitude (degrees) - optional
+    west_elevation_limit: West bound elevation limit (degrees) - default=0
+    east_elevation_limit: East bound elevation limit (degrees) - default=0
+    west_azimuth_limit: West bound azimuth limit (degrees) - optional
+    east_azimuth_limit: East bound azimuth limit (degrees) - optional
+
+  Returns:
+    a list of tuple (azi, elev) of possible pointing direction for FSS.
+  """
+  allowed_pointings = []
+  if west_sat_lon is None:
+    west_sat_lon = fss_lon - 180
+  if east_sat_lon is None:
+    east_sat_lon = fss_lon + 180
+
+  # Manage crossover of 180degree meridian
+  if west_sat_lon > east_sat_lon:
+    delta_west = fss_lon - west_sat_lon
+    delta_east = fss_lon - east_sat_lon
+    if abs(delta_west) > abs(delta_east):
+      west_sat_lon -= 360
+    else:
+      east_sat_lon += 360
+
+  # Find all orbital slots and corresponding pointing directions
+  # Note: Using loops from the FSS meridian east then west, as it allows to
+  #       handle nicely crossover over the +-180degree meridians.
+  lon = int(fss_lon/2) * 2 - 1  # odd-degree nearby orbit slot
+  while True:
+    lon += 2
+    if lon > east_sat_lon: break
+    if lon < west_sat_lon: continue
+    elevation = GsoElevation(fss_lat, fss_lon, lon)
+    azimuth = GsoAzimuth(fss_lat, fss_lon, lon)
+    if elevation < east_elevation_limit: break
+    if east_azimuth_limit is not None:
+      if fss_lat > 0:
+        if azimuth < east_azimuth_limit: break
+        if azimuth > west_azimuth_limit: continue
+      else:
+        if azimuth > east_azimuth_limit: break
+        if azimuth < west_azimuth_limit: continue
+    allowed_pointings.append((azimuth, elevation))
+
+  lon = int(fss_lon/2) * 2 + 1
+  while True:
+    lon -= 2
+    if lon < west_sat_lon: break
+    if lon > east_sat_lon: continue
+    elevation = GsoElevation(fss_lat, fss_lon, lon)
+    azimuth = GsoAzimuth(fss_lat, fss_lon, lon)
+    if elevation < west_elevation_limit: break
+    if west_azimuth_limit is not None:
+      if fss_lat > 0:
+        if azimuth > west_azimuth_limit: break
+        if azimuth < east_azimuth_limit: continue
+      else:
+        if azimuth < west_azimuth_limit: break
+        if azimuth > east_azimuth_limit: continue
+    allowed_pointings.append((azimuth, elevation))
+
+  return allowed_pointings

--- a/src/harness/reference_models/antenna/fss_pointing_test.py
+++ b/src/harness/reference_models/antenna/fss_pointing_test.py
@@ -1,0 +1,103 @@
+#    Copyright 2017 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import unittest
+
+import fss_pointing as fp
+
+# Tests based on https://www.ngs.noaa.gov/CORS/Articles/SolerEisemannJSE.pdf
+# which uses a slightly different SPHERICAL_GSO_CST than FCC 05-56
+fp._GSO_SPHERICAL_CST = 0.1508  # instead of 0.1512
+
+
+class TestAntenna(unittest.TestCase):
+
+  def test_gso_elevation(self):
+    # From https://www.ngs.noaa.gov/CORS/Articles/SolerEisemannJSE.pdf
+    # Table 1
+    self.assertAlmostEqual(fp.GsoElevation(0, 50, 50), 90)
+    self.assertAlmostEqual(fp.GsoElevation(5, 50, 50), 84.1139, 3)
+    self.assertAlmostEqual(fp.GsoElevation(25, 50, 50), 60.7782, 3)
+    self.assertAlmostEqual(fp.GsoElevation(55, 50, 50), 27.2990, 3)
+    self.assertAlmostEqual(fp.GsoElevation(80, 50, 50), 1.3291, 3)
+
+    # Table 2
+    self.assertAlmostEqual(fp.GsoElevation(45, 0, 30), 30.2785, 3)
+    self.assertAlmostEqual(fp.GsoElevation(45, 0, 75), 1.8768, 3)
+    self.assertAlmostEqual(fp.GsoElevation(45, 0, 77.6865), 0, 3)
+    self.assertAlmostEqual(fp.GsoElevation(45, 0, -60), 12.2299, 3)
+
+  def test_gso_azimuth(self):
+    # From: https://www.ngs.noaa.gov/CORS/Articles/SolerEisemannJSE.pdf
+    # Table 2
+    self.assertAlmostEqual(fp.GsoAzimuth(45, 0, 0), 180)
+    self.assertAlmostEqual(fp.GsoAzimuth(45, 0, 10), 165.9981, 4)
+    self.assertAlmostEqual(fp.GsoAzimuth(45, 0, 30), 140.7685, 4)
+    self.assertAlmostEqual(fp.GsoAzimuth(45, 0, 75), 100.7286, 4)
+    self.assertAlmostEqual(fp.GsoAzimuth(45, 0, 77.6865), 98.7743, 4)
+    self.assertAlmostEqual(fp.GsoAzimuth(45, 0, -60), 247.7923, 4)
+
+  def test_gso_pointings(self):
+    # From above, shall be +-30degree visibility
+    pointings = fp.GsoPossiblePointings(45, 0,
+                                        west_elevation_limit=30.2785,
+                                        east_elevation_limit=30.2785)
+    sat_lon_slots = range(-29, 30, 2)
+    self.assertEqual(len(pointings), len(sat_lon_slots))
+    for lon in sat_lon_slots:
+      elev = fp.GsoElevation(45, 0, lon)
+      azi = fp.GsoAzimuth(45, 0, lon)
+      self.assertIn((azi, elev), pointings)
+
+    # Same with further limitation in sat_orbit
+    pointings = fp.GsoPossiblePointings(45, 0,
+                                        west_elevation_limit=30.2785,
+                                        east_elevation_limit=30.2785,
+                                        west_sat_lon=-21,
+                                        east_sat_lon=40)
+    sat_lon_slots = range(-21, 30, 2)
+    self.assertEqual(len(pointings), len(sat_lon_slots))
+    for lon in sat_lon_slots:
+      elev = fp.GsoElevation(45, 0, lon)
+      azi = fp.GsoAzimuth(45, 0, lon)
+      self.assertIn((azi, elev), pointings)
+
+    # Same with further limitation in sat_orbit and azimuth
+    pointings = fp.GsoPossiblePointings(45, 0,
+                                        east_elevation_limit=30.2785,
+                                        west_sat_lon=-21,
+                                        east_sat_lon=40,
+                                        west_azimuth_limit=166,
+                                        east_azimuth_limit=140.7685)
+
+    sat_lon_slots = range(11, 30, 2)
+    self.assertEqual(len(pointings), len(sat_lon_slots))
+    for lon in sat_lon_slots:
+      elev = fp.GsoElevation(45, 0, lon)
+      azi = fp.GsoAzimuth(45, 0, lon)
+      self.assertIn((azi, elev), pointings)
+
+    # Check the 180 degree crossover
+    pointings = fp.GsoPossiblePointings(45, 180,
+                                        west_sat_lon=150,
+                                        east_sat_lon=-150)
+    sat_lon_slots = range(180-29, 180+30, 2)
+    self.assertEqual(len(pointings), len(sat_lon_slots))
+    for lon in sat_lon_slots:
+      elev = fp.GsoElevation(45, 180, lon)
+      azi = fp.GsoAzimuth(45, 180, lon)
+      self.assertIn((azi, elev), pointings)
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Allows to compute antenna gain for CBSD, DPA (radar), ESC and FSS.
Also provides a routine to find the FSS possible pointing angles according to the licensed information (range of east/west elevation, azimuth and GSO arc longitude).

This is an extension of RedTechnologies  PullRequests of July with better integration in the reference_models/ framework developed since then.