### PR TITLE
Make fccMaxEirp an optional param in InjectFccId()

### DIFF
--- a/src/harness/sas.py
+++ b/src/harness/sas.py
@@ -195,6 +195,8 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
                  self._GetDefaultAdminSSLKeyPath())
 
   def InjectFccId(self, request):
+    if 'fccMaxEirp' not in request:
+      request['fccMaxEirp'] = 47
     _RequestPost('https://%s/admin/injectdata/fcc_id' % self._base_url, request,
                  self._GetDefaultAdminSSLCertPath(),
                  self._GetDefaultAdminSSLKeyPath())

--- a/src/harness/sas_interface.py
+++ b/src/harness/sas_interface.py
@@ -203,9 +203,9 @@ class SasAdminInterface(object):
     """SAS admin interface to inject fcc id information into SAS under test.
 
     Args:
-      request: A dictionary with a single key-value pair where the key is
-        "fccId" and the value is a string of valid fccId which is going to be
-        injected into SAS under test.
+      request: A dictionary with the following key-value pairs:
+        "fccId": (string) valid fccId to be injected into SAS under test
+        "fccMaxEirp": (double) optional; default value of 47 dBm/10 MHz
     """
     pass
 


### PR DESCRIPTION
Add fccMaxEirp as an optional parameter to the InjectFccId() function with a default value of 47 dBm/10 MHz.