### PR TITLE
E-Hata fixes for robustness

### DIFF
--- a/src/harness/reference_models/propagation/ehata/its/ExtendedHata.cpp
+++ b/src/harness/reference_models/propagation/ehata/its/ExtendedHata.cpp
@@ -1,4 +1,5 @@
 #include "stdio.h"
+#include "cmath"
 #include "ehata.h"
 
 // ******* WinnForum extension *******
@@ -8,6 +9,15 @@ bool _WinnForum_Extensions = true; // on by default
 void SetWinnForumExtensions(bool on)
 {
   _WinnForum_Extensions = on;
+}
+
+// Definition of the profile distance calculation routine - see ehata.h
+double GetDistanceInMeters(double pfl[])
+{
+  double distance_m = pfl[0] * pfl[1];
+  if (fabs(distance_m - round(distance_m)) < 1e-5)
+    distance_m = round(distance_m);
+  return distance_m;
 }
 
 // Debug print routine
@@ -106,7 +116,12 @@ void ExtendedHata_DBG(float pfl[], float f__mhz, float h_b__meter, float h_m__me
         if (interValues->h_b_eff__meter > 200.0) interValues->h_b_eff__meter = 200.0;
     }
     // ******* End WinnForum extension *******
-    interValues->d__km = pfl[0] * pfl[1] / 1000;
+    // ******* WinnForum change *******
+    //interValues->d__km = pfl[0] * pfl[1] / 1000;
+    interValues->d__km = GetDistanceInMeters(pfl) / 1000.;
+
+    // ******* End WinnForum change *******
+
     float plb_median__db;
     MedianBasicPropLoss(f__mhz, interValues->h_b_eff__meter, interValues->h_m_eff__meter, interValues->d__km, enviro_code, &plb_median__db, interValues);
 

--- a/src/harness/reference_models/propagation/ehata/its/FineRollingHillyTerrainCorectionFactor.cpp
+++ b/src/harness/reference_models/propagation/ehata/its/FineRollingHillyTerrainCorectionFactor.cpp
@@ -35,6 +35,9 @@ float FineRollingHillyTerrainCorectionFactor(InterValues *interValues, float h_m
         return -K_h;
     else if (h_m_gnd__meter < interValues->pfl10__meter && h_m_gnd__meter >= interValues->pfl50__meter)
         return K_h * (h_m_gnd__meter - interValues->pfl50__meter) / (interValues->pfl10__meter - interValues->pfl50__meter);
-    else
-        return -K_h * (h_m_gnd__meter - interValues->pfl90__meter) / (interValues->pfl50__meter - interValues->pfl90__meter);
+    else {
+      // ** Winnforum fix - this condition is wrong and breaks the continuity **
+      //return -K_h * (h_m_gnd__meter - interValues->pfl90__meter) / (interValues->pfl50__meter - interValues->pfl90__meter);
+      return -K_h * (interValues->pfl50__meter - h_m_gnd__meter) / (interValues->pfl50__meter - interValues->pfl90__meter);      
+    }
 }

--- a/src/harness/reference_models/propagation/ehata/its/PreprocessTerrainPath.cpp
+++ b/src/harness/reference_models/propagation/ehata/its/PreprocessTerrainPath.cpp
@@ -32,8 +32,14 @@ void PreprocessTerrainPath(float *pfl, float h_b__meter, float h_m__meter, Inter
 void FindAverageGroundHeight(float *pfl, InterValues *interValues)
 {
     int np = int(pfl[0]);
-    float xi = pfl[1] * 0.001;      // step size of the profile points, in km
-    float d__km = np * xi;          // path distance, in km
+    // ******* WinnForum change *******
+    // Old code:
+    //float xi = pfl[1] * 0.001;      // step size of the profile points, in km
+    //float d__km = np * xi;          // path distance, in km
+    // New code:
+    float xi = pfl[1] / 1000.;      // step size of the profile points, in km
+    float d__km = GetDistanceInMeters(pfl) / 1000.;
+    // ******* End WinnForum change *******
 
     int i_start, i_end;
     float sum = 0.0;
@@ -132,8 +138,14 @@ void FindAverageGroundHeight(float *pfl, InterValues *interValues)
 void ComputeTerrainStatistics(float *pfl, InterValues *interValues)
 {
     int np = int(pfl[0]);
-    float xi = pfl[1] * 0.001;      // step size of the profile points, in km
-    float d__km = np * xi;          // path distance, in km
+    // ******* WinnForum change *******
+    // Old code:
+    //float xi = pfl[1] * 0.001;      // step size of the profile points, in km
+    //float d__km = np * xi;          // path distance, in km
+    // New code:
+    float xi = pfl[1] / 1000.;      // step size of the profile points, in km    
+    float d__km = GetDistanceInMeters(pfl) / 1000.;
+    // ******* End WinnForum change *******
 
     int i_start, i_end;
 
@@ -156,7 +168,14 @@ void ComputeTerrainStatistics(float *pfl, InterValues *interValues)
     }
 
     // create a copy of the 10 km path at the mobile, or the whole path (if less than 10 km)
-    float pfl_segment[400];
+    // ******* WinnForum change *******
+    // The following code may crash the application if using a step <= 25m
+    // Old code:
+    //float pfl_segment[400];
+    // New code:
+    float *pfl_segment = new float[i_end - i_start + 2];
+    // ******* End WinnForum change *******
+    
     for (int i = i_start; i <= i_end; i++)
         pfl_segment[i - i_start] = pfl[i];
 
@@ -179,6 +198,9 @@ void ComputeTerrainStatistics(float *pfl, InterValues *interValues)
         interValues->pfl90__meter = interValues->pfl90__meter * factor;
         interValues->deltah__meter = interValues->deltah__meter * factor;
     }
+    // ******* WinnForum change *******
+    delete[] pfl_segment;
+    // ******* End winnForum change *******    
 }
 
 /*
@@ -197,9 +219,15 @@ void ComputeTerrainStatistics(float *pfl, InterValues *interValues)
 */
 void MobileTerrainSlope(float *pfl, InterValues *interValues)
 {
-    int np = int(pfl[0]);           // number of points
+    // ******* WinnForum change *******
+    // Old code:
+    //int np = int(pfl[0]);           // number of points
+    //float xi = pfl[1];              // step size of the profile points, in meter
+    //float d__meter = np * xi;
+    // New code:
     float xi = pfl[1];              // step size of the profile points, in meter
-    float d__meter = np * xi;
+    float d__meter = GetDistanceInMeters(pfl);
+    // ******* End WinnForum change *******
 
     // find the mean slope of the terrain in the vicinity of the mobile station
     interValues->slope_max = -1.0e+31;
@@ -208,7 +236,13 @@ void MobileTerrainSlope(float *pfl, InterValues *interValues)
     float slope;
     
     float x1, x2;
-    float pfl_segment[400] = { 0 };
+    // ******* WinnForum change *******
+    // The following code may crash the application if using a step <= 25m
+    // Old code:
+    //float pfl_segment[400] = { 0 };
+    // New code:
+    float *pfl_segment = new float[int(10000/xi) + 4]();
+    // ******* End WinnForum change *******
 
     x1 = 0.0;
     x2 = 5000.0;
@@ -253,6 +287,9 @@ void MobileTerrainSlope(float *pfl, InterValues *interValues)
             interValues->trace_code = interValues->trace_code | TRACE__METHOD_07;
         }
     }
+    // ******* WinnForum change *******
+    delete[] pfl_segment;
+    // ******* End winnForum change *******    
 }
 
 /*
@@ -345,8 +382,13 @@ float AverageTerrainHeight(float *pfl)
 void SingleHorizonTest(float *pfl, float h_m__meter, float h_b__meter, InterValues *interValues)
 {
     int np = int(pfl[0]);           // number of points
-    float xi = pfl[1];              // step size of the profile points, in meter
-    float d__meter = np * xi;
+    // ******* WinnForum change *******
+    // Old code:
+    //float xi = pfl[1];              // step size of the profile points, in meter
+    //float d__meter = np * xi;
+    // New code:
+    float d__meter = GetDistanceInMeters(pfl);
+    // ******* End WinnForum change *******
 
     float h_gnd__meter = AverageTerrainHeight(pfl);
 

--- a/src/harness/reference_models/propagation/ehata/its/ehata.h
+++ b/src/harness/reference_models/propagation/ehata/its/ehata.h
@@ -35,6 +35,17 @@
 extern bool _WinnForum_Extensions; // default is ON
 void SetWinnForumExtensions(bool on);
 
+// Function to get the distance in meters from a profile:
+//  the `pfl` profile store the number of points and the step between
+//  points. The total profile distance is given by N*step, but can lead to a
+//  very small loss of precision because of floating point issues. This can
+//  create mismatch depending on compilers, given that the eHata model has
+//  specific logic based on threshold on specific integer values (10km, etc..).
+//  One solution is to reset the distance used in calculation to proper integer
+//  values when detected as very close to an integer value.
+//  This function does exactly that.
+float GetDistanceInMeters(float pfl[]);
+
 // ******* End WinnForum extension *******
 
 struct InterValues

--- a/src/harness/reference_models/propagation/wf_hybrid_test.py
+++ b/src/harness/reference_models/propagation/wf_hybrid_test.py
@@ -161,7 +161,7 @@ class TestWfHybrid(unittest.TestCase):
                                     reliability=-1, freq_mhz=3625.,
                                     region='SUBURBAN')
     self.assertAlmostEqual(avg_res.db_loss,
-                           10*np.log10(np.mean(10**(np.array(losses)/10.))),
+                           -10*np.log10(np.mean(10**(-np.array(losses)/10.))),
                            5)
 
   def test_indoor(self):


### PR DESCRIPTION
Two fixes:
 - Improve the path profile distance to recover floating point accuracy
   loss (caused by the profile format where the distance is obtained
   by a multiplication N.step, instead of being encoded). This may
   cause mismatch on various compilers, because of the calculation
   non-linearities dependent on specific 'plain' distance (10km...).

 - use internal dynamic array instead of hardcoded one, which causes
   crash if step resolution < 25m

NOTE: related to FW report: #333 