### PR TITLE
Fix flat-earth test mode.

### DIFF
--- a/src/harness/reference_models/geo/terrain.py
+++ b/src/harness/reference_models/geo/terrain.py
@@ -187,7 +187,7 @@ class TerrainDriver:
     alt = np.zeros(len(lat))
 
     if self.do_flat:
-      return alt[0] if is_scalar else alt
+      return alt[0]+10 if is_scalar else alt+10
 
     # Find the coordinates of the lat/lon in the tile file,
     # in floating point units.


### PR DESCRIPTION
The flat earth test mode of the terrain driver allows for simulation on
flat earth with zero altitude.
Unfortunately using zero altitude is detected by some model (E-Hata) as
the sea, and they apply a special correction increasing the pathloss.
To avoid confusion, the flat earth mode will now return a fixed altitude
of 10 meters to simulate being inland.

This does not affect normal operation as this is used only for tests.