### PR TITLE
Bunch of small fixes on the reference models

### DIFF
--- a/src/harness/reference_models/geo/terrain.py
+++ b/src/harness/reference_models/geo/terrain.py
@@ -82,12 +82,24 @@ class TerrainDriver:
     self._tile_lru = {}
     self.stats = tiles.TileStats('ned')
     self._lock = threading.Lock()
+    self.do_flat = False
 
   def SetTerrainDirectory(self, terrain_directory):
     """Configures the terrain data directory."""
     self._terrain_dir = terrain_directory
     if self._terrain_dir is None:
       self._terrain_dir = CONFIG.GetTerrainDir()
+
+  def SetFlatEarthMode(self, do_flat=False):
+    """Sets the driver in flat-earth mode.
+
+    This is an option to always return zero altitude, to be used for testing
+    and debugging. Not to be used in normal operations.
+
+    Inputs:
+      do_flat (bool): if True, the driver always return altitude 0 everywhere.
+    """
+    self.do_flat = do_flat
 
   def SetCacheSize(self, cache_size):
     """Configures the cache size."""
@@ -174,6 +186,9 @@ class TerrainDriver:
     ilon = np.floor(lon)
     alt = np.zeros(len(lat))
 
+    if self.do_flat:
+      return alt[0] if is_scalar else alt
+
     # Find the coordinates of the lat/lon in the tile file,
     # in floating point units.
     float_x = _NUM_PIXEL_OVERLAP + _TILE_BASE_DIM * (lon - ilon)
@@ -229,10 +244,7 @@ class TerrainDriver:
         # Use the elevation of the nearest point
         alt[idx] = tile_cache[iy[idx], ix[idx]]
 
-    if is_scalar:
-      return alt[0]
-    else:
-      return alt
+    return alt[0] if is_scalar else alt
 
   def TerrainProfile(self, lat1, lon1, lat2, lon2,
                      target_res_meter=-1,
@@ -272,7 +284,7 @@ class TerrainDriver:
     dist, _, _ = vincenty.GeodesicDistanceBearing(lat1, lon1, lat2, lon2)
     dist *= 1000.
 
-    num_points = int(dist/target_res_meter) + 1
+    num_points = np.ceil(dist/float(target_res_meter)) + 1
     if max_points > 0 and num_points > max_points:
       num_points = max_points
     if num_points < 2:

--- a/src/harness/reference_models/propagation/wf_hybrid_test.py
+++ b/src/harness/reference_models/propagation/wf_hybrid_test.py
@@ -91,7 +91,7 @@ class TestWfHybrid(unittest.TestCase):
     lat1, lng1, height1 = 37.756672, -122.508512, 20.0
     lat2, lng2, height2 = 37.754406, -122.388342, 10.0
     reliabilities = [0.1, 0.5, 0.9]
-    expected_itm_losses = [210.79, 211.51, 211.95]
+    expected_itm_losses = [210.75, 211.47, 211.92]
 
     for rel, exp_loss in zip(reliabilities, expected_itm_losses):
       res = wf_hybrid.CalcHybridPropagationLoss(lat1, lng1, height1, lat2, lng2, height2,
@@ -161,7 +161,7 @@ class TestWfHybrid(unittest.TestCase):
                                     reliability=-1, freq_mhz=3625.,
                                     region='SUBURBAN')
     self.assertAlmostEqual(avg_res.db_loss,
-                           10*np.log10(np.mean(10**(np.array(losses)/10.))),
+                           -10*np.log10(np.mean(10**(-np.array(losses)/10.))),
                            5)
 
   def test_indoor(self):

--- a/src/harness/reference_models/propagation/wf_itm_test.py
+++ b/src/harness/reference_models/propagation/wf_itm_test.py
@@ -57,7 +57,7 @@ class TestWfItm(unittest.TestCase):
     lat1, lng1, height1 = 37.756672, -122.508512, 20.0
     lat2, lng2, height2 = 37.754406, -122.388342, 10.0
     reliabilities = [0.1, 0.5, 0.9]
-    expected_losses = [213.72, 214.30, 214.66]
+    expected_losses = [213.68, 214.26, 214.62]
 
     for rel, exp_loss in zip(reliabilities, expected_losses):
       res = wf_itm.CalcItmPropagationLoss(lat1, lng1, height1, lat2, lng2, height2,


### PR DESCRIPTION
This is ongoing branch for fixes to reference models following various feedback from Winnforum participants.
 - Fix the profile number of points to follow the spec (final resolution
 shall be as close as possible as 30m without being higher). Reported by arhannan  in #361.
 - Add a utility routine on the terrain driver to force the driver to
 return all zero altitude. This is useful for testing/debugging, and was
 done before by not pointing to a valid geo database. But recent change
 on geo data robustness now prevent using that workaround. This new
 method allows to recover this behavior by simply doing:
   wf_itm.terrainDriver.SetFlatEarthMode(do_flat=True)
 - Fix the unit testing