### PR TITLE
SCS/SDS/SSS.16 implementation based on WG.2 confirmation -- revoked CA is sub-CA

### DIFF
--- a/cert/openssl.cnf
+++ b/cert/openssl.cnf
@@ -94,7 +94,7 @@ commonName				= supplied
 [ req ]
 default_bits			= 2048
 distinguished_name		= req_distinguished_name
-x509_extensions			= v3_ca	
+x509_extensions			= v3_ca
 string_mask 			= utf8only
 default_md				= sha384
 
@@ -136,7 +136,7 @@ URI.0 = http://localhost:9007/ca.crl
 
 ####################################################################
 #Not used yet
-[ ocsp_section ] 
+[ ocsp_section ]
 
 caIssuers;URI.0 = http://cacerts.digicert.com/WinnForumCA.crt
 OCSP;URI.0 = http://ocsp.digicert.com
@@ -312,7 +312,7 @@ certificatePolicies=@cps,ROLE_CA,ROLE_CBSD
 policyIdentifier = 2.16.840.1.114412.2.1
  CPS.1="https://www.digicert.com/CPS"
 
- 
+
 ####################################################################
 [ sas_req ]
 
@@ -326,7 +326,7 @@ crlDistributionPoints=@crl_section
 
 policyIdentifier = 2.16.840.1.114412.2.1
  CPS.1="https://www.digicert.com/CPS"
- 
+
 [ sas_req_sign ]
 
 subjectKeyIdentifier = hash
@@ -458,7 +458,7 @@ keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
 certificatePolicies=@cps,ROLE_PAL
 #ZONE = ASN1:UTF8String:
-#FREQUENCY = 
+#FREQUENCY =
 
 [ cps ]
 
@@ -474,13 +474,13 @@ keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
 certificatePolicies=@cps,ROLE_PAL
 #ZONE = ASN1:UTF8String:
-#FREQUENCY = 
+#FREQUENCY =
 
 [ cps ]
 
 policyIdentifier = 2.16.840.1.114412.2.1
  CPS.1="https://www.digicert.com/CPS"
- 
+
 ####################################################################
 [ cbsd_req ]
 
@@ -530,7 +530,7 @@ keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth
 certificatePolicies=@cps,ROLE_SAS
 ####################################################################
- 
+
 [ cbsd_oem_req ]
 
 subjectKeyIdentifier = hash
@@ -559,7 +559,7 @@ certificatePolicies=@cps,ROLE_CBSD
 
 policyIdentifier = 2.16.840.1.114412.2.1
  CPS.1="https://www.digicert.com/CPS"
- 
+
 ####################################################################
 [ crl_ext ]
 

--- a/src/harness/certs/README.md
+++ b/src/harness/certs/README.md
@@ -25,9 +25,9 @@ https://github.com/Wireless-Innovation-Forum/Spectrum-Access-System/tree/master/
                                                                              domain_proxy_inapplicable
 
                   -------------root_ca (same as above, separate graph for the clarity)--------------------
-                 /                    \         		     \
-                /                      \         		      \
-       revoked_sas_ca              revoked_cbsd_ca   		   revoked_proxy_ca
+                 /                    \                            \
+                /                      \                            \
+       revoked_sas_ca              revoked_cbsd_ca                revoked_proxy_ca
                 \                        \                                   \
                  \                        \                                   \
          sas_cert_from_revoked_ca      client_cert_from_revoked_ca          domain_proxy_cert_from_revoked_ca

--- a/src/harness/certs/README.md
+++ b/src/harness/certs/README.md
@@ -24,13 +24,13 @@ https://github.com/Wireless-Innovation-Forum/Spectrum-Access-System/tree/master/
                    sas_expired                                               domain_proxy_expired
                                                                              domain_proxy_inapplicable
 
-                  -------------root_ca --------------------------------------                
-                 /                   \         				      \ 
-                /                     \         			       \
-       blacklisted_sas_ca         blacklisted_cbsd_ca   		blacklisted_proxy_ca
+                  -------------root_ca (same as above, separate graph for the clarity)--------------------
+                 /                    \         		     \
+                /                      \         		      \
+       revoked_sas_ca              revoked_cbsd_ca   		   revoked_proxy_ca
                 \                        \                                   \
                  \                        \                                   \
-            sas_revoked_by_ca         client_revoked_by_ca              domain_proxy_revoked_by_ca
+         sas_cert_from_revoked_ca      client_cert_from_revoked_ca          domain_proxy_cert_from_revoked_ca
  
 unrecognized_ca             non_cbrs_root_ca----------------------------------------------
          |                     |                                 \	                  \
@@ -78,13 +78,13 @@ Required certificates are:
   used to verify the server chain and the client chain. Basically the
   concatenation of all intermediate certificate CA and root CA.
 
-* `blacklisted_sas_ca.cert`: intermediate SAS certificate authority signed by `root_ca` and status is
+* `revoked_sas_ca.cert`: intermediate SAS certificate authority signed by the same `root_ca` and status is
 revoked. Used on security test test_WINNF_FT_S_SSS_16.
 
-* `blacklisted_cbsd_ca.cert`: intermediate CBSD certificate authority signed by `root_ca` and status is
+* `revoked_cbsd_ca.cert`: intermediate CBSD certificate authority signed by the same `root_ca` and status is
 revoked. Used on security test test_WINNF_FT_S_SCS_16.
 
-* `blacklisted_proxy_ca.cert`: intermediate Domain Proxy certificate authority signed by `root_ca` and status is
+* `revoked_proxy_ca.cert`: intermediate Domain Proxy certificate authority signed by the same `root_ca` and status is
 revoked. Used on security test test_WINNF_FT_S_SDS_16.
 
 * `unrecognized_root_ca.cert`: root certificate authority to generate unrecognized device
@@ -125,8 +125,8 @@ revoked. Used on security test test_WINNF_FT_S_SDS_16.
 * `client_inapplicable.[cert|key]`: leaf CBSD device inapplicable fields certificate
   Used on security test test_WINNF_FT_S_SCS_15.
 
-* `client_revoked_by_ca.[cert|key]`: leaf CBSD device certificate signed by revoked intermediate CA 
-  `blacklisted_cbsd_ca` and corresponding trusted client certificate bundle.
+* `client_cert_from_revoked_ca.[cert|key]`: leaf CBSD device certificate signed by revoked intermediate CA 
+  `revoked_cbsd_ca` and corresponding trusted client certificate bundle.
    Used on security test test_WINNF_FT_S_SCS_16.
 
 * `corrupted_domain_proxy.cert`: corrupted 'domain_proxy.cert' certificate where the 20th character have been changed.
@@ -141,8 +141,8 @@ revoked. Used on security test test_WINNF_FT_S_SDS_16.
 * `domain_proxy_inapplicable.[cert|key]`: domain_proxy device inapplicable fields certificate
   Used on security test test_WINNF_FT_S_SDS_15.
   
-* `domain_proxy_revoked_by_ca.[cert|key]`: domain proxy certificate signed by revoked intermediate CA 
-  `blacklisted_proxy_ca` and corresponding trusted client certificate bundle.
+* `domain_proxy_cert_from_revoked_ca.[cert|key]`: domain proxy certificate signed by revoked intermediate CA 
+  `revoked_proxy_ca` and corresponding trusted client certificate bundle.
    Used on security test test_WINNF_FT_S_SDS_16.
 
 * `unrecognized_sas.[cert|key]`: leaf SAS certificate signed by
@@ -166,6 +166,6 @@ revoked. Used on security test test_WINNF_FT_S_SDS_16.
 * `sas_expired.[cert|key]`: leaf SAS expired certificate
   Used on security test test_WINNF_FT_S_SSS_12.
 
-* `sas_revoked_by_ca.[cert|key]`: leaf SAS certificate signed by revoked intermediate CA 
-  `blacklisted_sas_ca` and corresponding trusted client certificate bundle.
+* `sas_cert_from_revoked_ca.[cert|key]`: leaf SAS certificate signed by revoked intermediate CA 
+  `revoked_sas_ca` and corresponding trusted client certificate bundle.
    Used on security test test_WINNF_FT_S_SSS_16.

--- a/src/harness/certs/README.md
+++ b/src/harness/certs/README.md
@@ -24,6 +24,13 @@ https://github.com/Wireless-Innovation-Forum/Spectrum-Access-System/tree/master/
                    sas_expired                                               domain_proxy_expired
                                                                              domain_proxy_inapplicable
 
+                  -------------root_ca --------------------------------------                
+                 /                   \         				      \ 
+                /                     \         			       \
+       blacklisted_sas_ca         blacklisted_cbsd_ca   		blacklisted_proxy_ca
+                \                        \                                   \
+                 \                        \                                   \
+            sas_revoked_by_ca         client_revoked_by_ca              domain_proxy_revoked_by_ca
  
 unrecognized_ca             non_cbrs_root_ca----------------------------------------------
          |                     |                                 \	                  \
@@ -71,6 +78,15 @@ Required certificates are:
   used to verify the server chain and the client chain. Basically the
   concatenation of all intermediate certificate CA and root CA.
 
+* `blacklisted_sas_ca.cert`: intermediate SAS certificate authority signed by `root_ca` and status is
+revoked. Used on security test test_WINNF_FT_S_SSS_16.
+
+* `blacklisted_cbsd_ca.cert`: intermediate CBSD certificate authority signed by `root_ca` and status is
+revoked. Used on security test test_WINNF_FT_S_SCS_16.
+
+* `blacklisted_proxy_ca.cert`: intermediate Domain Proxy certificate authority signed by `root_ca` and status is
+revoked. Used on security test test_WINNF_FT_S_SDS_16.
+
 * `unrecognized_root_ca.cert`: root certificate authority to generate unrecognized device
   Self signed.
   
@@ -109,6 +125,10 @@ Required certificates are:
 * `client_inapplicable.[cert|key]`: leaf CBSD device inapplicable fields certificate
   Used on security test test_WINNF_FT_S_SCS_15.
 
+* `client_revoked_by_ca.[cert|key]`: leaf CBSD device certificate signed by revoked intermediate CA 
+  `blacklisted_cbsd_ca` and corresponding trusted client certificate bundle.
+   Used on security test test_WINNF_FT_S_SCS_16.
+
 * `corrupted_domain_proxy.cert`: corrupted 'domain_proxy.cert' certificate where the 20th character have been changed.
   Used on security test test_WINNF_FT_S_SDS_7.
 
@@ -120,6 +140,10 @@ Required certificates are:
 
 * `domain_proxy_inapplicable.[cert|key]`: domain_proxy device inapplicable fields certificate
   Used on security test test_WINNF_FT_S_SDS_15.
+  
+* `domain_proxy_revoked_by_ca.[cert|key]`: domain proxy certificate signed by revoked intermediate CA 
+  `blacklisted_proxy_ca` and corresponding trusted client certificate bundle.
+   Used on security test test_WINNF_FT_S_SDS_16.
 
 * `unrecognized_sas.[cert|key]`: leaf SAS certificate signed by
   `unrecognized_root_ca`, and corresponding trusted client certificates bundle.
@@ -142,3 +166,6 @@ Required certificates are:
 * `sas_expired.[cert|key]`: leaf SAS expired certificate
   Used on security test test_WINNF_FT_S_SSS_12.
 
+* `sas_revoked_by_ca.[cert|key]`: leaf SAS certificate signed by revoked intermediate CA 
+  `blacklisted_sas_ca` and corresponding trusted client certificate bundle.
+   Used on security test test_WINNF_FT_S_SSS_16.

--- a/src/harness/certs/generate_fake_certs.sh
+++ b/src/harness/certs/generate_fake_certs.sh
@@ -7,8 +7,11 @@ sed -i '/TEST = critical, ASN1:NULL/d' ../../../cert/openssl.cnf
 rm -rf crl/
 mkdir private
 mkdir root
-touch index.txt
-echo -n 'unique_subject = no' >> index.txt.attr
+mkdir crl
+
+# Empty the index.txt to avoid to old certificates index.
+cat /dev/null > index.txt
+echo -n 'unique_subject = no' > index.txt.attr
 
 function gen_corrupt_cert()
 {
@@ -31,7 +34,7 @@ fi
 printf "%x: %02x" $pos $corrupted_dec_byte | xxd -r - $4
 }
 # Generate root and intermediate CA certificate/key.
-echo "\n\nGenerate 'root_ca' and 'root-ecc_ca' certificate/key"
+echo -e "\n\nGenerate 'root_ca' and 'root-ecc_ca' certificate/key"
 openssl req -new -x509 -newkey rsa:4096 -sha384 -nodes -days 7300 \
     -extensions root_ca -config ../../../cert/openssl.cnf \
     -out root_ca.cert -keyout private/root_ca.key \
@@ -42,7 +45,7 @@ openssl req -new -x509 -key private/root-ecc_ca.key -out root-ecc_ca.cert \
     -sha384 -nodes -days 7300 -extensions root_ca -config ../../../cert/openssl.cnf \
     -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=WInnForum ECC Root CA-1"
 
-echo "\n\nGenerate 'sas_ca' and 'sas-ecc_ca' certificate/key"
+echo -e "\n\nGenerate 'sas_ca' and 'sas-ecc_ca' certificate/key"
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts sas_ca  -config ../../../cert/openssl.cnf \
     -out sas_ca.csr -keyout private/sas_ca.key \
@@ -62,7 +65,7 @@ openssl ca -cert root-ecc_ca.cert -keyfile private/root-ecc_ca.key -in sas-ecc_c
     -out sas-ecc_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
-echo "\n\nGenerate 'cbsd_ca' certificate/key"
+echo -e "\n\nGenerate 'cbsd_ca' certificate/key"
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts cbsd_ca  -config ../../../cert/openssl.cnf \
     -out cbsd_ca.csr -keyout private/cbsd_ca.key \
@@ -83,7 +86,7 @@ openssl ca -cert root-ecc_ca.cert -keyfile private/root-ecc_ca.key -in cbsd-ecc_
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
 # Generate fake server certificate/key.
-echo "\n\nGenerate 'server' certificate/key"
+echo -e "\n\nGenerate 'server' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out server.csr -keyout server.key \
@@ -104,7 +107,7 @@ openssl ca -cert sas-ecc_ca.cert -keyfile private/sas-ecc_ca.key -in server-ecc.
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Generate sas server certificate/key.
-echo "\n\nGenerate 'sas server' certificate/key"
+echo -e "\n\nGenerate 'sas server' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
     -out sas.csr -keyout sas.key \
@@ -115,7 +118,7 @@ openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas.csr \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Generate normal operation client certificate/key.
-echo "\n\nGenerate 'client' certificate/key"
+echo -e "\n\nGenerate 'client' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts cbsd_req -config ../../../cert/openssl.cnf \
     -out client.csr -keyout client.key \
@@ -125,7 +128,7 @@ openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in client.csr \
     -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-echo "\n\nGenerate 'certs for devices' certificate/key"
+echo -e "\n\nGenerate 'certs for devices' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts cbsd_req -config ../../../cert/openssl.cnf \
     -out device_a.csr -keyout device_a.key \
@@ -144,7 +147,7 @@ openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in device_c.csr \
     -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-echo "\n\nGenerate 'admin_client' certificate/key"
+echo -e "\n\nGenerate 'admin_client' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts cbsd_req -config ../../../cert/openssl.cnf \
     -out admin_client.csr -keyout admin_client.key \
@@ -155,7 +158,7 @@ openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in admin_client.csr \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Generate Domain Proxy certificate/key.
-echo "\n\nGenerate 'proxy_ca' certificate/key"
+echo -e "\n\nGenerate 'proxy_ca' certificate/key"
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts oper_ca  -config ../../../cert/openssl.cnf \
     -out proxy_ca.csr -keyout private/proxy_ca.key \
@@ -164,7 +167,7 @@ openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in proxy_ca.csr \
     -policy policy_anything -extensions oper_ca_sign -config ../../../cert/openssl.cnf \
     -out proxy_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
-echo "\n\nGenerate 'domain_proxy' certificate/key"
+echo -e "\n\nGenerate 'domain_proxy' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts oper_req -config ../../../cert/openssl.cnf \
     -out domain_proxy.csr -keyout domain_proxy.key \
@@ -175,7 +178,7 @@ openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key -in domain_proxy.cs
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Generate certificates for test case WINNF.FT.S.SCS.6 - Unrecognized root of trust certificate presented during registration
-echo "\n\nGenerate 'unrecognized_device' certificate/key"
+echo -e "\n\nGenerate 'unrecognized_device' certificate/key"
 openssl req -new -x509 -newkey rsa:4096 -sha384 -nodes -days 7300 \
     -extensions root_ca -config ../../../cert/openssl.cnf \
     -out unrecognized_root_ca.cert -keyout private/unrecognized_root_ca.key \
@@ -191,12 +194,12 @@ openssl ca -cert unrecognized_root_ca.cert -keyfile private/unrecognized_root_ca
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Certificates for test case WINNF.FT.S.SCS.7 - corrupted certificate, based on client.cert
-echo "\n\nGenerate 'corrupted_client' certificate/key"
+echo -e "\n\nGenerate 'corrupted_client' certificate/key"
 gen_corrupt_cert client.key client.cert corrupted_client.key corrupted_client.cert
 
 #Certificate for test case WINNF.FT.S.SCS.8 - Self-signed certificate presented during registration
 #Using the same CSR that was created for normal operation
-echo "\n\nGenerate 'self_signed_client' certificate/key"
+echo -e "\n\nGenerate 'self_signed_client' certificate/key"
 openssl x509 -signkey client.key -in client.csr \
     -out self_signed_client.cert \
     -req -days 1185
@@ -207,7 +210,7 @@ openssl req -new -x509 -newkey rsa:4096 -sha384 -nodes -days 7300 \
     -out non_cbrs_root_ca.cert -keyout private/non_cbrs_root_ca.key \
     -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=WInnForum RSA Root CA-2"
 
-echo "\n\nGenerate 'non_cbrs_signed_cbsd_ca' certificate/key"
+echo -e "\n\nGenerate 'non_cbrs_signed_cbsd_ca' certificate/key"
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts cbsd_ca  -config ../../../cert/openssl.cnf \
     -out non_cbrs_root_signed_cbsd_ca.csr -keyout private/non_cbrs_root_signed_cbsd_ca.key \
@@ -229,14 +232,14 @@ openssl ca -cert non_cbrs_root_signed_cbsd_ca.cert -keyfile private/non_cbrs_roo
 
 #Certificate for test case WINNF.FT.S.SCS.10 - Certificate of wrong type presented during registration
 # Creating a wrong type certificate by reusing the server.csr and creating a server certificate.
-echo "\n\nGenerate wrong type certificate/key"
+echo -e "\n\nGenerate wrong type certificate/key"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in server.csr \
     -out wrong_type_client.cert -outdir ./root \
     -policy policy_anything -extensions sas_client_mode_req_sign   -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 #Certificate for test case WINNF.FT.S.SCS.12 - Expired certificate presented during registration
-echo "\n\nGenerate 'client_expired' certificate/key"
+echo -e "\n\nGenerate 'client_expired' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts cbsd_req -config ../../../cert/openssl.cnf \
     -out client_expired.csr -keyout client_expired.key \
@@ -247,14 +250,14 @@ openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in client_expired.cs
     -batch -notext -create_serial -utf8 -startdate 20150214120000Z -enddate 20160214120000Z -md sha384
 
 #Certificate for test case WINNF.FT.S.SCS.15 - Certificate with inapplicable fields presented during registration
-echo "\n\nGenerate 'inapplicable certificate for WINNF.FT.S.SCS.15' certificate/key"
+echo -e "\n\nGenerate 'inapplicable certificate for WINNF.FT.S.SCS.15' certificate/key"
 openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in client.csr \
     -out client_inapplicable.cert -outdir ./root \
     -policy policy_anything -extensions cbsd_req_inapplicable_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Generate certificates for test case WINNF.FT.S.SDS.6 - Unrecognized root of trust certificate presented during registration
-echo "\n\nGenerate 'unrecognized_domain_proxy' certificate/key"
+echo -e "\n\nGenerate 'unrecognized_domain_proxy' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts oper_req -config ../../../cert/openssl.cnf \
     -out unrecognized_domain_proxy.csr -keyout unrecognized_domain_proxy.key \
@@ -265,18 +268,18 @@ openssl ca -cert unrecognized_root_ca.cert -keyfile private/unrecognized_root_ca
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Certificates for test case WINN.FT.S.SDS.7 - corrupted certificate, based on domain_proxy.cert
-echo "\n\nGenerate 'corrupted_domain_proxy' certificate/key"
+echo -e "\n\nGenerate 'corrupted_domain_proxy' certificate/key"
 gen_corrupt_cert domain_proxy.key domain_proxy.cert corrupted_domain_proxy.key corrupted_domain_proxy.cert
 
 #Certificate for test case WINNF.FT.S.SDS.8 - Self-signed certificate presented during registration
 #Using the same CSR that was created for normal operation
-echo "\n\nGenerate 'self_signed_domain_proxy' certificate/key"
+echo -e "\n\nGenerate 'self_signed_domain_proxy' certificate/key"
 openssl x509 -signkey domain_proxy.key -in domain_proxy.csr \
     -out self_signed_domain_proxy.cert \
     -req -days 1185
 
 #Certificate for test case WINNF.FT.S.SDS.9 - Non-CBRS trust root signed certificate presented during registration
-echo "\n\nGenerate non_cbrs_root_signed_oper_ca.csr certificate/key"
+echo -e "\n\nGenerate non_cbrs_root_signed_oper_ca.csr certificate/key"
 
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts oper_ca -config ../../../cert/openssl.cnf \
@@ -289,7 +292,7 @@ openssl ca -cert non_cbrs_root_ca.cert -keyfile private/non_cbrs_root_ca.key -in
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
 #Generate a Domain Proxy certifcate signed by an intermediate Domain Proxy CA which is signed by a non-CBRS root CA
-echo "\n\nGenerate domain_proxy certificate/key"
+echo -e "\n\nGenerate domain_proxy certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts oper_req -config ../../../cert/openssl.cnf \
     -out non_cbrs_signed_domain_proxy.csr -keyout non_cbrs_signed_domain_proxy.key \
@@ -301,14 +304,14 @@ openssl ca -cert non_cbrs_root_signed_oper_ca.cert -keyfile private/non_cbrs_roo
 
 # Certificate for test case WINNF.FT.S.SDS.10 - Certificate of wrong type presented during registration
 # Creating a wrong type certificate by reusing the server.csr and creating a server certificate.
-echo "\n\nGenerate wrong type certificate/key"
+echo -e "\n\nGenerate wrong type certificate/key"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in server.csr \
     -out wrong_type_domain_proxy.cert -outdir ./root \
     -policy policy_anything -extensions sas_client_mode_req_sign   -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 #Certificate for test case WINNF.FT.S.SDS.12 - Expired certificate presented during registration
-echo "\n\nGenerate 'domain_proxy_expired' certificate/key"
+echo -e "\n\nGenerate 'domain_proxy_expired' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts oper_req -config ../../../cert/openssl.cnf \
     -out domain_proxy_expired.csr -keyout domain_proxy_expired.key \
@@ -319,14 +322,14 @@ openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key -in domain_proxy_ex
     -batch -notext -create_serial -utf8 -startdate 20150214120000Z -enddate 20160214120000Z -md sha384
 
 #Certificate for test case WINNF.FT.S.SDS.15 -Certificate with inapplicable fields presented during registration
-echo "\n\nGenerate 'inapplicable certificate for WINNF.FT.S.SDS.15' certificate"
+echo -e "\n\nGenerate 'inapplicable certificate for WINNF.FT.S.SDS.15' certificate"
 openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key -in domain_proxy.csr \
     -out domain_proxy_inapplicable.cert -outdir ./root \
     -policy policy_anything -extensions oper_req_inapplicable_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Generate certificates for test case WINNF.FT.S.SSS.6 - Unrecognized root of trust certificate presented during registration
-echo "\n\nGenerate 'unrecognized_sas' certificate/key"
+echo -e "\n\nGenerate 'unrecognized_sas' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
     -out unrecognized_sas.csr -keyout unrecognized_sas.key \
@@ -337,18 +340,18 @@ openssl ca -cert unrecognized_root_ca.cert -keyfile private/unrecognized_root_ca
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Certificates for test case WINN.FT.S.SSS.7 - corrupted certificate, based on sas.cert
-echo "\n\nGenerate 'corrupted_sas' certificate/key"
+echo -e "\n\nGenerate 'corrupted_sas' certificate/key"
 gen_corrupt_cert sas.key sas.cert corrupted_sas.key corrupted_sas.cert
 
 #Certificate for test case WINNF.FT.S.SSS.8 - Self-signed certificate presented during registration
 #Using the same CSR that was created for normal operation
-echo "\n\nGenerate 'self_signed_sas' certificate/key"
+echo -e "\n\nGenerate 'self_signed_sas' certificate/key"
 openssl x509 -signkey sas.key -in sas.csr \
     -out self_signed_sas.cert \
     -req -days 1185
 
 #Certificate for test case WINNF.FT.S.SSS.9 - Non-CBRS trust root signed certificate presented during registration
-echo "\n\nGenerate non_cbrs_root_signed_sas_ca.csr certificate/key"
+echo -e "\n\nGenerate non_cbrs_root_signed_sas_ca.csr certificate/key"
 
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts sas_ca -config ../../../cert/openssl.cnf \
@@ -361,7 +364,7 @@ openssl ca -cert non_cbrs_root_ca.cert -keyfile private/non_cbrs_root_ca.key -in
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
 #Generate a SAS certifcate signed by an intermediate SAS CA which is signed by a non-CBRS root CA
-echo "\n\nGenerate sas certificate/key"
+echo -e "\n\nGenerate sas certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
     -out non_cbrs_signed_sas.csr -keyout non_cbrs_signed_sas.key \
@@ -373,14 +376,14 @@ openssl ca -cert non_cbrs_root_signed_sas_ca.cert -keyfile private/non_cbrs_root
 
 # Certificate for test case WINNF.FT.S.SSS.10 - Certificate of wrong type presented by SAS Test Harness 
 # Creating a wrong type certificate by reusing the client.csr and creating a client certificate.
-echo "\n\nGenerate wrong type certificate/key"
+echo -e "\n\nGenerate wrong type certificate/key"
 openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in client.csr \
     -out wrong_type_sas.cert -outdir ./root \
     -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 #Certificate for test case WINNF.FT.S.SSS.12 - Expired certificate presented by SAS Test Harness 
-echo "\n\nGenerate 'sas_expired' certificate/key"
+echo -e "\n\nGenerate 'sas_expired' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
     -out sas_expired.csr -keyout sas_expired.key \
@@ -391,54 +394,121 @@ openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas_expired.csr \
     -batch -notext -create_serial -utf8 -startdate 20150214120000Z -enddate 20160214120000Z -md sha384
 
 #Certificate for test case WINNF.FT.S.SSS.15 -Certificate with inapplicable fields presented by SAS Test Harness 
-echo "\n\nGenerate 'inapplicable certificate for WINNF.FT.S.SSS.15' certificate"
+echo -e "\n\nGenerate 'inapplicable certificate for WINNF.FT.S.SSS.15' certificate"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas.csr \
     -out sas_inapplicable.cert -outdir ./root \
     -policy policy_anything -extensions sas_req_inapplicable_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-#Certificate for test case WINNF.FT.S.SCS.16 - Certificate signed by a revoked CA presented during registration
-#Revoke the CBSD CA Certificate
-openssl ca -revoke cbsd_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
+# Certificate for test case WINNF.FT.S.SCS.16 - Certificate signed by a revoked CA presented during registration
+echo -e "\n\nGenerate 'blacklisted_cbsd_ca' certificate/key to revoke intermediate CA"
+openssl req -new -newkey rsa:4096 -nodes \
+    -reqexts cbsd_ca  -config ../../../cert/openssl.cnf \
+    -out blacklisted_cbsd_ca.csr -keyout private/blacklisted_cbsd_ca.key \
+    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=WInnForum CBSD CA-1 - Blacklisted"
+openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in blacklisted_cbsd_ca.csr \
+    -policy policy_anything -extensions cbsd_ca_sign -config ../../../cert/openssl.cnf \
+    -out blacklisted_cbsd_ca.cert -outdir ./root \
+    -batch -notext -create_serial -utf8 -days 5475 -md sha384
+
+# Generate client certificate/key signed by valid CA.
+echo -e "\n\nGenerate 'client' certificate/key signed by blacklisted_cbsd_ca"
+openssl req -new -newkey rsa:2048 -nodes \
+    -reqexts cbsd_req -config ../../../cert/openssl.cnf \
+    -out client_revoked_by_ca.csr -keyout client_revoked_by_ca.key \
+    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=SAS CBSD - Blacklisted"
+openssl ca -cert blacklisted_cbsd_ca.cert -keyfile private/blacklisted_cbsd_ca.key -in client_revoked_by_ca.csr \
+    -out client_revoked_by_ca.cert -outdir ./root \
+    -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
+    -batch -notext -create_serial -utf8 -days 1185 -md sha384
+
+# Revoke the CBSD CA Certificate.
+echo -e "\n\nRevoke intermediate CA (blacklisted_cbsd_ca) who already signed client certificate."
+openssl ca -revoke blacklisted_cbsd_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
      -config ../../../cert/openssl.cnf
 
-#Certificate for test case WINNF.FT.S.SDS.16 - Certificate signed by a revoked CA presented during registration
-#Revoke the Domain Proxy CA Certificate
-openssl ca -revoke proxy_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
-     -config ../../../cert/openssl.cnf
+# Certificate for test case WINNF.FT.S.SDS.16 - Certificate signed by a revoked CA presented during registration.
+echo -e "\n\nGenerate 'blacklisted_proxy_ca' certificate/key to revoke intermediate CA."
+openssl req -new -newkey rsa:4096 -nodes \
+    -reqexts oper_ca  -config ../../../cert/openssl.cnf \
+    -out blacklisted_proxy_ca.csr -keyout private/blacklisted_proxy_ca.key \
+    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=WInnForum RSA Domain Proxy CA - Blacklisted"
+openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in blacklisted_proxy_ca.csr \
+    -policy policy_anything -extensions oper_ca_sign -config ../../../cert/openssl.cnf \
+    -out blacklisted_proxy_ca.cert -outdir ./root \
+    -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
-#Certificate for test case WINNF.FT.S.SSS.16 - Certificate signed by a revoked CA presented during registration
-#Revoke the SAS CA Certificate
-openssl ca -revoke sas_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
-     -config ../../../cert/openssl.cnf
+echo -e "\n\nGenerate 'domain_proxy' certificate/key signed by blacklisted_proxy_ca"
+openssl req -new -newkey rsa:2048 -nodes \
+    -reqexts oper_req -config ../../../cert/openssl.cnf \
+    -out domain_proxy_revoked_by_ca.csr -keyout domain_proxy_revoked_by_ca.key \
+    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=domainProxy_a - Blacklisted"
+openssl ca -cert blacklisted_proxy_ca.cert -keyfile private/blacklisted_proxy_ca.key -in domain_proxy_revoked_by_ca.csr \
+    -out domain_proxy_revoked_by_ca.cert -outdir ./root \
+    -policy policy_anything -extensions oper_req_sign -config ../../../cert/openssl.cnf \
+    -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-#Creating CRL for revoked CA xxS.16 test cases
-echo "\n\n Generate CRL for root_ca"
+# Revoke the Domain Proxy CA Certificate.
+echo -e "\n\nRevoke intermediate CA (blacklisted_proxy_ca) who already signed domain proxy certificate."
+openssl ca -revoke blacklisted_proxy_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
+    -config ../../../cert/openssl.cnf
+
+# Certificate for test case WINNF.FT.S.SSS.16 - Certificate signed by a revoked CA presented during registration
+echo -e "\n\nGenerate 'sas_ca' certificate/key to revoke intermediate CA."
+openssl req -new -newkey rsa:4096 -nodes \
+    -reqexts sas_ca  -config ../../../cert/openssl.cnf \
+    -out blacklisted_sas_ca.csr -keyout private/blacklisted_sas_ca.key \
+    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=WInnForum RSA SAS CA-1 - Blacklisted"
+openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in blacklisted_sas_ca.csr \
+    -policy policy_anything -extensions sas_ca_sign -config ../../../cert/openssl.cnf \
+    -out blacklisted_sas_ca.cert -outdir ./root \
+    -batch -notext -create_serial -utf8 -days 5475 -md sha384
+
+# Generate sas server certificate/key.
+echo -e "\n\nGenerate 'sas server' certificate/key signed by blacklisted_sas_ca"
+openssl req -new -newkey rsa:2048 -nodes \
+    -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
+    -out sas_revoked_by_ca.csr -keyout sas_revoked_by_ca.key \
+    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=SAS - Blacklisted"
+openssl ca -cert blacklisted_sas_ca.cert -keyfile private/blacklisted_sas_ca.key -in sas_revoked_by_ca.csr \
+    -out sas_revoked_by_ca.cert -outdir ./root \
+    -policy policy_anything -extensions sas_client_mode_req_sign -config ../../../cert/openssl.cnf \
+    -batch -notext -create_serial -utf8 -days 1185 -md sha384
+
+# Revoke the SAS CA Certificate.
+openssl ca -revoke blacklisted_sas_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
+    -config ../../../cert/openssl.cnf
+
+# Creating CRL for revoked CA xxS.16 test cases
+echo -e "\n\n Generate CRL for root_ca"
 openssl ca -gencrl -keyfile private/root_ca.key -cert root_ca.cert \
-     -config ../../../cert/openssl.cnf  -crlhours 1\
-     -out root/root_ca.crl
+     -config ../../../cert/openssl.cnf  -crldays 365 \
+     -out crl/root_ca.crl
 
-echo "\n\n Generate CRL for sas_ca"
-openssl ca -gencrl -keyfile private/sas_ca.key -cert sas_ca.cert \
-     -config ../../../cert/openssl.cnf -crlhours 1 \
-     -out root/sas_ca.crl
+echo -e "\n\n Generate CRL for blacklisted_cbsd_ca"
+openssl ca -gencrl -keyfile private/blacklisted_cbsd_ca.key -cert blacklisted_cbsd_ca.cert \
+     -config ../../../cert/openssl.cnf -crldays 365 \
+     -out crl/blacklisted_cbsd_ca.crl
 
-echo "\n\n Generate CRL for proxy_ca"
-openssl ca -gencrl -keyfile private/proxy_ca.key -cert proxy_ca.cert \
-     -config ../../../cert/openssl.cnf -crlhours 1 \
-     -out root/proxy_ca.crl
+echo -e "\n\n Generate CRL for blacklisted_sas_ca"
+openssl ca -gencrl -keyfile private/blacklisted_sas_ca.key -cert blacklisted_sas_ca.cert \
+     -config ../../../cert/openssl.cnf -crldays 365 \
+     -out crl/blacklisted_sas_ca.crl
 
-echo "\n\n Generate CRL for cbsd_ca"
-openssl ca -gencrl -keyfile private/cbsd_ca.key -cert cbsd_ca.cert \
-     -config ../../../cert/openssl.cnf -crlhours 1 \
-     -out root/cbsd_ca.crl
-
-#Create CA certificate chain containing the CRLs with revoked certificates
-cat root/cbsd_ca.crl root/sas_ca.crl root/proxy_ca.crl root/root_ca.crl > ca_intermediate.crl
+echo -e "\n\n Generate CRL for blacklisted_proxy_ca"
+openssl ca -gencrl -keyfile private/blacklisted_proxy_ca.key -cert blacklisted_proxy_ca.cert \
+     -config ../../../cert/openssl.cnf -crldays 365 \
+     -out crl/blacklisted_proxy_ca.crl
 
 # Generate trusted CA bundle.
-echo "\n\nGenerate 'ca' bundle"
-cat cbsd_ca.cert proxy_ca.cert sas_ca.cert root_ca.cert cbsd-ecc_ca.cert sas-ecc_ca.cert root-ecc_ca.cert > ca.cert
+echo -e "\n\nGenerate 'ca' bundle"
+cat cbsd_ca.cert proxy_ca.cert sas_ca.cert root_ca.cert cbsd-ecc_ca.cert sas-ecc_ca.cert root-ecc_ca.cert \
+    blacklisted_cbsd_ca.cert blacklisted_sas_ca.cert blacklisted_proxy_ca.cert > ca.cert
+
+# Create CA certificate chain containing the CRLs with revoked leaf certificates.
+cat crl/blacklisted_cbsd_ca.crl crl/blacklisted_sas_ca.crl crl/blacklisted_proxy_ca.crl crl/root_ca.crl > crl/ca.crl
+cat ca.cert crl/ca.crl > ca_crl_chain_sxs16.cert
+
 # Note: following server implementation, we could also put only the root_ca.cert
 # on ca.cert, then append the intermediate on each leaf certificate:
 #   cat root_ca.cert > ca.cert

--- a/src/harness/certs/generate_fake_certs.sh
+++ b/src/harness/certs/generate_fake_certs.sh
@@ -9,8 +9,9 @@ mkdir private
 mkdir root
 mkdir crl
 
-# Empty the index.txt to avoid to old certificates index.
-cat /dev/null > index.txt
+# Empty the index.txt to avoid to old certificates index
+rm index.txt
+touch index.txt
 echo -n 'unique_subject = no' > index.txt.attr
 
 function gen_corrupt_cert()
@@ -401,82 +402,82 @@ openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas.csr \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Certificate for test case WINNF.FT.S.SCS.16 - Certificate signed by a revoked CA presented during registration
-echo -e "\n\nGenerate 'blacklisted_cbsd_ca' certificate/key to revoke intermediate CA"
+echo -e "\n\nGenerate 'revoked_cbsd_ca' certificate/key to revoke intermediate CA"
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts cbsd_ca  -config ../../../cert/openssl.cnf \
-    -out blacklisted_cbsd_ca.csr -keyout private/blacklisted_cbsd_ca.key \
-    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=WInnForum CBSD CA-1 - Blacklisted"
-openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in blacklisted_cbsd_ca.csr \
+    -out revoked_cbsd_ca.csr -keyout private/revoked_cbsd_ca.key \
+    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=WInnForum CBSD CA-1 - Revoked"
+openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in revoked_cbsd_ca.csr \
     -policy policy_anything -extensions cbsd_ca_sign -config ../../../cert/openssl.cnf \
-    -out blacklisted_cbsd_ca.cert -outdir ./root \
+    -out revoked_cbsd_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
 # Generate client certificate/key signed by valid CA.
-echo -e "\n\nGenerate 'client' certificate/key signed by blacklisted_cbsd_ca"
+echo -e "\n\nGenerate 'client' certificate/key signed by revoked_cbsd_ca"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts cbsd_req -config ../../../cert/openssl.cnf \
-    -out client_revoked_by_ca.csr -keyout client_revoked_by_ca.key \
-    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=SAS CBSD - Blacklisted"
-openssl ca -cert blacklisted_cbsd_ca.cert -keyfile private/blacklisted_cbsd_ca.key -in client_revoked_by_ca.csr \
-    -out client_revoked_by_ca.cert -outdir ./root \
+    -out client_cert_from_revoked_ca.csr -keyout client_cert_from_revoked_ca.key \
+    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=SAS CBSD - Revoked"
+openssl ca -cert revoked_cbsd_ca.cert -keyfile private/revoked_cbsd_ca.key -in client_cert_from_revoked_ca.csr \
+    -out client_cert_from_revoked_ca.cert -outdir ./root \
     -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Revoke the CBSD CA Certificate.
-echo -e "\n\nRevoke intermediate CA (blacklisted_cbsd_ca) who already signed client certificate."
-openssl ca -revoke blacklisted_cbsd_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
+echo -e "\n\nRevoke intermediate CA (revoked_cbsd_ca) who already signed client certificate."
+openssl ca -revoke revoked_cbsd_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
      -config ../../../cert/openssl.cnf
 
 # Certificate for test case WINNF.FT.S.SDS.16 - Certificate signed by a revoked CA presented during registration.
-echo -e "\n\nGenerate 'blacklisted_proxy_ca' certificate/key to revoke intermediate CA."
+echo -e "\n\nGenerate 'revoked_proxy_ca' certificate/key to revoke intermediate CA."
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts oper_ca  -config ../../../cert/openssl.cnf \
-    -out blacklisted_proxy_ca.csr -keyout private/blacklisted_proxy_ca.key \
-    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=WInnForum RSA Domain Proxy CA - Blacklisted"
-openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in blacklisted_proxy_ca.csr \
+    -out revoked_proxy_ca.csr -keyout private/revoked_proxy_ca.key \
+    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=WInnForum RSA Domain Proxy CA - Revoked"
+openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in revoked_proxy_ca.csr \
     -policy policy_anything -extensions oper_ca_sign -config ../../../cert/openssl.cnf \
-    -out blacklisted_proxy_ca.cert -outdir ./root \
+    -out revoked_proxy_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
-echo -e "\n\nGenerate 'domain_proxy' certificate/key signed by blacklisted_proxy_ca"
+echo -e "\n\nGenerate 'domain_proxy' certificate/key signed by revoked_proxy_ca"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts oper_req -config ../../../cert/openssl.cnf \
-    -out domain_proxy_revoked_by_ca.csr -keyout domain_proxy_revoked_by_ca.key \
-    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=domainProxy_a - Blacklisted"
-openssl ca -cert blacklisted_proxy_ca.cert -keyfile private/blacklisted_proxy_ca.key -in domain_proxy_revoked_by_ca.csr \
-    -out domain_proxy_revoked_by_ca.cert -outdir ./root \
+    -out domain_proxy_cert_from_revoked_ca.csr -keyout domain_proxy_cert_from_revoked_ca.key \
+    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=domainProxy_a - Revoked"
+openssl ca -cert revoked_proxy_ca.cert -keyfile private/revoked_proxy_ca.key -in domain_proxy_cert_from_revoked_ca.csr \
+    -out domain_proxy_cert_from_revoked_ca.cert -outdir ./root \
     -policy policy_anything -extensions oper_req_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Revoke the Domain Proxy CA Certificate.
-echo -e "\n\nRevoke intermediate CA (blacklisted_proxy_ca) who already signed domain proxy certificate."
-openssl ca -revoke blacklisted_proxy_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
+echo -e "\n\nRevoke intermediate CA (revoked_proxy_ca) who already signed domain proxy certificate."
+openssl ca -revoke revoked_proxy_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
     -config ../../../cert/openssl.cnf
 
 # Certificate for test case WINNF.FT.S.SSS.16 - Certificate signed by a revoked CA presented during registration
 echo -e "\n\nGenerate 'sas_ca' certificate/key to revoke intermediate CA."
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts sas_ca  -config ../../../cert/openssl.cnf \
-    -out blacklisted_sas_ca.csr -keyout private/blacklisted_sas_ca.key \
-    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=WInnForum RSA SAS CA-1 - Blacklisted"
-openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in blacklisted_sas_ca.csr \
+    -out revoked_sas_ca.csr -keyout private/revoked_sas_ca.key \
+    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=WInnForum RSA SAS CA-1 - Revoked"
+openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in revoked_sas_ca.csr \
     -policy policy_anything -extensions sas_ca_sign -config ../../../cert/openssl.cnf \
-    -out blacklisted_sas_ca.cert -outdir ./root \
+    -out revoked_sas_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
 # Generate sas server certificate/key.
-echo -e "\n\nGenerate 'sas server' certificate/key signed by blacklisted_sas_ca"
+echo -e "\n\nGenerate 'sas server' certificate/key signed by revoked_sas_ca"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
-    -out sas_revoked_by_ca.csr -keyout sas_revoked_by_ca.key \
-    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=SAS - Blacklisted"
-openssl ca -cert blacklisted_sas_ca.cert -keyfile private/blacklisted_sas_ca.key -in sas_revoked_by_ca.csr \
-    -out sas_revoked_by_ca.cert -outdir ./root \
+    -out sas_cert_from_revoked_ca.csr -keyout sas_cert_from_revoked_ca.key \
+    -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=SAS - Revoked"
+openssl ca -cert revoked_sas_ca.cert -keyfile private/revoked_sas_ca.key -in sas_cert_from_revoked_ca.csr \
+    -out sas_cert_from_revoked_ca.cert -outdir ./root \
     -policy policy_anything -extensions sas_client_mode_req_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Revoke the SAS CA Certificate.
-openssl ca -revoke blacklisted_sas_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
+openssl ca -revoke revoked_sas_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
     -config ../../../cert/openssl.cnf
 
 # Creating CRL for revoked CA xxS.16 test cases
@@ -485,28 +486,28 @@ openssl ca -gencrl -keyfile private/root_ca.key -cert root_ca.cert \
      -config ../../../cert/openssl.cnf  -crldays 365 \
      -out crl/root_ca.crl
 
-echo -e "\n\n Generate CRL for blacklisted_cbsd_ca"
-openssl ca -gencrl -keyfile private/blacklisted_cbsd_ca.key -cert blacklisted_cbsd_ca.cert \
+echo -e "\n\n Generate CRL for revoked_cbsd_ca"
+openssl ca -gencrl -keyfile private/revoked_cbsd_ca.key -cert revoked_cbsd_ca.cert \
      -config ../../../cert/openssl.cnf -crldays 365 \
-     -out crl/blacklisted_cbsd_ca.crl
+     -out crl/revoked_cbsd_ca.crl
 
-echo -e "\n\n Generate CRL for blacklisted_sas_ca"
-openssl ca -gencrl -keyfile private/blacklisted_sas_ca.key -cert blacklisted_sas_ca.cert \
+echo -e "\n\n Generate CRL for revoked_sas_ca"
+openssl ca -gencrl -keyfile private/revoked_sas_ca.key -cert revoked_sas_ca.cert \
      -config ../../../cert/openssl.cnf -crldays 365 \
-     -out crl/blacklisted_sas_ca.crl
+     -out crl/revoked_sas_ca.crl
 
-echo -e "\n\n Generate CRL for blacklisted_proxy_ca"
-openssl ca -gencrl -keyfile private/blacklisted_proxy_ca.key -cert blacklisted_proxy_ca.cert \
+echo -e "\n\n Generate CRL for revoked_proxy_ca"
+openssl ca -gencrl -keyfile private/revoked_proxy_ca.key -cert revoked_proxy_ca.cert \
      -config ../../../cert/openssl.cnf -crldays 365 \
-     -out crl/blacklisted_proxy_ca.crl
+     -out crl/revoked_proxy_ca.crl
 
 # Generate trusted CA bundle.
 echo -e "\n\nGenerate 'ca' bundle"
 cat cbsd_ca.cert proxy_ca.cert sas_ca.cert root_ca.cert cbsd-ecc_ca.cert sas-ecc_ca.cert root-ecc_ca.cert \
-    blacklisted_cbsd_ca.cert blacklisted_sas_ca.cert blacklisted_proxy_ca.cert > ca.cert
+    revoked_cbsd_ca.cert revoked_sas_ca.cert revoked_proxy_ca.cert > ca.cert
 
 # Create CA certificate chain containing the CRLs with revoked leaf certificates.
-cat crl/blacklisted_cbsd_ca.crl crl/blacklisted_sas_ca.crl crl/blacklisted_proxy_ca.crl crl/root_ca.crl > crl/ca.crl
+cat crl/revoked_cbsd_ca.crl crl/revoked_sas_ca.crl crl/revoked_proxy_ca.crl crl/root_ca.crl > crl/ca.crl
 cat ca.cert crl/ca.crl > ca_crl_chain_sxs16.cert
 
 # Note: following server implementation, we could also put only the root_ca.cert

--- a/src/harness/certs/generate_fake_certs.sh
+++ b/src/harness/certs/generate_fake_certs.sh
@@ -397,6 +397,45 @@ openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas.csr \
     -policy policy_anything -extensions sas_req_inapplicable_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
+#Certificate for test case WINNF.FT.S.SCS.16 - Certificate signed by a revoked CA presented during registration
+#Revoke the CBSD CA Certificate
+openssl ca -revoke cbsd_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
+     -config ../../../cert/openssl.cnf
+
+#Certificate for test case WINNF.FT.S.SDS.16 - Certificate signed by a revoked CA presented during registration
+#Revoke the Domain Proxy CA Certificate
+openssl ca -revoke proxy_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
+     -config ../../../cert/openssl.cnf
+
+#Certificate for test case WINNF.FT.S.SSS.16 - Certificate signed by a revoked CA presented during registration
+#Revoke the SAS CA Certificate
+openssl ca -revoke sas_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
+     -config ../../../cert/openssl.cnf
+
+#Creating CRL for revoked CA xxS.16 test cases
+echo "\n\n Generate CRL for root_ca"
+openssl ca -gencrl -keyfile private/root_ca.key -cert root_ca.cert \
+     -config ../../../cert/openssl.cnf  -crlhours 1\
+     -out root/root_ca.crl
+
+echo "\n\n Generate CRL for sas_ca"
+openssl ca -gencrl -keyfile private/sas_ca.key -cert sas_ca.cert \
+     -config ../../../cert/openssl.cnf -crlhours 1 \
+     -out root/sas_ca.crl
+
+echo "\n\n Generate CRL for proxy_ca"
+openssl ca -gencrl -keyfile private/proxy_ca.key -cert proxy_ca.cert \
+     -config ../../../cert/openssl.cnf -crlhours 1 \
+     -out root/proxy_ca.crl
+
+echo "\n\n Generate CRL for cbsd_ca"
+openssl ca -gencrl -keyfile private/cbsd_ca.key -cert cbsd_ca.cert \
+     -config ../../../cert/openssl.cnf -crlhours 1 \
+     -out root/cbsd_ca.crl
+
+#Create CA certificate chain containing the CRLs with revoked certificates
+cat root/cbsd_ca.crl root/sas_ca.crl root/proxy_ca.crl root/root_ca.crl > ca_intermediate.crl
+
 # Generate trusted CA bundle.
 echo "\n\nGenerate 'ca' bundle"
 cat cbsd_ca.cert proxy_ca.cert sas_ca.cert root_ca.cert cbsd-ecc_ca.cert sas-ecc_ca.cert root-ecc_ca.cert > ca.cert

--- a/src/harness/certs/revoke_and_generate_crl.sh
+++ b/src/harness/certs/revoke_and_generate_crl.sh
@@ -17,12 +17,12 @@ function revoke_certificate()
       CA=sas_ca
   elif [ "$CN" == "WInnForum RSA Root CA-1" ]; then
       CA=root_ca
-  elif [ "$CN" == "WInnForum CBSD CA-1 - Blacklisted" ]; then
-      CA=blacklisted_cbsd_ca
-  elif [ "$CN" == "WInnForum RSA Domain Proxy CA - Blacklisted" ]; then
-      CA=blacklisted_proxy_ca
-  elif [ "$CN" == "WInnForum RSA SAS CA-1 - Blacklisted" ]; then
-      CA=blacklisted_sas_ca
+  elif [ "$CN" == "WInnForum CBSD CA-1 - Revoked" ]; then
+      CA=revoked_cbsd_ca
+  elif [ "$CN" == "WInnForum RSA Domain Proxy CA - Revoked" ]; then
+      CA=revoked_proxy_ca
+  elif [ "$CN" == "WInnForum RSA SAS CA-1 - Revoked" ]; then
+      CA=revoked_sas_ca
   else
       echo "Unknown issuer CN=$CN for certificate $1"
       exit -1

--- a/src/harness/certs/revoke_and_generate_crl.sh
+++ b/src/harness/certs/revoke_and_generate_crl.sh
@@ -17,6 +17,12 @@ function revoke_certificate()
       CA=sas_ca
   elif [ "$CN" == "WInnForum RSA Root CA-1" ]; then
       CA=root_ca
+  elif [ "$CN" == "WInnForum CBSD CA-1 - Blacklisted" ]; then
+      CA=blacklisted_cbsd_ca
+  elif [ "$CN" == "WInnForum RSA Domain Proxy CA - Blacklisted" ]; then
+      CA=blacklisted_proxy_ca
+  elif [ "$CN" == "WInnForum RSA SAS CA-1 - Blacklisted" ]; then
+      CA=blacklisted_sas_ca
   else
       echo "Unknown issuer CN=$CN for certificate $1"
       exit -1
@@ -29,28 +35,39 @@ function revoke_certificate()
 
 function generate_crl_chain()
 {
-  #Create a CRL for root CA containing the revoked intermediate CA certificate.
+  # Create a CRL for root CA containing the revoked intermediate CA certificate.
   echo -e "\n\n Generate CRL for root_ca"
   openssl ca -gencrl -keyfile private/root_ca.key -cert root_ca.cert \
-      -config ../../../cert/openssl.cnf -crlhours 1 \
+      -config ../../../cert/openssl.cnf -crldays 365 \
       -out crl/root_ca.crl
-
-  #Creating CRL for blacklisted certificates SxS.11 test cases.
   echo -e "\n\n Generate CRL for sas_ca"
   openssl ca -gencrl -keyfile private/sas_ca.key -cert sas_ca.cert \
-      -config ../../../cert/openssl.cnf -crlhours 1 \
+      -config ../../../cert/openssl.cnf -crldays 365 \
       -out crl/sas_ca.crl
   echo -e "\n\n Generate CRL for proxy_ca"
   openssl ca -gencrl -keyfile private/proxy_ca.key -cert proxy_ca.cert \
-      -config ../../../cert/openssl.cnf -crlhours 1 \
+      -config ../../../cert/openssl.cnf -crldays 365 \
       -out crl/proxy_ca.crl
   echo -e "\n\n Generate CRL for cbsd_ca"
   openssl ca -gencrl -keyfile private/cbsd_ca.key -cert cbsd_ca.cert \
-      -config ../../../cert/openssl.cnf -crlhours 1 \
+      -config ../../../cert/openssl.cnf -crldays 365 \
       -out crl/cbsd_ca.crl
+  echo -e "\n\n Generate CRL for blacklisted_cbsd_ca"
+  openssl ca -gencrl -keyfile private/blacklisted_cbsd_ca.key -cert blacklisted_cbsd_ca.cert \
+      -config ../../../cert/openssl.cnf -crldays 365 \
+      -out crl/blacklisted_cbsd_ca.crl
+  echo -e "\n\n Generate CRL for blacklisted_sas_ca"
+  openssl ca -gencrl -keyfile private/blacklisted_sas_ca.key -cert blacklisted_sas_ca.cert \
+      -config ../../../cert/openssl.cnf -crldays 365 \
+      -out crl/blacklisted_sas_ca.crl
+  echo -e "\n\n Generate CRL for blacklisted_proxy_ca"
+  openssl ca -gencrl -keyfile private/blacklisted_proxy_ca.key -cert blacklisted_proxy_ca.cert \
+      -config ../../../cert/openssl.cnf -crldays 365 \
+      -out crl/blacklisted_proxy_ca.crl
 
-  #Create CA certificate chain containing the CRLs of revoked leaf certificates.
-  cat crl/cbsd_ca.crl crl/sas_ca.crl crl/proxy_ca.crl crl/root_ca.crl > crl/ca.crl
+  # Create CA certificate chain containing the CRLs of revoked leaf certificates.
+  cat crl/cbsd_ca.crl crl/sas_ca.crl crl/proxy_ca.crl crl/root_ca.crl \
+      crl/blacklisted_cbsd_ca.crl crl/blacklisted_sas_ca.crl crl/blacklisted_proxy_ca.crl > crl/ca.crl
 }
 #Argument1 : Type (-r,-u)
 if [ "$1" == "-r" ]; then

--- a/src/harness/certs/revoke_and_generate_crl.sh
+++ b/src/harness/certs/revoke_and_generate_crl.sh
@@ -7,26 +7,26 @@ function revoke_certificate()
   #Argument1: Name of the certificate to be revoked.
 
   #Fetch the Common Name to find out the issuer
-  CN=`openssl x509 -issuer -in $1 -noout | sed 's/^.*CN=//'`
-
+  local CN=`openssl x509 -issuer -in $1 -noout | sed 's/^.*CN=//'`
+  local CA=''
   if [ "$CN" == "WInnForum RSA CBSD CA-1" ]; then
-      CA=cbsd_ca
+    CA=cbsd_ca
   elif [ "$CN" == "WInnForum RSA Domain Proxy CA" ]; then
-      CA=proxy_ca
+    CA=proxy_ca
   elif [ "$CN" == "WInnForum RSA SAS CA-1" ]; then
-      CA=sas_ca
+    CA=sas_ca
   elif [ "$CN" == "WInnForum RSA Root CA-1" ]; then
-      CA=root_ca
+    CA=root_ca
   elif [ "$CN" == "WInnForum CBSD CA-1 - Revoked" ]; then
-      CA=revoked_cbsd_ca
+    CA=revoked_cbsd_ca
   elif [ "$CN" == "WInnForum RSA Domain Proxy CA - Revoked" ]; then
-      CA=revoked_proxy_ca
+    CA=revoked_proxy_ca
   elif [ "$CN" == "WInnForum RSA SAS CA-1 - Revoked" ]; then
-      CA=revoked_sas_ca
+    CA=revoked_sas_ca
   else
-      echo "Unknown issuer CN=$CN for certificate $1"
-      exit -1
-   fi
+    echo "Unknown issuer CN=$CN for certificate $1"
+    exit -1
+  fi
   # Revoke certificate.
   openssl ca -revoke $1 -keyfile private/$CA.key -cert $CA.cert \
       -config ../../../cert/openssl.cnf

--- a/src/harness/fake_sas.py
+++ b/src/harness/fake_sas.py
@@ -56,6 +56,7 @@ from datetime import timedelta
 import uuid
 import json
 import ssl
+import sys
 import os
 import sas_interface
 
@@ -409,40 +410,32 @@ class FakeSasHandler(BaseHTTPRequestHandler):
     self.wfile.write(json.dumps(response))
 
 
-def RunFakeServer(version, is_ecc, ca_cert, verify_crl):
+def RunFakeServer(version, is_ecc, ca_cert_path, verify_crl):
   FakeSasHandler.SetVersion(version)
   if is_ecc:
     assert ssl.HAS_ECDH
   server = HTTPServer(('localhost', PORT), FakeSasHandler)
+  try:
+    with open(ca_cert_path) as file_handle:
+      ca_cert_data = file_handle.read()
+  except IOError:
+    print "%s does not exist" % ca_cert_path
+    return
+  print "\nCA chain is loaded into fake_sas:%s" % ca_cert_path
+  ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
+  ssl_context.options |= ssl.CERT_REQUIRED
 
-  if ca_cert is not None:
-    assert os.path.exists(os.path.join('certs', ca_cert)), "%s is not exist in certs path" % ca_cert
-
+  # If verify CRL flag is set then load the ca chain with CRLs and verify that
+  # the client certificate is not revoked.
   if verify_crl:
-    # If verify CRL flag is set then load the ca chain with CRLs and verify that
-    # the client certificate is not revoked.
-    ssl_context = ssl.create_default_context(ssl.Purpose.CLIENT_AUTH)
-    ssl_context.options &= ssl.CERT_REQUIRED
     ssl_context.verify_flags = ssl.VERIFY_CRL_CHECK_CHAIN
-    ssl_context.load_verify_locations(cafile=os.path.join('certs', ca_cert))
-    ssl_context.load_cert_chain(
+  ssl_context.load_verify_locations(cafile=ca_cert_path)
+  ssl_context.load_cert_chain(
       certfile=ECC_CERT_FILE if is_ecc else CERT_FILE,
-      keyfile=ECC_KEY_FILE if is_ecc else KEY_FILE
-    )
-    ssl_context.set_ciphers(':'.join(ECC_CIPHERS if is_ecc else CIPHERS))
-    ssl_context.verify_mode = ssl.CERT_REQUIRED
-    server.socket = ssl_context.wrap_socket(server.socket,
-                                            server_side=True)
-  else:
-    server.socket = ssl.wrap_socket(
-      server.socket,
-      certfile=ECC_CERT_FILE if is_ecc else CERT_FILE,
-      keyfile=ECC_KEY_FILE if is_ecc else KEY_FILE,
-      ca_certs=CA_CERT,
-      cert_reqs=ssl.CERT_REQUIRED,  # CERT_NONE to disable client certificate check
-      ssl_version=ssl.PROTOCOL_TLSv1_2,
-      ciphers=':'.join(ECC_CIPHERS if is_ecc else CIPHERS),
-      server_side=True)
+      keyfile=ECC_KEY_FILE if is_ecc else KEY_FILE)
+  ssl_context.set_ciphers(':'.join(ECC_CIPHERS if is_ecc else CIPHERS))
+  ssl_context.verify_mode = ssl.CERT_REQUIRED
+  server.socket = ssl_context.wrap_socket(server.socket, server_side=True)
   print 'Will start server at localhost:%d, use <Ctrl-C> to stop.' % PORT
   server.serve_forever()
 
@@ -452,13 +445,20 @@ if __name__ == '__main__':
   parser.add_argument(
       '--ecc', help='Use ECDSA certificate', action='store_true')
   parser.add_argument(
-    '--ca', help='Use CA certificate', dest='ca_cert', action='store')
-  parser.add_argument(
-    '--verify_crl', help='Use revoke and CRL', dest='verify_crl', action='store_true')
-  args = parser.parse_args()
-
+      '--verify_crl', help='Enable CRL verification. If this flag is set then '
+                           '--ca <cert_file> argument is mandatory. The <cert_file> '
+                           'should contain the certificate chain and CRL chain.',
+      dest='verify_crl', action='store_true')
+  parser.add_argument('--ca', required='--verify_crl' in sys.argv,
+                      help='CA certiicate chain with or without CRL chain.',
+                      dest='ca_cert', action='store')
+  try:
+    args = parser.parse_args()
+  except:
+    parser.print_help()
+    sys.exit(0)
   config_parser = ConfigParser.RawConfigParser()
   config_parser.read(['sas.cfg'])
   version = config_parser.get('SasConfig', 'Version')
-  RunFakeServer(version, args.ecc, args.ca_cert, args.verify_crl)
-
+  ca_cert_path = CA_CERT if not args.ca_cert else os.path.join('certs', args.ca_cert)
+  RunFakeServer(version, args.ecc, ca_cert_path, args.verify_crl)

--- a/src/harness/simple_crl_server.py
+++ b/src/harness/simple_crl_server.py
@@ -177,7 +177,7 @@ def revokeCertificate():
   # Retrives the all certificates from certs directory.
   cert_name = getCertificateNameToBlacklist()
   logging.info('Certificate selected to blacklist is:%s', cert_name)
-  revoke_cert_command = "cd {0} && ./revoke_and_generate_crl.sh " \
+  revoke_cert_command = "cd {0} && bash ./revoke_and_generate_crl.sh " \
                         "-r {1}".format(getCertsDirectoryAbsolutePath(),
                                          cert_name)
   command_exit_status = subprocess.call(revoke_cert_command, shell=True)
@@ -205,7 +205,7 @@ def updateCrlUrlAndRegenerateCertificates():
   logging.info('CRL URL has been updated correctly in openssl.cnf')
 
   # Re-generate certificates.
-  script_name = './generate_fake_certs.sh'
+  script_name = 'bash ./generate_fake_certs.sh'
   command = 'cd {0} && {1}'.format(getCertsDirectoryAbsolutePath(), script_name)
   command_exit_status = subprocess.call(command, shell=True)
   if command_exit_status:
@@ -225,7 +225,7 @@ def generateCrlChain():
   placed in the 'harness/certs/crl/' directory.
   """
 
-  create_crl_chain_command = "cd {0} && ./revoke_and_generate_crl.sh -u".format(
+  create_crl_chain_command = "cd {0} && bash ./revoke_and_generate_crl.sh -u".format(
       getCertsDirectoryAbsolutePath())
   command_exit_status = subprocess.call(create_crl_chain_command, shell=True)
   if command_exit_status:

--- a/src/harness/simple_crl_server.py
+++ b/src/harness/simple_crl_server.py
@@ -26,11 +26,6 @@ from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
 
 DEFAULT_CRL_URL = 'http://localhost:9007/ca.crl'
 DEFAULT_CRL_SERVER_PORT = 80
-CERT_TYPE = {
-    '1': 'CBSD',
-    '2': 'DP',
-    '3': 'SAS'
-}
 MENU_ACTIONS = {}
 MENU_ID_MAIN_MENU = '-1'
 MENU_ID_QUIT = '0'
@@ -182,17 +177,8 @@ def revokeCertificate():
   # Retrives the all certificates from certs directory.
   cert_name = getCertificateNameToBlacklist()
   logging.info('Certificate selected to blacklist is:%s', cert_name)
-  print "select the certificate type:"
-  print "\n".join("[%s] %s" % (cert_id, cert_type)
-                  for (cert_id, cert_type) in sorted(CERT_TYPE.iteritems()))
-  cert_type = raw_input(CLI_PROMPT_TEXT)
-  if cert_type not in CERT_TYPE:
-    raise Exception("RunTimeError:Type of certificate to be blacklisted is incorrect."
-                    "Please select one of the values:%s" % CERT_TYPE.values())
-
   revoke_cert_command = "cd {0} && ./revoke_and_generate_crl.sh " \
-                        "{1} {2}".format(getCertsDirectoryAbsolutePath(),
-                                         CERT_TYPE[cert_type],
+                        "-r {1}".format(getCertsDirectoryAbsolutePath(),
                                          cert_name)
   command_exit_status = subprocess.call(revoke_cert_command, shell=True)
   if command_exit_status:

--- a/src/harness/simple_crl_server.py
+++ b/src/harness/simple_crl_server.py
@@ -177,7 +177,7 @@ def revokeCertificate():
   # Retrives the all certificates from certs directory.
   cert_name = getCertificateNameToBlacklist()
   logging.info('Certificate selected to blacklist is:%s', cert_name)
-  revoke_cert_command = "cd {0} && bash ./revoke_and_generate_crl.sh " \
+  revoke_cert_command = "cd {0} && ./revoke_and_generate_crl.sh " \
                         "-r {1}".format(getCertsDirectoryAbsolutePath(),
                                          cert_name)
   command_exit_status = subprocess.call(revoke_cert_command, shell=True)
@@ -205,7 +205,7 @@ def updateCrlUrlAndRegenerateCertificates():
   logging.info('CRL URL has been updated correctly in openssl.cnf')
 
   # Re-generate certificates.
-  script_name = 'bash ./generate_fake_certs.sh'
+  script_name = './generate_fake_certs.sh'
   command = 'cd {0} && {1}'.format(getCertsDirectoryAbsolutePath(), script_name)
   command_exit_status = subprocess.call(command, shell=True)
   if command_exit_status:
@@ -225,7 +225,7 @@ def generateCrlChain():
   placed in the 'harness/certs/crl/' directory.
   """
 
-  create_crl_chain_command = "cd {0} && bash ./revoke_and_generate_crl.sh -u".format(
+  create_crl_chain_command = "cd {0} && ./revoke_and_generate_crl.sh -u".format(
       getCertsDirectoryAbsolutePath())
   command_exit_status = subprocess.call(create_crl_chain_command, shell=True)
   if command_exit_status:

--- a/src/harness/testcases/README.md
+++ b/src/harness/testcases/README.md
@@ -4,3 +4,54 @@
 
 The current test cases are based on the [WinnForum test specification](https://workspace.winnforum.org/higherlogic/ws/public/download/5637/WINNF-TS-0061-V1.1.0%20-%20WG4%20SAS%20Test%20and%20Certification%20Spec.pdf) v1.1 (Jan 2018)
 
+## Security Test Cases
+
+The SCS.11/16, SDS.11/16 and SSS.11/16 TCs just expect the handshake failure and do not validate the reason for failure.<br>
+The correct way to run the fake_sas for these test cases is
+<pre>
+<code>
+<b> $ python fake_sas.py --verify_crl --ca ca_crl_chain_sxs11/16.cert </b>
+</code>
+</pre>
+
+As WinnF WG.2 and ITS approved to use CRL as the initial certificate blacklisting solution before OCSP is available, 
+came up with following agreements
+
+<b>Agreements:</b>
+1. Deploy a CRL server (a.k.a The certificate revocation list distribution point CDP) in the ITS designated VM environment 
+to serve as a FCC certification dedicated CRL server.
+
+2. Certificates, sub-CAs to be blacklisted for all the test cases (e.g. SCS.11 and SCS.16 etc.) will be created and 
+per-loaded into the CRL server appropriately. There is NO need for the test harness codes to blacklist a certificate 
+or sub-CA on-demand. During the test, the test codes will directly use the certificate or sub-CA that are already 
+in the CRL.
+
+3. SAS UUT is assumed to pull the CRL periodically as if in normal operation. There is only a coordination need, 
+that is to make sure SAS UUT has the latest CRL information before running the related test cases.
+
+If a SAS UUT is used for testing the CRL test cases then the steps to manually download the CRL file using wget and 
+concatenating it with the CA chain would not be needed as the <b>simple CRL server</b> is used to mimic an actual 
+CRL server and the CDP URL field of the certificates is updated with the URL of the <b>simple CRL server</b>. 
+As fake_sas updates are on a best effort basis and the intention is to keep it simple, the automatic retrieval of 
+CRL file is not implemented in fake_sas.
+
+To obtain the CRL file, the <b>simple CRL server</b> in <b>master</b> branch needs to be 
+executed and a CRL chain can be retrieved from this server.
+
+The steps are
+
+1. Run the ‘simple CRL server’
+<b> $ python simple_crl_server.py </b>
+2. Use the menu option to blacklist a certificate (client cert or DP cert or SAS cert).
+3. Use wget on the simple CRL server URL to get the CRL chain file.
+<b> wget http://localhost:9007/ca.crl </b>
+4. Concatenate the CA chain file and the CRL file to create a combined CA chain and CRL chain file.
+<b> cat certs/ca.cert ca.crl > certs/ca_crl_chain.cert </b>
+5. Run the fake_sas with the <b>--verify_crl</b> and <b>--ca ca_crl_chain.cert</b> option.
+
+The details of using the <b>simple CRL server</b> is documented under <b>harness/CRLServer-README.md file</b>. 
+The simple CRL server is also enhanced with simpler menu option and ability to blacklist intermediate CAs.
+
+However to make it bit more easier to run the SXS.11/16 test cases, a default CRL file containing the CA chain and 
+the CRL chain containing the blacklisted certificates for SXS.11/16 test cases is created. 
+So the fake_sas can be run with the ca file <b>ca_crl_chain_sxs11/16.cert</b> without running the <b>simple CRL server</b>.

--- a/src/harness/testcases/WINNF_FT_S_SCS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SCS_testcase.py
@@ -258,21 +258,21 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     self.assertEqual(response['response']['responseCode'],104)
 
   def generate_SCS_16_default_config(self, filename):
-    """Generates the WinnForum configuration for SCS_16. """
+    """Generate the WinnForum configuration for SCS_16."""
     # Create the configuration for client cert/key path.
 
     config = {
-      'clientCert': self.getCertFilename("client.cert"),
-      'clientKey': self.getCertFilename("client.key")
+        'clientCert': self.getCertFilename("client_revoked_by_ca.cert"),
+        'clientKey': self.getCertFilename("client_revoked_by_ca.key")
     }
     writeConfig(filename, config)
 
   @configurable_testcase(generate_SCS_16_default_config)
   def test_WINNF_FT_S_SCS_16(self, config_filename):
     """Certificate signed by a revoked CA presented during registration.
-       Checks that SAS UUT response with fatal alert message.
-    """
 
+    Checks that SAS UUT response with fatal alert message.
+    """
     # Read the configuration
     config = loadConfig(config_filename)
 

--- a/src/harness/testcases/WINNF_FT_S_SCS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SCS_testcase.py
@@ -15,6 +15,7 @@
 import json
 import logging
 import os
+import time
 import security_testcase
 import time
 from OpenSSL import SSL
@@ -257,6 +258,36 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     # Check registration response
     self.assertEqual(response['response']['responseCode'],104)
 
+  def generate_SCS_16_default_config(self, filename):
+    """Generates the WinnForum configuration for SCS_16. """
+    # Create the configuration for client cert/key,wait timer information
+
+    config = {
+      'clientCert': self.getCertFilename("client.cert"),
+      'clientKey': self.getCertFilename("client.key"),
+      'waitTimer': 60
+    }
+    writeConfig(filename, config)
+
+  @configurable_testcase(generate_SCS_16_default_config)
+  def test_WINNF_FT_S_SCS_16(self, config_filename):
+    """Certificate signed by a revoked CA presented during registration.
+       Checks that SAS UUT response with fatal alert message.
+    """
+
+    # Read the configuration
+    config = loadConfig(config_filename)
+
+    logging.info("Waiting for %s secs to allow the UUT to pull the revoked certificate "
+                 "list from the CRL server " % config['waitTimer'])
+
+    # Wait for the timer
+    time.sleep(config['waitTimer'])
+
+    # Tls handshake fails since CA is revoked
+    self.assertTlsHandshakeFailure(client_cert=config['clientCert'],
+                                   client_key=config['clientKey'])
+    logging.info("TLS handshake failed as the CA certificate has been revoked")
 
   @winnforum_testcase
   def test_WINNF_FT_S_SCS_17(self):

--- a/src/harness/testcases/WINNF_FT_S_SCS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SCS_testcase.py
@@ -15,7 +15,6 @@
 import json
 import logging
 import os
-import time
 import security_testcase
 import time
 from OpenSSL import SSL
@@ -260,12 +259,11 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
 
   def generate_SCS_16_default_config(self, filename):
     """Generates the WinnForum configuration for SCS_16. """
-    # Create the configuration for client cert/key,wait timer information
+    # Create the configuration for client cert/key path.
 
     config = {
       'clientCert': self.getCertFilename("client.cert"),
-      'clientKey': self.getCertFilename("client.key"),
-      'waitTimer': 60
+      'clientKey': self.getCertFilename("client.key")
     }
     writeConfig(filename, config)
 
@@ -278,16 +276,11 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     # Read the configuration
     config = loadConfig(config_filename)
 
-    logging.info("Waiting for %s secs to allow the UUT to pull the revoked certificate "
-                 "list from the CRL server " % config['waitTimer'])
-
-    # Wait for the timer
-    time.sleep(config['waitTimer'])
-
     # Tls handshake fails since CA is revoked
     self.assertTlsHandshakeFailure(client_cert=config['clientCert'],
                                    client_key=config['clientKey'])
     logging.info("TLS handshake failed as the CA certificate has been revoked")
+	
 
   @winnforum_testcase
   def test_WINNF_FT_S_SCS_17(self):

--- a/src/harness/testcases/WINNF_FT_S_SCS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SCS_testcase.py
@@ -262,8 +262,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the configuration for client cert/key path.
 
     config = {
-        'clientCert': self.getCertFilename("client_revoked_by_ca.cert"),
-        'clientKey': self.getCertFilename("client_revoked_by_ca.key")
+        'clientCert': self.getCertFilename("client_cert_from_revoked_ca.cert"),
+        'clientKey': self.getCertFilename("client_cert_from_revoked_ca.key")
     }
     writeConfig(filename, config)
 
@@ -280,7 +280,6 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     self.assertTlsHandshakeFailure(client_cert=config['clientCert'],
                                    client_key=config['clientKey'])
     logging.info("TLS handshake failed as the CA certificate has been revoked")
-	
 
   @winnforum_testcase
   def test_WINNF_FT_S_SCS_17(self):

--- a/src/harness/testcases/WINNF_FT_S_SDS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SDS_testcase.py
@@ -266,23 +266,23 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
 
     # Check registration response
     self.assertEqual(response['response']['responseCode'],104)
-	
+
   def generate_SDS_16_default_config(self, filename):
-    """Generates the WinnForum configuration for SDS_16. """
+    """Generate the WinnForum configuration for SDS_16."""
     # Create the configuration for domain proxy cert/key path.
 
     config = {
-      'domainProxyCert': self.getCertFilename("domain_proxy.cert"),
-      'domainProxyKey': self.getCertFilename("domain_proxy.key")
+        'domainProxyCert': self.getCertFilename("domain_proxy_revoked_by_ca.cert"),
+        'domainProxyKey': self.getCertFilename("domain_proxy_revoked_by_ca.key")
     }
     writeConfig(filename, config)
 
   @configurable_testcase(generate_SDS_16_default_config)
   def test_WINNF_FT_S_SDS_16(self, config_filename):
     """Certificate signed by a revoked CA presented during registration.
-       Checks that SAS UUT response with fatal alert message.
-    """
 
+    Checks that SAS UUT response with fatal alert message.
+    """
     # Read the configuration
     config = loadConfig(config_filename)
 

--- a/src/harness/testcases/WINNF_FT_S_SDS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SDS_testcase.py
@@ -272,8 +272,8 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     # Create the configuration for domain proxy cert/key path.
 
     config = {
-        'domainProxyCert': self.getCertFilename("domain_proxy_revoked_by_ca.cert"),
-        'domainProxyKey': self.getCertFilename("domain_proxy_revoked_by_ca.key")
+        'domainProxyCert': self.getCertFilename("domain_proxy_cert_from_revoked_ca.cert"),
+        'domainProxyKey': self.getCertFilename("domain_proxy_cert_from_revoked_ca.key")
     }
     writeConfig(filename, config)
 

--- a/src/harness/testcases/WINNF_FT_S_SDS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SDS_testcase.py
@@ -20,6 +20,7 @@ from OpenSSL import SSL
 from util import winnforum_testcase, configurable_testcase, \
   writeConfig, loadConfig
 
+
 DOMAIN_PROXY_CERT = os.path.join('certs', 'domain_proxy.cert')
 DOMAIN_PROXY_KEY = os.path.join('certs', 'domain_proxy.key')
 
@@ -265,15 +266,14 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
 
     # Check registration response
     self.assertEqual(response['response']['responseCode'],104)
-
+	
   def generate_SDS_16_default_config(self, filename):
     """Generates the WinnForum configuration for SDS_16. """
-    # Create the configuration for client cert/key,wait timer information
+    # Create the configuration for domain proxy cert/key path.
 
     config = {
       'domainProxyCert': self.getCertFilename("domain_proxy.cert"),
-      'domainProxyKey': self.getCertFilename("domain_proxy.key"),
-      'waitTimer': 60
+      'domainProxyKey': self.getCertFilename("domain_proxy.key")
     }
     writeConfig(filename, config)
 
@@ -285,12 +285,6 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
 
     # Read the configuration
     config = loadConfig(config_filename)
-
-    logging.info("Waiting for %s secs to allow the UUT to pull the revoked certificate "
-                 "list from the CRL server " % config['waitTimer'])
-
-    # Wait for the timer
-    time.sleep(config['waitTimer'])
 
     # Tls handshake fails since CA is revoked
     self.assertTlsHandshakeFailure(client_cert=config['domainProxyCert'],

--- a/src/harness/testcases/WINNF_FT_S_SSS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SSS_testcase.py
@@ -14,7 +14,6 @@
 import json
 import logging
 import os
-import time
 from OpenSSL import SSL
 from OpenSSL.crypto import load_certificate, FILETYPE_PEM
 import security_testcase
@@ -335,36 +334,27 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
 
   def generate_SSS_16_default_config(self, filename):
     """Generates the WinnForum configuration for SSS_16. """
-    # Create the configuration for client cert/key,wait timer information
+    # Create the configuration for SAS cert/key path.
 
     config = {
       'sasCert': self.getCertFilename("sas.cert"),
-      'sasKey': self.getCertFilename("sas.key"),
-      'waitTimer': 60
+      'sasKey': self.getCertFilename("sas.key")
     }
     writeConfig(filename, config)
 
   @configurable_testcase(generate_SSS_16_default_config)
   def test_WINNF_FT_S_SSS_16(self, config_filename):
-    """Certificate signed by a revoked CA presented during registration.
+    """Certificate signed by a revoked CA presented by SAS Test Harness.
        Checks that SAS UUT response with fatal alert message.
     """
-
     # Read the configuration
     config = loadConfig(config_filename)
-
-    logging.info("Waiting for %s secs to allow the UUT to pull the revoked certificate "
-                 "list from the CRL server " % config['waitTimer'])
-
-    # Wait for the timer
-    time.sleep(config['waitTimer'])
 
     # Tls handshake fails since CA is revoked
     self.assertTlsHandshakeFailure(client_cert=config['sasCert'],
                                    client_key=config['sasKey'])
 
     logging.info("TLS handshake failed as the CA certificate has been revoked")
-
 
   def generate_SSS_17_default_config(self, filename):
     """Generates the WinnForum configuration for SSS_17"""

--- a/src/harness/testcases/WINNF_FT_S_SSS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SSS_testcase.py
@@ -333,19 +333,20 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     self.assertFalse(trigger_succeed, "Full Activity Dump is expected to fail")
 
   def generate_SSS_16_default_config(self, filename):
-    """Generates the WinnForum configuration for SSS_16. """
+    """Generate the WinnForum configuration for SSS_16."""
     # Create the configuration for SAS cert/key path.
 
     config = {
-      'sasCert': self.getCertFilename("sas.cert"),
-      'sasKey': self.getCertFilename("sas.key")
+        'sasCert': self.getCertFilename("sas_revoked_by_ca.cert"),
+        'sasKey': self.getCertFilename("sas_revoked_by_ca.key")
     }
     writeConfig(filename, config)
 
   @configurable_testcase(generate_SSS_16_default_config)
   def test_WINNF_FT_S_SSS_16(self, config_filename):
     """Certificate signed by a revoked CA presented by SAS Test Harness.
-       Checks that SAS UUT response with fatal alert message.
+
+    Checks that SAS UUT response with fatal alert message.
     """
     # Read the configuration
     config = loadConfig(config_filename)

--- a/src/harness/testcases/WINNF_FT_S_SSS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SSS_testcase.py
@@ -337,8 +337,8 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the configuration for SAS cert/key path.
 
     config = {
-        'sasCert': self.getCertFilename("sas_revoked_by_ca.cert"),
-        'sasKey': self.getCertFilename("sas_revoked_by_ca.key")
+        'sasCert': self.getCertFilename("sas_cert_from_revoked_ca.cert"),
+        'sasKey': self.getCertFilename("sas_cert_from_revoked_ca.key")
     }
     writeConfig(filename, config)
 


### PR DESCRIPTION
As WinnF WG.2 and ITS approved to use CRL as the initial certificate blacklisting solution before OCSP is available, the test codes developers working on security related test cases came to the following agreements:

1. Deploy a CRL server (a.k.aThe certificate revocation list distribution point – CDP) in the ITS designated VM environment to serve as a FCC certification dedicated CRL server
2. Certificates, sub-CAs to be blacklisted for all the test cases (e.g. SCS.11 and SCS.16 etc.) will be created and per-loaded into the CRL server appropriately. There is NO need for the test harness codes to blacklist a certificate or sub-CA on-demand. During the test, the test codes will directly use the certificate or sub-CA that are already in the CRL.
3. SAS UUT is assumed to pull the CRL periodically as if in normal operation. There is only a coordination need, that is to make sure SAS UUT has the latest CRL information before running the related test cases.

The SCS.16, SDS.16 and SSS.16 test cases are modified to meeting these agreements as below

1.  the revoked CA is sub-CA that will be inserted into CRL
2. the test cases will use CRL for testing the revoked sub-CA requirement.
 