### PR TITLE
fix logging handler being added every time a test case is invoked

### DIFF
--- a/src/harness/util.py
+++ b/src/harness/util.py
@@ -34,12 +34,13 @@ from shapely.geometry import shape, Point, LineString
 
 
 def _log_testcase_header(name, doc):
-  handler = logging.StreamHandler(sys.stdout)
-  handler.setFormatter(
-    logging.Formatter(
-      '[%(levelname)s] %(asctime)s %(filename)s:%(lineno)d %(message)s'))
-  logging.getLogger().addHandler(handler)
-  logging.getLogger().setLevel(logging.INFO)
+  if not len(logging.getLogger().handlers):
+    handler = logging.StreamHandler(sys.stdout)
+    handler.setFormatter(
+      logging.Formatter(
+        '[%(levelname)s] %(asctime)s %(filename)s:%(lineno)d %(message)s'))
+    logging.getLogger().addHandler(handler)
+    logging.getLogger().setLevel(logging.INFO)
   logging.info('Running WinnForum test case %s:', name)
   logging.info(doc)
 


### PR DESCRIPTION
Only add a logging handler if none have been added. So logging will be configured whether running one testcase or running testcases using test_main.py, which also adds a logger.