### PR TITLE
Fix antenna gain when beamwidth is 0 or 360 degrees.

### DIFF
--- a/src/harness/reference_models/antenna/antenna.py
+++ b/src/harness/reference_models/antenna/antenna.py
@@ -88,7 +88,7 @@ def GetStandardAntennaGains(hor_dirs, ant_azimuth=None, ant_beamwidth=None, ant_
     hor_dirs:       Ray directions in horizontal plane (degrees).
                     Either a scalar or an iterable.
     ant_azimut:     Antenna azimuth (degrees).
-    ant_beamwidth:  Antenna 3dB curoff beamwidth (degrees).
+    ant_beamwidth:  Antenna 3dB cutoff beamwidth (degrees).
                     If None, then antenna is isotropic (default).
     ant_gain:       Antenna gain (dBi).
 

--- a/src/harness/reference_models/antenna/antenna.py
+++ b/src/harness/reference_models/antenna/antenna.py
@@ -99,7 +99,8 @@ def GetStandardAntennaGains(hor_dirs, ant_azimuth=None, ant_beamwidth=None, ant_
   is_scalar = np.isscalar(hor_dirs)
   hor_dirs = np.atleast_1d(hor_dirs)
 
-  if ant_beamwidth is None or ant_azimuth is None:
+  if (ant_beamwidth is None or ant_azimuth is None or
+      ant_beamwidth == 0 or ant_beamwidth == 360):
     gains = ant_gain * np.ones(hor_dirs.shape)
   else:
     bore_angle = hor_dirs - ant_azimuth

--- a/src/harness/reference_models/antenna/antenna_test.py
+++ b/src/harness/reference_models/antenna/antenna_test.py
@@ -48,11 +48,19 @@ class TestAntenna(unittest.TestCase):
   def test_standard_gain(self):
     # Isotropic antenna
     gains = antenna.GetStandardAntennaGains([0, 90, 180, 270],
-                                           0, None, 5)
+                                            0, None, 5)
     self.assertEqual(np.max(np.abs(
         gains - 5 * np.ones(4))), 0)
     gains = antenna.GetStandardAntennaGains([0, 90, 180, 270],
-                                           None, 90, 5)
+                                            None, 90, 5)
+    self.assertEqual(np.max(np.abs(
+        gains - 5 * np.ones(4))), 0)
+    gains = antenna.GetStandardAntennaGains([0, 90, 180, 270],
+                                            0, 0, 5)
+    self.assertEqual(np.max(np.abs(
+        gains - 5 * np.ones(4))), 0)
+    gains = antenna.GetStandardAntennaGains([0, 90, 180, 270],
+                                            0, 360, 5)
     self.assertEqual(np.max(np.abs(
         gains - 5 * np.ones(4))), 0)
 


### PR DESCRIPTION
The spec allows for such extrema values without clear specification
of the behavior. Clearly when those happens, we should consider the
antenna as omnidirectional.