### PR TITLE
Add a new utility routine GridPolygon().

### DIFF
--- a/src/harness/reference_models/geo/utils.py
+++ b/src/harness/reference_models/geo/utils.py
@@ -71,10 +71,10 @@ def GridPolygon(poly, res_arcsec):
 
   res = res_arcsec / 3600.
   bounds = poly.bounds
-  lng_min = int(bounds[0] / res) * res
-  lat_min = int(bounds[1] / res) * res
-  lng_max = int(bounds[2] / res + 1) * res
-  lat_max = int(bounds[3] / res + 1) * res
+  lng_min = np.floor(bounds[0] / res) * res
+  lat_min = np.floor(bounds[1] / res) * res
+  lng_max = np.ceil(bounds[2] / res + 1) * res
+  lat_max = np.ceil(bounds[3] / res + 1) * res
   mesh_lng, mesh_lat = np.mgrid[lng_min:lng_max:res,
                                 lat_min:lat_max:res]
   points = np.vstack((mesh_lng.ravel(), mesh_lat.ravel())).T

--- a/src/harness/reference_models/geo/utils.py
+++ b/src/harness/reference_models/geo/utils.py
@@ -73,8 +73,8 @@ def GridPolygon(poly, res_arcsec):
   bounds = poly.bounds
   lng_min = np.floor(bounds[0] / res) * res
   lat_min = np.floor(bounds[1] / res) * res
-  lng_max = np.ceil(bounds[2] / res + 1) * res
-  lat_max = np.ceil(bounds[3] / res + 1) * res
+  lng_max = np.ceil(bounds[2] / res) * res + res/2
+  lat_max = np.ceil(bounds[3] / res) * res + res/2
   mesh_lng, mesh_lat = np.mgrid[lng_min:lng_max:res,
                                 lat_min:lat_max:res]
   points = np.vstack((mesh_lng.ravel(), mesh_lat.ravel())).T

--- a/src/harness/reference_models/geo/utils.py
+++ b/src/harness/reference_models/geo/utils.py
@@ -12,7 +12,7 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
-"""Utility routines.
+"""Utility geometry routines.
 """
 
 import shapely.geometry as sgeo
@@ -40,6 +40,48 @@ def GeoJsonToShapelyGeometry(geo):
   if isinstance(geo, sgeo.Polygon) or isinstance(geo, sgeo.MultiPolygon):
     geo = geo.buffer(0)
   return geo
+
+
+def GridPolygon(poly, res_arcsec):
+  """Grids a polygon or multi-polygon.
+
+  This performs regular gridding of a polygon in PlateCarree (equirectangular)
+  projection (ie with fixed step in degrees in lat/lon space).
+  Points falling in the boundary of polygon will be included.
+
+  Args:
+    poly: A Polygon or MultiPolygon in WGS84 or NAD83, defined either
+      as a `shapely` or GeoJSON dict geometries.
+    res_arcsec: The resolution (in arcsec) used for regular gridding.
+
+  Returns:
+    A list of (lon, lat) defining the grid points.
+  """
+  if isinstance(poly, dict):
+    poly = GeoJsonToShapelyGeometry(poly)
+    return GridPolygon(poly, res_arcsec)
+
+  if isinstance(poly, sgeo.MultiPolygon):
+    # Optional block: for MultiPolygons, we process per polygon
+    # to avoid inefficiencies if polygons largely disjoint.
+    pts = ops.unary_union(
+        [sgeo.asMultiPoint(GridPolygon(p, res_arcsec))
+         for p in poly])
+    return [(p.x, p.y) for p in pts]
+
+  res = res_arcsec / 3600.
+  bounds = poly.bounds
+  lng_min = int(bounds[0] / res) * res
+  lat_min = int(bounds[1] / res) * res
+  lng_max = int(bounds[2] / res + 1) * res
+  lat_max = int(bounds[3] / res + 1) * res
+  mesh_lng, mesh_lat = np.mgrid[lng_min:lng_max:res,
+                                lat_min:lat_max:res]
+  points = np.vstack((mesh_lng.ravel(), mesh_lat.ravel())).T
+  pts = poly.intersection(sgeo.asMultiPoint(points))
+  if isinstance(pts, sgeo.Point):
+    return [(pts.x, pts.y)]
+  return [(p.x, p.y) for p in pts]
 
 
 def _RingArea(latitudes, longitudes):

--- a/src/harness/reference_models/geo/utils_test.py
+++ b/src/harness/reference_models/geo/utils_test.py
@@ -18,6 +18,7 @@ import os
 import unittest
 import geojson
 import shapely.geometry as sgeo
+from shapely import ops
 
 from reference_models.geo import utils
 
@@ -101,6 +102,38 @@ class TestUtils(unittest.TestCase):
     self.assertAlmostEqual(area - area_with_hole, 0.617, 3)
     self.assertEqual(square, square_cleaned)
     self.assertEqual(multipoly_cleaned, sgeo.MultiPolygon([square, hole]))
+
+  def test_grid_point_and_null(self):
+    poly = sgeo.Polygon([(1.9, 0.9), (2.1, 0.9), (2.1, 1.1), (1.9, 1.1)])
+    exp_pts = [(2.0, 1.0)]
+    pts = utils.GridPolygon(poly, res_arcsec=900.)
+    self.assertListEqual(pts, exp_pts)
+    pts = utils.GridPolygon(poly, res_arcsec=7200.)
+    self.assertListEqual(pts, [])
+
+  def test_grid_simple(self):
+    poly = sgeo.Polygon([(1.9, 3.9), (3.1, 3.9), (3.1, 4.4),
+                         (2.5, 4.5), (2.4, 5.1), (1.9, 5.1)])
+    exp_pts = {(2.0, 4.0), (2.5, 4.0), (3.0, 4.0),
+               (2.0, 4.5), (2.5, 4.5), (2.0, 5.0)}
+    pts = utils.GridPolygon(poly, res_arcsec=1800.)
+    self.assertSetEqual(set(pts), exp_pts)
+
+  def test_grid_complex(self):
+    with open(os.path.join(TEST_DIR, 'test_geocollection.json'), 'r') as fd:
+      json_geo = geojson.load(fd)
+
+    shape_geo = utils.GeoJsonToShapelyGeometry(json_geo)
+    exp_pts = {(-95, 40), (-95.5, 40.5), (-95.5, 40),
+               (-96, 40), (-96.5, 40.5), (-96.5, 40)}
+    pts = utils.GridPolygon(json_geo, res_arcsec=1800)
+    self.assertSetEqual(set(pts), exp_pts)
+
+    pts = utils.GridPolygon(shape_geo, res_arcsec=1800)
+    self.assertSetEqual(set(pts), exp_pts)
+
+    pts = utils.GridPolygon(ops.unary_union(shape_geo), res_arcsec=1800)
+    self.assertSetEqual(set(pts), exp_pts)
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Useful to efficiently grid a zone from a GeoJSON or a Shapely
polygon (PPA, DPA, ...).