### PR TITLE
Add geodata submodule retrieved from WinnForum/SAS-Data repo.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "data/geo"]
+	path = data/geo
+	url = https://github.com/Wireless-Innovation-Forum/SAS-Data


### PR DESCRIPTION
Introduce the SAS-data repository as a submodule under data/geo.

Discussions within WinnForum led to the continuing use of Git LFS to hold the geo reference data (for NED and NLCD) but in a separate repository at: https://github.com/Wireless-Innovation-Forum/SAS-Data

This PR simply introduce the ability to see this repository as a GIT submodule under data/geo