### PR TITLE
Update the configurations and the generation script of the certificates

### DIFF
--- a/cert/openssl.cnf
+++ b/cert/openssl.cnf
@@ -322,7 +322,7 @@ basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature
 extendedKeyUsage = serverAuth
 certificatePolicies=@cps,ROLE_SAS,FRN
-TEST = critical, ASN1:NULL
+TEST = ASN1:NULL
 [ cps ]
 
 policyIdentifier = 2.16.840.1.114412.2.1
@@ -336,7 +336,7 @@ basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature
 extendedKeyUsage = serverAuth
 certificatePolicies=@cps,ROLE_SAS,FRN
-TEST = critical, ASN1:NULL
+TEST = ASN1:NULL
 [ cps ]
 
 policyIdentifier = 2.16.840.1.114412.2.1
@@ -476,7 +476,7 @@ subjectKeyIdentifier = hash
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
 certificatePolicies=@cps,ROLE_CBSD
-TEST = critical, ASN1:NULL
+TEST = ASN1:NULL
 #FCCID
 #SERIAL
 
@@ -493,9 +493,18 @@ basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth
 certificatePolicies=@cps,ROLE_CBSD
-TEST = critical, ASN1:NULL
+TEST = ASN1:NULL
 #FCCID
 #SERIAL
+
+[ cbsd_req_sign_without_test_ext ]
+
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always,issuer
+basicConstraints = CA:FALSE
+keyUsage = critical, digitalSignature, keyEncipherment
+extendedKeyUsage = clientAuth
+certificatePolicies=@cps,ROLE_CBSD
 
 [ cbsd_req_inapplicable_sign ]
 
@@ -505,7 +514,7 @@ basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth
 certificatePolicies=@cps,ROLE_CBSD,ZONE
-TEST = critical, ASN1:NULL
+TEST = ASN1:NULL
 [ cps ]
 
 policyIdentifier = 2.16.840.1.114412.2.1
@@ -518,7 +527,7 @@ basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth
 certificatePolicies=@cps,ROLE_SAS
-TEST = critical, ASN1:NULL
+TEST = ASN1:NULL
 ####################################################################
  
 [ cbsd_oem_req ]
@@ -529,7 +538,7 @@ keyUsage = critical, digitalSignature, keyEncipherment
 certificatePolicies=@cps,ROLE_CBSD
 #FCCID
 #SERIAL
-TEST = critical, ASN1:NULL
+TEST = ASN1:NULL
 [ cps ]
 
 policyIdentifier = 2.16.840.1.114412.2.1
@@ -543,7 +552,7 @@ basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
 certificatePolicies=@cps,ROLE_CBSD
-TEST = critical, ASN1:NULL
+TEST = ASN1:NULL
 #FCCID
 #SERIAL
 

--- a/src/harness/certs/generate_fake_certs.sh
+++ b/src/harness/certs/generate_fake_certs.sh
@@ -360,7 +360,7 @@ openssl ca -cert non_cbrs_root_ca.cert -keyfile private/non_cbrs_root_ca.key -in
 echo "\n\nGenerate sas certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
-    -out non_cbrs_signed_sas.csr -keyout private/non_cbrs_signed_sas.key \
+    -out non_cbrs_signed_sas.csr -keyout non_cbrs_signed_sas.key \
     -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=SAS Unknown"
 openssl ca -cert non_cbrs_root_signed_sas_ca.cert -keyfile private/non_cbrs_root_signed_sas_ca.key -in non_cbrs_signed_sas.csr \
     -out non_cbrs_signed_sas.cert -outdir ./root \

--- a/src/harness/certs/generate_fake_certs.sh
+++ b/src/harness/certs/generate_fake_certs.sh
@@ -360,7 +360,7 @@ openssl ca -cert non_cbrs_root_ca.cert -keyfile private/non_cbrs_root_ca.key -in
 echo "\n\nGenerate sas certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
-    -out non_cbrs_signed_sas.csr -keyout non_cbrs_signed_sas.key \
+    -out non_cbrs_signed_sas.csr -keyout private/non_cbrs_signed_sas.key \
     -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=SAS Unknown"
 openssl ca -cert non_cbrs_root_signed_sas_ca.cert -keyfile private/non_cbrs_root_signed_sas_ca.key -in non_cbrs_signed_sas.csr \
     -out non_cbrs_signed_sas.cert -outdir ./root \

--- a/src/harness/certs/generate_fake_certs.sh
+++ b/src/harness/certs/generate_fake_certs.sh
@@ -1,8 +1,5 @@
 #!/bin/bash
 
-# Remove the unknown TEST extension to get useable certificate ...
-sed -i '/TEST = critical, ASN1:NULL/d' ../../../cert/openssl.cnf
-
 # Setup: build intermediate directories.
 mkdir private
 mkdir root
@@ -128,19 +125,19 @@ echo "\n\nGenerate 'certs for devices' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts cbsd_req -config ../../../cert/openssl.cnf \
     -out device_a.csr -keyout device_a.key \
-    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=device_a"
+    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=test_fcc_id_a:test_serial_number_a"
 openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in device_a.csr \
     -out device_a.cert -outdir ./root \
-    -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions cbsd_req_sign_without_test_ext -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts cbsd_req -config ../../../cert/openssl.cnf \
     -out device_c.csr -keyout device_c.key \
-    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=device_c"
+    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=test_fcc_id_c:test_serial_number_c"
 openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in device_c.csr \
     -out device_c.cert -outdir ./root \
-    -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions cbsd_req_sign_without_test_ext -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 echo "\n\nGenerate 'admin_client' certificate/key"


### PR DESCRIPTION
- re add the test extention to the certificates
- remove the keyword critical from the test extension
- add section in opennssl config for cbsd not test certificate
- update devices certificates with fcc ID and Cbsd serial number