### PR TITLE
Provide  HAAT calculation routine.

### DIFF
--- a/src/harness/reference_models/geo/terrain.py
+++ b/src/harness/reference_models/geo/terrain.py
@@ -322,3 +322,28 @@ class TerrainDriver:
     lat, lon = zip(*points)
     elev.extend(self.GetTerrainElevation(lat, lon, do_interp))
     return elev
+
+  def ComputeNormalizedHaat(self, lat, lon):
+    """Computes normalized HAAT (Height Above Average Terrain).
+
+    Args:
+      lat, lon: point coordinates (in degrees).
+
+    Returns:
+      a tuple of
+        the HAAT for an antenna at height 0 above ground level.
+        the terrain altitude at given location
+    """
+    radial_angles = np.linspace(0, 360, 8., endpoint=False)
+    distances_km = np.linspace(3, 16, 50)
+    all_lat = [lat]
+    all_lon = [lon]
+    for bearing in radial_angles:
+      lats, lons, _ = vincenty.GeodesicPoints(lat, lon, distances_km, bearing)
+      all_lat.extend(lats)
+      all_lon.extend(lons)
+
+    all_lat = np.array(all_lat)
+    all_lon = np.array(all_lon)
+    altitudes = self.GetTerrainElevation(all_lat, all_lon)
+    return altitudes[0] - np.mean(altitudes[1:]), altitudes[0]

--- a/src/harness/reference_models/geo/terrain_test.py
+++ b/src/harness/reference_models/geo/terrain_test.py
@@ -131,5 +131,17 @@ class TestTerrain(unittest.TestCase):
     self.assertEqual(len(self.terrain_driver._tile_lru), 2)
 
 
+  def test_haat(self):
+    # Twin Peaks - SF
+    haat, h0 = self.terrain_driver.ComputeNormalizedHaat(
+        lat=37.751458, lon=-122.447831)
+    self.assertAlmostEqual(haat, 249.81, 2)
+    self.assertAlmostEqual(h0, 274.69, 2)
+    # Ocean - far away from the coast
+    haat, h0 = self.terrain_driver.ComputeNormalizedHaat(
+        lat=37.50, lon=-122.999)
+    self.assertEqual(haat, 0.0)
+    self.assertEqual(h0, 0.0)
+
 if __name__ == '__main__':
   unittest.main()

--- a/src/harness/reference_models/propagation/wf_itm.py
+++ b/src/harness/reference_models/propagation/wf_itm.py
@@ -313,3 +313,22 @@ def GetHorizonAngles(its_elev, height_cbsd, height_rx, refractivity):
           np.arctan(theta1) * 180/np.pi,
           dl0,
           dl1)
+
+# Utility function to compute the HAAT for a CBSD
+def ComputeHaat(lat_cbsd, lon_cbsd, height_cbsd, height_is_agl=True):
+  """Computes a CBSD HAAT (Height above average terrain).
+
+  Args:
+    lat_cbsd, lon_cbsd: the CBSD location (degrees).
+    height_cbsd: the CBSD antenna height (meters)
+    height_is_agl: boolean specifying if height is AGL (Above Ground Level)
+      or AMSL (Above Mean Sea Level).
+
+  Returns:
+    the CBSD HAAT (meters).
+  """
+  norm_haat, alt_ground = terrainDriver.ComputeNormalizedHaat(lat_cbsd, lon_cbsd)
+  if height_is_agl:
+    return height_cbsd + norm_haat
+  else:
+    return height_cbsd - alt_ground + norm_haat

--- a/src/harness/reference_models/propagation/wf_itm_test.py
+++ b/src/harness/reference_models/propagation/wf_itm_test.py
@@ -132,5 +132,21 @@ class TestWfItm(unittest.TestCase):
     self.assertAlmostEqual(d0, 55357.7, 1)
     self.assertAlmostEqual(d1, 19450.0, 1)
 
+  def test_haat(self):
+    # Twin Peaks
+    haat = wf_itm.ComputeHaat(
+        lat_cbsd=37.751458, lon_cbsd=-122.447831, height_cbsd=10)
+    self.assertAlmostEqual(haat, 259.81, 2)
+    haat = wf_itm.ComputeHaat(
+        lat_cbsd=37.751458, lon_cbsd=-122.447831, height_cbsd=284.69,
+        height_is_agl=False)
+    self.assertAlmostEqual(haat, 259.80, 2)
+
+    # Ocean - far away from the coast
+    haat  = wf_itm.ComputeHaat(
+        lat_cbsd=37.50, lon_cbsd=-122.999, height_cbsd=10)
+    self.assertEqual(haat, 10)
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
New function wf_itm.ComputeHaat().

Note: this is provided as part of  wf_itm which manages the terrain driver.
A future PR will have some cleanup so that the wf_itm module is the unique source of data drivers (currently duplicated in wf_hybrid). 