### PR TITLE
Improve logging - timestamp and error description

### DIFF
--- a/src/harness/sas.py
+++ b/src/harness/sas.py
@@ -57,12 +57,21 @@ def GetTestingSas():
   version = config_parser.get('SasConfig', 'Version')
   return SasImpl(base_url, version), SasAdminImpl(base_url)
 
+
 def _RequestPost(url, request, config):
-  """Sends HTTPS POST request.
+    return _Request(url, request, config)
+
+
+def _RequestGet(url, config):
+    return _Request(url, None, config)
+
+
+def _Request(url, request, config):
+  """Sends HTTPS request.
 
   Args:
     url: Destination of the HTTPS request.
-    request: Content of the request.
+    request: Content of the request. (Can be None)
     config: a |TlsConfig| object defining the TLS/HTTPS configuration.
   Returns:
     A dictionary represents the JSON response received from server.
@@ -109,41 +118,6 @@ def _RequestPost(url, request, config):
   if body:
     return json.loads(body)
 
-
-def _RequestGet(url, config):
-  """Sends HTTPS GET request.
-
-  Args:
-    url: Destination of the HTTPS request.
-    config: a |TlsConfig| object defining the TLS/HTTPS configuration.
-  Returns:
-    A dictionary represents the JSON response received from server.
-  """
-  response = StringIO.StringIO()
-  conn = pycurl.Curl()
-  conn.setopt(conn.URL, url)
-  conn.setopt(conn.WRITEFUNCTION, response.write)
-  header = [
-      'Host: %s' % urlparse.urlparse(url).hostname,
-      'content-type: application/json'
-  ]
-  conn.setopt(conn.VERBOSE, 3  # Improve readability.
-              if logging.getLogger().isEnabledFor(logging.DEBUG) else False)
-  conn.setopt(conn.SSLVERSION, config.ssl_version)
-  conn.setopt(conn.SSLCERTTYPE, 'PEM')
-  conn.setopt(conn.SSLCERT, config.client_cert)
-  conn.setopt(conn.SSLKEY, config.client_key)
-  conn.setopt(conn.CAINFO, config.ca_cert)
-  conn.setopt(conn.HTTPHEADER, header)
-  conn.setopt(conn.SSL_CIPHER_LIST, ':'.join(config.ciphers))
-  logging.info('Request to URL ' + url)
-  conn.setopt(conn.TIMEOUT, HTTP_TIMEOUT_SECS)
-  conn.perform()
-  assert conn.getinfo(pycurl.HTTP_CODE) == 200, conn.getinfo(pycurl.HTTP_CODE)
-  conn.close()
-  body = response.getvalue()
-  logging.info('Response:\n' + body)
-  return json.loads(body)
 
 class SasImpl(sas_interface.SasInterface):
   """Implementation of SasInterface for SAS certification testing."""

--- a/src/harness/sas.py
+++ b/src/harness/sas.py
@@ -109,7 +109,7 @@ def _Request(url, request, config):
   except pycurl.error as e:
     # e contains a tuple (libcurl_error_code, string_description).
     # See https://curl.haxx.se/libcurl/c/libcurl-errors.html
-    raise AssertionError(e.args[0])
+    raise AssertionError(e.args[0], e.args[1])
   http_code = conn.getinfo(pycurl.HTTP_CODE)
   conn.close()
   body = response.getvalue()

--- a/src/harness/util.py
+++ b/src/harness/util.py
@@ -21,6 +21,7 @@ import json
 import logging
 import os
 import random
+import sys
 import uuid
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -33,6 +34,11 @@ from shapely.geometry import shape, Point, LineString
 
 
 def _log_testcase_header(name, doc):
+  handler = logging.StreamHandler(sys.stdout)
+  handler.setFormatter(
+    logging.Formatter(
+      '[%(levelname)s] %(asctime)s %(filename)s:%(lineno)d %(message)s'))
+  logging.getLogger().addHandler(handler)
   logging.getLogger().setLevel(logging.INFO)
   logging.info('Running WinnForum test case %s:', name)
   logging.info(doc)


### PR DESCRIPTION
1. Added formatter to test case logging so it would include timestamp and other fields from the test_main.py formatter. Having the timestamp (which defaults to a local timestamp, even if in a different timezone than SAS) will help in correlating SAS logs to Test Harness logs.

2. Added error description to the assert message, since that message sometimes contains more details than the number provides and could be useful for debugging.
  a. Consolidated _RequestPost and _RequestGet, as the only difference is request is None for _RequestGet.