### PR TITLE
Misc minor fixes to ref models

### DIFF
--- a/src/harness/reference_models/geo/terrain.py
+++ b/src/harness/reference_models/geo/terrain.py
@@ -244,6 +244,9 @@ class TerrainDriver:
         # Use the elevation of the nearest point
         alt[idx] = tile_cache[iy[idx], ix[idx]]
 
+    if not do_interp:
+      alt[alt < -900] = 0.
+
     return alt[0] if is_scalar else alt
 
   def TerrainProfile(self, lat1, lon1, lat2, lon2,

--- a/src/harness/reference_models/propagation/ehata/ehata.py
+++ b/src/harness/reference_models/propagation/ehata/ehata.py
@@ -90,9 +90,6 @@ def CbsdEffectiveHeights(height_cbsd, its_elev):
   dist_km = npts * xi         # path distance, in km
   elev_cbsd = its_elev[2]
 
-  if height_cbsd < 20:
-    height_cbsd = 20.
-
   if dist_km < 3.0:
     eff_height = height_cbsd
 


### PR DESCRIPTION
- process correctly terrain invalid values in non interpolation mode.
  This does not affect current operation as terrain is always used as interpolated, but can eventually 
  affect internal testing between real SAS and reference models.

- Remove a useless test in CbsdEffectiveHeight() (ehata/ehata.py).
  This test is already part of wf_hybrid.py, and prevent the routine
   to provide same result as internal effective height from C code, which
   is useful for testing. Reported by Mayowa from Commscope.
