### PR TITLE
Improve logging

### DIFF
--- a/src/harness/sas.py
+++ b/src/harness/sas.py
@@ -92,7 +92,7 @@ def _RequestPost(url, request, config):
   conn.setopt(conn.SSL_CIPHER_LIST, ':'.join(config.ciphers))
   conn.setopt(conn.POST, True)
   request = json.dumps(request) if request else ''
-  logging.debug('Request to URL ' + url + ':\n' + request)
+  logging.info('Request to URL ' + url + ':\n' + request)
   conn.setopt(conn.POSTFIELDS, request)
   conn.setopt(conn.TIMEOUT, HTTP_TIMEOUT_SECS)
   try:
@@ -104,7 +104,7 @@ def _RequestPost(url, request, config):
   http_code = conn.getinfo(pycurl.HTTP_CODE)
   conn.close()
   body = response.getvalue()
-  logging.debug('Response:\n' + body)
+  logging.info('Response:\n' + body)
   assert http_code == 200, http_code
   if body:
     return json.loads(body)
@@ -136,13 +136,13 @@ def _RequestGet(url, config):
   conn.setopt(conn.CAINFO, config.ca_cert)
   conn.setopt(conn.HTTPHEADER, header)
   conn.setopt(conn.SSL_CIPHER_LIST, ':'.join(config.ciphers))
-  logging.debug('Request to URL ' + url)
+  logging.info('Request to URL ' + url)
   conn.setopt(conn.TIMEOUT, HTTP_TIMEOUT_SECS)
   conn.perform()
   assert conn.getinfo(pycurl.HTTP_CODE) == 200, conn.getinfo(pycurl.HTTP_CODE)
   conn.close()
   body = response.getvalue()
-  logging.debug('Response:\n' + body)
+  logging.info('Response:\n' + body)
   return json.loads(body)
 
 class SasImpl(sas_interface.SasInterface):

--- a/src/harness/util.py
+++ b/src/harness/util.py
@@ -33,6 +33,7 @@ from shapely.geometry import shape, Point, LineString
 
 
 def _log_testcase_header(name, doc):
+  logging.getLogger().setLevel(logging.INFO)
   logging.info('Running WinnForum test case %s:', name)
   logging.info(doc)
 


### PR DESCRIPTION
Add logger to testcase decorator. Promote logging level of request/response messages to INFO.

Add a logger to ensure that logging is turned on, even when running only
one test case (e.g. with `python -m unittest`).

Promote logging of requests/responses to INFO level so that we can see
them without getting all of the curl debug messages at the same time.