### PR TITLE
fix SCS.10 and SDS.10 issues

### DIFF
--- a/cert/openssl.cnf
+++ b/cert/openssl.cnf
@@ -510,15 +510,6 @@ TEST = critical, ASN1:NULL
 
 policyIdentifier = 2.16.840.1.114412.2.1
  CPS.1="https://www.digicert.com/CPS"
-
-[ wrong_cbsd_req_sign ]
-subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
-basicConstraints = CA:FALSE
-keyUsage = critical, digitalSignature, keyEncipherment
-extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_SAS
-TEST = critical, ASN1:NULL
 ####################################################################
  
 [ cbsd_oem_req ]

--- a/src/harness/certs/generate_fake_certs.sh
+++ b/src/harness/certs/generate_fake_certs.sh
@@ -231,7 +231,7 @@ openssl ca -cert non_cbrs_root_signed_cbsd_ca.cert -keyfile private/non_cbrs_roo
 echo "\n\nGenerate wrong type certificate/key"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in server.csr \
     -out wrong_type_client.cert -outdir ./root \
-    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_client_mode_req_sign   -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 #Certificate for test case WINNF.FT.S.SCS.12 - Expired certificate presented during registration
@@ -303,7 +303,7 @@ openssl ca -cert non_cbrs_root_signed_oper_ca.cert -keyfile private/non_cbrs_roo
 echo "\n\nGenerate wrong type certificate/key"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in server.csr \
     -out wrong_type_domain_proxy.cert -outdir ./root \
-    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_client_mode_req_sign   -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 #Certificate for test case WINNF.FT.S.SDS.12 - Expired certificate presented during registration


### PR DESCRIPTION
This PR is to address the issues found by Tahashi of Sony.

[1] SCS.10
-line 234 :    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \

  Comment: 
This will create cert of the wrong usage (serverAuth). 
I’ve Looked into the openssl.cnf file and I believe the correct way is: 

  -policy policy_anything -extensions wrong_cbsd_req_sign -config ../../../cert/openssl.cnf \

[FW] We agree with this comment and the TLS authentication will fail for the wrong usage. We will use sas_client_mode_req_sign instead of wrong_cbsd_req_sign. I think that will be correct approach. Both wrong_cbsd_req_sign and sas_client_mode_req_sign are exactly the same. Both will create a SAS certificate with usage clientAuth. sas_client_mode_req_sign
was added to address the usage issue.

[2] SDS.10
-line 306:    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \

  Comment: 
SDS.10 would be the same situation. 

[FW] Similar to the previous comment sas_client_mode_req_sign will be used and we do not have to create  a wrong_oper_req_sign section.

