### PR TITLE
Simple CRL server using native openssl CRL capabilities

### DIFF
--- a/cert/openssl.cnf
+++ b/cert/openssl.cnf
@@ -486,7 +486,7 @@ policyIdentifier = 2.16.840.1.114412.2.1
 
 subjectKeyIdentifier = hash
 basicConstraints = CA:FALSE
-keyUsage = critical, digitalSignature, keyEncipherment,cRLSign
+keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 certificatePolicies=@cps,ROLE_CBSD
 crlDistributionPoints=@crl_section
 #FCCID
@@ -502,7 +502,7 @@ policyIdentifier = 2.16.840.1.114412.2.1
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer
 basicConstraints = CA:FALSE
-keyUsage = critical, digitalSignature, keyEncipherment,cRLSign
+keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
 certificatePolicies=@cps,ROLE_CBSD
 crlDistributionPoints=@crl_section

--- a/cert/openssl.cnf
+++ b/cert/openssl.cnf
@@ -129,11 +129,10 @@ basicConstraints 				= critical, CA:true
 keyUsage 						= critical, digitalSignature, cRLSign, keyCertSign
 
 ####################################################################
-#Not used yet
+
 [ crl_section ]
 
-URI.0 = http://crl3.digicert.com/WInnForumCA.crl
-URI.1 = http://crl4.digicert.com/WInnForumCA.crl
+URI.0 = http://localhost:9007/ca.crl
 
 ####################################################################
 #Not used yet
@@ -319,9 +318,10 @@ policyIdentifier = 2.16.840.1.114412.2.1
 
 subjectKeyIdentifier = hash
 basicConstraints = CA:FALSE
-keyUsage = critical, digitalSignature
+keyUsage = critical, digitalSignature, cRLSign
 extendedKeyUsage = serverAuth
 certificatePolicies=@cps,ROLE_SAS,FRN
+crlDistributionPoints=@crl_section
 [ cps ]
 
 policyIdentifier = 2.16.840.1.114412.2.1
@@ -332,9 +332,10 @@ policyIdentifier = 2.16.840.1.114412.2.1
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer
 basicConstraints = CA:FALSE
-keyUsage = critical, digitalSignature
+keyUsage = critical, digitalSignature, cRLSign
 extendedKeyUsage = serverAuth
 certificatePolicies=@cps,ROLE_SAS,FRN
+crlDistributionPoints=@crl_section
 [ cps ]
 
 policyIdentifier = 2.16.840.1.114412.2.1
@@ -345,9 +346,10 @@ policyIdentifier = 2.16.840.1.114412.2.1
 
 subjectKeyIdentifier = hash
 basicConstraints = CA:FALSE
-keyUsage = critical, digitalSignature, keyEncipherment
+keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
 certificatePolicies=@cps,ROLE_SAS,FRN
+crlDistributionPoints=@crl_section
 
 [ cps ]
 
@@ -359,9 +361,10 @@ CPS.1="https://www.digicert.com/CPS"
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer
 basicConstraints = CA:FALSE
-keyUsage = critical, digitalSignature, keyEncipherment
+keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
 certificatePolicies=@cps,ROLE_SAS,FRN
+crlDistributionPoints=@crl_section
 
 [ cps ]
 
@@ -382,9 +385,10 @@ certificatePolicies=@cps,ROLE_SAS,ZONE
 
 subjectKeyIdentifier = hash
 basicConstraints = CA:FALSE
-keyUsage = critical, digitalSignature, keyEncipherment
+keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
 certificatePolicies=@cps,ROLE_OPERATOR,FRN
+crlDistributionPoints=@crl_section
 #FRN
 
 [ cps ]
@@ -397,9 +401,10 @@ policyIdentifier = 2.16.840.1.114412.2.1
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer
 basicConstraints = CA:FALSE
-keyUsage = critical, digitalSignature, keyEncipherment
+keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
 certificatePolicies=@cps,ROLE_OPERATOR,FRN
+crlDistributionPoints=@crl_section
 #FRN
 
 [ oper_req_inapplicable_sign ]
@@ -481,8 +486,9 @@ policyIdentifier = 2.16.840.1.114412.2.1
 
 subjectKeyIdentifier = hash
 basicConstraints = CA:FALSE
-keyUsage = critical, digitalSignature, keyEncipherment
+keyUsage = critical, digitalSignature, keyEncipherment,cRLSign
 certificatePolicies=@cps,ROLE_CBSD
+crlDistributionPoints=@crl_section
 #FCCID
 #SERIAL
 
@@ -496,9 +502,10 @@ policyIdentifier = 2.16.840.1.114412.2.1
 subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer
 basicConstraints = CA:FALSE
-keyUsage = critical, digitalSignature, keyEncipherment
+keyUsage = critical, digitalSignature, keyEncipherment,cRLSign
 extendedKeyUsage = clientAuth
 certificatePolicies=@cps,ROLE_CBSD
+crlDistributionPoints=@crl_section
 #FCCID
 #SERIAL
 

--- a/src/harness/CRLServer-README.md
+++ b/src/harness/CRLServer-README.md
@@ -1,0 +1,400 @@
+# Simple CRL Server
+The simple CRL server implements a simple CRL server. The default URL for this CRL server
+is http://localhost:9007/ca.crl. This a simple HTTP server that responds only to this URL and provides
+the ca.crl file present in the harness/certs/crl/ directory. When the simple CRL server is started
+it creates a CRL file for the intermediate CAs (CBSD CA, DP CA and SAS CA) and the root CA. All the
+CRL files are concatenated to create CRL chain file named ca.crl. The first time the simple CRL server
+started the ca.crl file may not have any certificates revoked.
+
+The simple CRL server provides menu options to revoke any CBSD or DP or SAS certificate. It lists
+all the certificate files and revokes the certificates using the appropriate intermediate CA based
+on the certificate type. The ca.crl chain is then regenerated to include the revoked certificate's
+sequence number. Another menu option is to update the CRL URL. If the URL mentioned in the CDP 
+extension field of the certificates needs to be changed then this option can be used. It updates 
+the [ crl_section ] in the openssl.cnf file and invokes the script 'generate_fake_certs.sh' to 
+generate the certificates with the updated extension field.
+
+
+### Starting CRL Server:
+Go to harness directory and execute **python simple_crl_server.py**<br/>
+The simple CRL server will start and generate a CRL file based on the contents from the **harness/certs**
+directory.<br/> The crl file will not have any certificates revoked when started for the first time.<br/>
+The ca.crl file at the location "certs/XXXX" will be served by this simple CRL server.<br/>
+<pre>
+<code>
+$ python simple_crl_server.py 
+\n\n Generate CRL for root_ca
+Using configuration from ../../../cert/openssl.cnf
+\n\n Generate CRL for sas_ca
+Using configuration from ../../../cert/openssl.cnf
+\n\n Generate CRL for proxy_ca
+Using configuration from ../../../cert/openssl.cnf
+\n\n Generate CRL for cbsd_ca
+Using configuration from ../../../cert/openssl.cnf
+[INFO] 2018-03-19 16:40:27,542 crl/ca.crl CRL chain is created successfully
+[INFO] 2018-03-19 16:40:27,065 CRL Server has been started 
+   _____ _____  _         _____
+  / ____|  __ \| |       / ____|
+ | |    | |__) | |      | (___   ___ _ ____   _____ _ __
+ | |    |  _  /| |       \___ \ / _ \ '__\ \ / / _ \ '__|
+ | |____| | \ \| |____   ____) |  __/ |   \ V /  __/ |
+  \_____|_|  \_\______| |_____/ \___|_|    \_/ \___|_|
+
+Please select the options:
+[1] Revoke Certificate
+[2] Update CRL URL and Re-generate certificates
+[0] Quit
+CRL Server> [INFO] 2018-03-19 16:40:27,066 <b>Started CRL Server at localhost:9007</b>
+</code>
+</pre>
+## Revoking a Certificate
+
+### Revoke Certificate using CRLServer
+- Step #1 Enter Option 1 to Revoke Certificate 
+  - Lists out the all existing certificates present in harness/certs directory.
+- Step #2 Select certificate to blacklist.
+  - The selected certificate has been considered for revocation.
+- Step #3 Specify the type of certificate whether it is a CBSD,DP or SAS certificate. 
+  - The selected certificate type option has been considered for revocation.
+- Step #4 Wait for few second(s) to receive confirmation message (highlighted below) about certificate revocation 
+  and it's corresponding serial number addition to CRL Database.
+<pre>
+<code>
+   _____ _____  _         _____
+  / ____|  __ \| |       / ____|
+ | |    | |__) | |      | (___   ___ _ ____   _____ _ __
+ | |    |  _  /| |       \___ \ / _ \ '__\ \ / / _ \ '__|
+ | |____| | \ \| |____   ____) |  __/ |   \ V /  __/ |
+  \_____|_|  \_\______| |_____/ \___|_|    \_/ \___|_|
+
+Please select the options:
+<b>[1] Revoke Certificate</b>
+[2] Update CRL URL and Re-generate certificates
+[0] Quit
+CRL Server> <b>1</b>
+Certificates present in directory path: **/harness/certs**
+Select the certificate to blacklist:
+[0] admin_client.cert
+[1] ca.cert
+[2] cbsd-ecc_ca.cert
+[3] cbsd_ca.cert
+<b>[4] client.cert</b>
+[5] client_expired.cert
+
+CRL Server> <b>4</b>
+[INFO] 2018-03-19 16:48:01,372 Certificate selected to blacklist is:client.cert
+Select the certificate type:
+<b>[1] CBSD</b>
+[2] DP
+[3] SAS
+CRL Server> <b>1</b>
+Using configuration from ../../../cert/openssl.cnf
+Adding Entry with serial number 9946F8E1AEFBD7C0 to DB for /C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=SAS CBSD Example
+<b>Revoking Certificate 9946F8E1AEFBD7C0.</b>
+Data Base Updated
+\n\n Generate CRL for root_ca
+Using configuration from ../../../cert/openssl.cnf
+\n\n Generate CRL for sas_ca
+Using configuration from ../../../cert/openssl.cnf
+\n\n Generate CRL for proxy_ca
+Using configuration from ../../../cert/openssl.cnf
+\n\n Generate CRL for cbsd_ca
+Using configuration from ../../../cert/openssl.cnf
+<b>[INFO] 2018-03-19 16:48:48,923 client.cert is blacklisted successfully</b>
+</code>
+</pre> 
+
+### Update CDP CRL Distribution Point in certificate and Regenerate CRLs
+
+
+Select this option to update the CDP URL extension field in the certificates with the URL of the simple CRL server.<br/> 
+The <b>[ crl_section ]</b> field in the <b>'openssl.cnf'</b> will be updated with the URL of this simple CRL server and 
+all the certificates will be regenerated.<br/>
+<pre>
+<code>
+   _____ _____  _         _____
+  / ____|  __ \| |       / ____|
+ | |    | |__) | |      | (___   ___ _ ____   _____ _ __
+ | |    |  _  /| |       \___ \ / _ \ '__\ \ / / _ \ '__|
+ | |____| | \ \| |____   ____) |  __/ |   \ V /  __/ |
+  \_____|_|  \_\______| |_____/ \___|_|    \_/ \___|_|
+
+Please select the options:
+[1] Revoke Certificate
+<b>[2] Update CRL URL and Re-generate certificates</b>
+[0] Quit
+CRL Server><b>2</b> 
+[INFO] 2018-03-18 21:29:01,192 CRL URL has been updated correctly in openssl.cnf
+\n\nGenerate 'root_ca' and 'root-ecc_ca' certificate/key
+Generating a 4096 bit RSA private key
+.++
+..................................................................++
+writing new private key to 'private/root_ca.key'
+-----
+\n\nGenerate 'sas_ca' and 'sas-ecc_ca' certificate/key
+Generating a 4096 bit RSA private key
+...............................................................................................++
+.........................................++
+writing new private key to 'private/sas_ca.key'
+-----
+Using configuration from ../../../cert/openssl.cnf
+Check that the request matches the signature
+Signature ok
+Certificate Details:
+        Serial Number:
+            f4:b9:9d:d7:27:21:14:3d
+        Validity
+            Not Before: Mar 18 15:59:05 2018 GMT
+            Not After : Mar 14 15:59:05 2033 GMT
+        Subject:
+            countryName               = US
+            stateOrProvinceName       = District of Columbia
+            localityName              = Washington
+            organizationName          = Wireless Innovation Forum
+            organizationalUnitName    = www.wirelessinnovation.org
+            commonName                = WInnForum RSA SAS CA-1
+        X509v3 extensions:
+            X509v3 Subject Key Identifier:
+                CF:45:8F:3A:CB:A5:9A:F3:95:8E:2D:0D:51:FF:61:63:75:73:B8:57
+            X509v3 Authority Key Identifier:
+                keyid:50:69:EB:DA:C3:98:14:4A:63:8F:57:09:B5:D2:EB:15:36:E3:F6:4B
+
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 Certificate Policies:
+                Policy: 2.16.840.1.114412.2.1
+                  CPS: https://www.digicert.com/CPS
+                Policy: ROLE_CA
+                Policy: ROLE_SAS
+
+Certificate is to be certified until Mar 14 15:59:05 2033 GMT (5475 days)
+
+Write out database with 1 new entries
+Data Base Updated
+Using configuration from ../../../cert/openssl.cnf
+Check that the request matches the signature
+Signature ok
+Certificate Details:
+        Serial Number:
+            f4:b9:9d:d7:27:21:14:3e
+        Validity
+            Not Before: Mar 18 15:59:05 2018 GMT
+            Not After : Mar 14 15:59:05 2033 GMT
+        Subject:
+            countryName               = US
+            stateOrProvinceName       = District of Columbia
+            localityName              = Washington
+            organizationName          = Wireless Innovation Forum
+            organizationalUnitName    = www.wirelessinnovation.org
+            commonName                = WInnForum ECC SAS CA-1
+        X509v3 extensions:
+            X509v3 Subject Key Identifier:
+                30:09:FF:DC:84:99:40:EC:D8:1B:2D:54:4B:A0:55:36:98:5A:09:C4
+            X509v3 Authority Key Identifier:
+                keyid:E0:5E:23:72:C1:35:5B:DC:05:32:19:D3:02:49:8D:C2:BD:B7:AA:69
+
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:0
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 Certificate Policies:
+                Policy: 2.16.840.1.114412.2.1
+                  CPS: https://www.digicert.com/CPS
+                Policy: ROLE_CA
+                Policy: ROLE_SAS
+
+Certificate is to be certified until Mar 14 15:59:05 2033 GMT (5475 days)
+
+Write out database with 1 new entries
+Data Base Updated
+\n\nGenerate 'cbsd_ca' certificate/key
+Generating a 4096 bit RSA private key
+..........++
+...................................................................................................................................++
+writing new private key to 'private/cbsd_ca.key'
+-----
+Using configuration from ../../../cert/openssl.cnf
+Check that the request matches the signature
+Signature ok
+Certificate Details:
+        Serial Number:
+            f4:b9:9d:d7:27:21:14:3f
+        Validity
+            Not Before: Mar 18 15:59:08 2018 GMT
+            Not After : Mar 14 15:59:08 2033 GMT
+        Subject:
+            countryName               = US
+            stateOrProvinceName       = District of Columbia
+            localityName              = Washington
+            organizationName          = Wireless Innovation Forum
+            organizationalUnitName    = www.wirelessinnovation.org
+            commonName                = WInnForum RSA CBSD CA-1
+        X509v3 extensions:
+            X509v3 Subject Key Identifier:
+                EB:86:4E:70:E5:3E:AF:D0:89:95:29:BF:F8:4C:AE:CA:A0:80:01:32
+            X509v3 Authority Key Identifier:
+                keyid:50:69:EB:DA:C3:98:14:4A:63:8F:57:09:B5:D2:EB:15:36:E3:F6:4B
+
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:1
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 Certificate Policies:
+                Policy: 2.16.840.1.114412.2.1
+                  CPS: https://www.digicert.com/CPS
+                Policy: ROLE_CA
+                Policy: ROLE_CBSD
+
+Certificate is to be certified until Mar 14 15:59:08 2033 GMT (5475 days)
+
+Write out database with 1 new entries
+Data Base Updated
+Using configuration from ../../../cert/openssl.cnf
+Check that the request matches the signature
+Signature ok
+Certificate Details:
+        Serial Number:
+            f4:b9:9d:d7:27:21:14:40
+        Validity
+            Not Before: Mar 18 15:59:09 2018 GMT
+            Not After : Mar 14 15:59:09 2033 GMT
+        Subject:
+            countryName               = US
+            stateOrProvinceName       = District of Columbia
+            localityName              = Washington
+            organizationName          = Wireless Innovation Forum
+            organizationalUnitName    = www.wirelessinnovation.org
+            commonName                = WInnForum ECC CBSD CA-1
+        X509v3 extensions:
+            X509v3 Subject Key Identifier:
+                D4:44:F2:CD:99:D4:24:0D:47:B5:EB:3A:BE:91:3B:8D:A8:0E:5E:4E
+            X509v3 Authority Key Identifier:
+                keyid:E0:5E:23:72:C1:35:5B:DC:05:32:19:D3:02:49:8D:C2:BD:B7:AA:69
+
+            X509v3 Basic Constraints: critical
+                CA:TRUE, pathlen:1
+            X509v3 Key Usage: critical
+                Digital Signature, Certificate Sign, CRL Sign
+            X509v3 Certificate Policies:
+                Policy: 2.16.840.1.114412.2.1
+                  CPS: https://www.digicert.com/CPS
+                Policy: ROLE_CA
+                Policy: ROLE_CBSD
+
+Certificate is to be certified until Mar 14 15:59:09 2033 GMT (5475 days)
+\n\nGenerate 'certs for devices' certificate/key
+Generating a 2048 bit RSA private key
+..........+++
+..................................+++
+writing new private key to 'device_a.key'
+-----
+Using configuration from ../../../cert/openssl.cnf
+Check that the request matches the signature
+Signature ok
+Certificate Details:
+        Serial Number:
+            f4:b9:9d:d7:27:21:14:45
+        Validity
+            Not Before: Mar 18 15:59:10 2018 GMT
+            Not After : Jun 15 15:59:10 2021 GMT
+        Subject:
+            countryName               = US
+            stateOrProvinceName       = District of Columbia
+            localityName              = Washington
+            organizationName          = Wireless Innovation Forum
+            organizationalUnitName    = www.wirelessinnovation.org
+            commonName                = device_a
+        X509v3 extensions:
+            X509v3 Subject Key Identifier:
+                2E:AA:66:B6:21:D6:CD:40:40:32:88:BD:B4:1A:32:94:58:10:EA:CF
+            X509v3 Authority Key Identifier:
+                keyid:EB:86:4E:70:E5:3E:AF:D0:89:95:29:BF:F8:4C:AE:CA:A0:80:01:32
+
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment, CRL Sign
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Certificate Policies:
+                Policy: 2.16.840.1.114412.2.1
+                  CPS: https://www.digicert.com/CPS
+                Policy: ROLE_CBSD
+
+            X509v3 CRL Distribution Points:
+
+                Full Name:
+                   <b>URI:http://localhost:9007/ca.crl</b>
+
+Certificate is to be certified until Jun 15 15:59:10 2021 GMT (1185 days)
+
+Write out database with 1 new entries
+Data Base Updated
+Generating a 2048 bit RSA private key
+.......................................+++
+..........................................+++
+writing new private key to 'device_c.key'
+-----
+Using configuration from ../../../cert/openssl.cnf
+Check that the request matches the signature
+Signature ok
+Certificate Details:
+        Serial Number:
+            f4:b9:9d:d7:27:21:14:46
+        Validity
+            Not Before: Mar 18 15:59:10 2018 GMT
+            Not After : Jun 15 15:59:10 2021 GMT
+        Subject:
+            countryName               = US
+            stateOrProvinceName       = District of Columbia
+            localityName              = Washington
+            organizationName          = Wireless Innovation Forum
+            organizationalUnitName    = www.wirelessinnovation.org
+            commonName                = device_c
+        X509v3 extensions:
+            X509v3 Subject Key Identifier:
+                BC:A3:10:06:92:43:1A:84:4E:EA:85:E2:E4:5B:8F:4C:7D:7E:F2:EB
+            X509v3 Authority Key Identifier:
+                keyid:EB:86:4E:70:E5:3E:AF:D0:89:95:29:BF:F8:4C:AE:CA:A0:80:01:32
+
+            X509v3 Basic Constraints:
+                CA:FALSE
+            X509v3 Key Usage: critical
+                Digital Signature, Key Encipherment, CRL Sign
+            X509v3 Extended Key Usage:
+                TLS Web Client Authentication
+            X509v3 Certificate Policies:
+                Policy: 2.16.840.1.114412.2.1
+                  CPS: https://www.digicert.com/CPS
+                Policy: ROLE_CBSD
+
+            X509v3 CRL Distribution Points:
+
+                Full Name:
+                  <b>URI:http://localhost:9007/ca.crl</b>
+
+Certificate is to be certified until Jun 15 15:59:10 2021 GMT (1185 days)
+
+Write out database with 1 new entries
+Data Base Updated
+\n\nGenerate 'ca' bundle
+<b>[INFO] 2018-03-18 21:29:55,879 The certs are regenerated successfully</b> 
+\n\n Generate CRL for root_ca
+Using configuration from ../../../cert/openssl.cnf
+\n\n Generate CRL for sas_ca
+Using configuration from ../../../cert/openssl.cnf
+\n\n Generate CRL for proxy_ca
+Using configuration from ../../../cert/openssl.cnf
+\n\n Generate CRL for cbsd_ca
+Using configuration from ../../../cert/openssl.cnf
+<b>[INFO] 2018-03-18 21:29:56,020 crl/ca.crl CRL chain is created successfully</b>
+
+</code>
+</pre>
+
+
+The various certificates follow the PKI structure defined on the "CBRS COMSEC TS
+WINNF-15-S-0065" document. Naming and base configuration are issued from
+https://github.com/Wireless-Innovation-Forum/Spectrum-Access-System/tree/master/cert

--- a/src/harness/CRLServer-README.md
+++ b/src/harness/CRLServer-README.md
@@ -19,7 +19,7 @@ generate the certificates with the updated extension field.
 Go to harness directory and execute **python simple_crl_server.py**<br/>
 The simple CRL server will start and generate a CRL file based on the contents from the **harness/certs**
 directory.<br/> The crl file will not have any certificates revoked when started for the first time.<br/>
-The ca.crl file at the location "certs/XXXX" will be served by this simple CRL server.<br/>
+The ca.crl file at the location "harness/certs/crl" will be served by this simple CRL server.<br/>
 <pre>
 <code>
 $ python simple_crl_server.py 

--- a/src/harness/certs/generate_fake_certs.sh
+++ b/src/harness/certs/generate_fake_certs.sh
@@ -4,6 +4,7 @@
 sed -i '/TEST = critical, ASN1:NULL/d' ../../../cert/openssl.cnf
 
 # Setup: build intermediate directories.
+rm -rf crl/
 mkdir private
 mkdir root
 touch index.txt
@@ -407,7 +408,5 @@ cat cbsd_ca.cert proxy_ca.cert sas_ca.cert root_ca.cert cbsd-ecc_ca.cert sas-ecc
 #   cat sas_ca.cert >>  server.cert
 
 # cleanup: remove all files not directly used by the testcases.
-rm -rf private
 rm -rf root
-rm index.txt*
 rm *.csr

--- a/src/harness/certs/revoke_and_generate_crl.sh
+++ b/src/harness/certs/revoke_and_generate_crl.sh
@@ -1,0 +1,57 @@
+#!/bin/bash 
+
+mkdir -p crl
+
+function blacklist_certificate()
+{
+#   Argument1: Name of the certificate to be  blacklisted
+#   Argument2: Intermediate CA to generate CRL.
+    openssl ca -revoke $1 -keyfile private/$2.key -cert $2.cert \
+    -config ../../../cert/openssl.cnf
+    generate_crl_chain
+}
+
+function generate_crl_chain()
+{
+
+#Create a CRL for root CA containing the revoked intermediate CA certificate
+echo "\n\n Generate CRL for root_ca"
+openssl ca -gencrl -keyfile private/root_ca.key -cert root_ca.cert \
+     -config ../../../cert/openssl.cnf  -crlhours 1\
+     -out crl/root_ca.crl
+
+#Creating CRL for blacklisted certificates SxS.11 test cases
+echo "\n\n Generate CRL for sas_ca"
+openssl ca -gencrl -keyfile private/sas_ca.key -cert sas_ca.cert \
+     -config ../../../cert/openssl.cnf -crlhours 1 \
+     -out crl/sas_ca.crl
+
+echo "\n\n Generate CRL for proxy_ca"
+openssl ca -gencrl -keyfile private/proxy_ca.key -cert proxy_ca.cert \
+     -config ../../../cert/openssl.cnf -crlhours 1 \
+     -out crl/proxy_ca.crl
+
+echo "\n\n Generate CRL for cbsd_ca"
+openssl ca -gencrl -keyfile private/cbsd_ca.key -cert cbsd_ca.cert \
+     -config ../../../cert/openssl.cnf -crlhours 1 \
+     -out crl/cbsd_ca.crl
+
+#Create CA certificate chain containing the  CRLs with revoked leaf certificates
+cat crl/cbsd_ca.crl crl/sas_ca.crl crl/proxy_ca.crl crl/root_ca.crl > crl/ca.crl
+
+}
+
+# Argument1 : Type (CBSD,DP,SAS,-u)
+if [ "$1" == "CBSD"  ]; then
+    blacklist_certificate  $2 cbsd_ca
+elif [ "$1" == "DP"  ]; then
+    blacklist_certificate  $2 proxy_ca
+elif [ "$1" == "SAS"  ]; then
+    blacklist_certificate  $2 sas_ca
+elif [ "$1" == "-u"  ]; then
+    generate_crl_chain
+else
+    echo "wrong option other than (CBSD,DP,SAS,-r)"
+    exit -1
+fi
+

--- a/src/harness/certs/revoke_and_generate_crl.sh
+++ b/src/harness/certs/revoke_and_generate_crl.sh
@@ -40,13 +40,13 @@ function generate_crl_chain()
 }
 
 #Argument1 : Type (CBSD,DP,SAS,-u)
-if [ $1 == "CBSD" ]; then
+if [ "$1" == "CBSD" ]; then
   blacklist_certificate  $2 cbsd_ca
-elif [ $1 == "DP" ]; then
+elif [ "$1" == "DP" ]; then
   blacklist_certificate  $2 proxy_ca
-elif [ $1 == "SAS" ]; then
+elif [ "$1" == "SAS" ]; then
   blacklist_certificate  $2 sas_ca
-elif [ $1 == "-u" ]; then
+elif [ "$1" == "-u" ]; then
   generate_crl_chain
 else
   echo "Wrong option other than (CBSD,DP,SAS,-u)"

--- a/src/harness/certs/revoke_and_generate_crl.sh
+++ b/src/harness/certs/revoke_and_generate_crl.sh
@@ -16,21 +16,21 @@ function blacklist_certificate()
 function generate_crl_chain()
 {
   #Create a CRL for root CA containing the revoked intermediate CA certificate.
-  echo "\n\n Generate CRL for root_ca"
+  echo -e "\n\n Generate CRL for root_ca"
   openssl ca -gencrl -keyfile private/root_ca.key -cert root_ca.cert \
       -config ../../../cert/openssl.cnf -crlhours 1 \
       -out crl/root_ca.crl
 
   #Creating CRL for blacklisted certificates SxS.11 test cases.
-  echo "\n\n Generate CRL for sas_ca"
+  echo -e "\n\n Generate CRL for sas_ca"
   openssl ca -gencrl -keyfile private/sas_ca.key -cert sas_ca.cert \
       -config ../../../cert/openssl.cnf -crlhours 1 \
       -out crl/sas_ca.crl
-  echo "\n\n Generate CRL for proxy_ca"
+  echo -e "\n\n Generate CRL for proxy_ca"
   openssl ca -gencrl -keyfile private/proxy_ca.key -cert proxy_ca.cert \
       -config ../../../cert/openssl.cnf -crlhours 1 \
       -out crl/proxy_ca.crl
-  echo "\n\n Generate CRL for cbsd_ca"
+  echo -e "\n\n Generate CRL for cbsd_ca"
   openssl ca -gencrl -keyfile private/cbsd_ca.key -cert cbsd_ca.cert \
       -config ../../../cert/openssl.cnf -crlhours 1 \
       -out crl/cbsd_ca.crl

--- a/src/harness/certs/revoke_and_generate_crl.sh
+++ b/src/harness/certs/revoke_and_generate_crl.sh
@@ -4,54 +4,51 @@ mkdir -p crl
 
 function blacklist_certificate()
 {
-#   Argument1: Name of the certificate to be  blacklisted
-#   Argument2: Intermediate CA to generate CRL.
-    openssl ca -revoke $1 -keyfile private/$2.key -cert $2.cert \
-    -config ../../../cert/openssl.cnf
-    generate_crl_chain
+  #Argument1: Name of the certificate to be  blacklisted.
+  #Argument2: Intermediate CA to generate CRL.
+
+  # Revoke certificate.
+  openssl ca -revoke $1 -keyfile private/$2.key -cert $2.cert \
+      -config ../../../cert/openssl.cnf
+  generate_crl_chain
 }
 
 function generate_crl_chain()
 {
+  #Create a CRL for root CA containing the revoked intermediate CA certificate.
+  echo "\n\n Generate CRL for root_ca"
+  openssl ca -gencrl -keyfile private/root_ca.key -cert root_ca.cert \
+      -config ../../../cert/openssl.cnf -crlhours 1 \
+      -out crl/root_ca.crl
 
-#Create a CRL for root CA containing the revoked intermediate CA certificate
-echo "\n\n Generate CRL for root_ca"
-openssl ca -gencrl -keyfile private/root_ca.key -cert root_ca.cert \
-     -config ../../../cert/openssl.cnf  -crlhours 1\
-     -out crl/root_ca.crl
+  #Creating CRL for blacklisted certificates SxS.11 test cases.
+  echo "\n\n Generate CRL for sas_ca"
+  openssl ca -gencrl -keyfile private/sas_ca.key -cert sas_ca.cert \
+      -config ../../../cert/openssl.cnf -crlhours 1 \
+      -out crl/sas_ca.crl
+  echo "\n\n Generate CRL for proxy_ca"
+  openssl ca -gencrl -keyfile private/proxy_ca.key -cert proxy_ca.cert \
+      -config ../../../cert/openssl.cnf -crlhours 1 \
+      -out crl/proxy_ca.crl
+  echo "\n\n Generate CRL for cbsd_ca"
+  openssl ca -gencrl -keyfile private/cbsd_ca.key -cert cbsd_ca.cert \
+      -config ../../../cert/openssl.cnf -crlhours 1 \
+      -out crl/cbsd_ca.crl
 
-#Creating CRL for blacklisted certificates SxS.11 test cases
-echo "\n\n Generate CRL for sas_ca"
-openssl ca -gencrl -keyfile private/sas_ca.key -cert sas_ca.cert \
-     -config ../../../cert/openssl.cnf -crlhours 1 \
-     -out crl/sas_ca.crl
-
-echo "\n\n Generate CRL for proxy_ca"
-openssl ca -gencrl -keyfile private/proxy_ca.key -cert proxy_ca.cert \
-     -config ../../../cert/openssl.cnf -crlhours 1 \
-     -out crl/proxy_ca.crl
-
-echo "\n\n Generate CRL for cbsd_ca"
-openssl ca -gencrl -keyfile private/cbsd_ca.key -cert cbsd_ca.cert \
-     -config ../../../cert/openssl.cnf -crlhours 1 \
-     -out crl/cbsd_ca.crl
-
-#Create CA certificate chain containing the  CRLs with revoked leaf certificates
-cat crl/cbsd_ca.crl crl/sas_ca.crl crl/proxy_ca.crl crl/root_ca.crl > crl/ca.crl
-
+  #Create CA certificate chain containing the CRLs of revoked leaf certificates.
+  cat crl/cbsd_ca.crl crl/sas_ca.crl crl/proxy_ca.crl crl/root_ca.crl > crl/ca.crl
 }
 
-# Argument1 : Type (CBSD,DP,SAS,-u)
-if [ "$1" == "CBSD"  ]; then
-    blacklist_certificate  $2 cbsd_ca
-elif [ "$1" == "DP"  ]; then
-    blacklist_certificate  $2 proxy_ca
-elif [ "$1" == "SAS"  ]; then
-    blacklist_certificate  $2 sas_ca
-elif [ "$1" == "-u"  ]; then
-    generate_crl_chain
+#Argument1 : Type (CBSD,DP,SAS,-u)
+if [ $1 == "CBSD" ]; then
+  blacklist_certificate  $2 cbsd_ca
+elif [ $1 == "DP" ]; then
+  blacklist_certificate  $2 proxy_ca
+elif [ $1 == "SAS" ]; then
+  blacklist_certificate  $2 sas_ca
+elif [ $1 == "-u" ]; then
+  generate_crl_chain
 else
-    echo "wrong option other than (CBSD,DP,SAS,-r)"
-    exit -1
+  echo "Wrong option other than (CBSD,DP,SAS,-u)"
+  exit -1
 fi
-

--- a/src/harness/simple_crl_server.py
+++ b/src/harness/simple_crl_server.py
@@ -12,9 +12,8 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-"""
-  A simple Certificate Revocation List (CRL) server implementation.
-"""
+"""A simple Certificate Revocation List (CRL) server implementation."""
+
 import inspect
 import logging
 import os
@@ -26,7 +25,6 @@ from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
 
 DEFAULT_CRL_URL = 'http://localhost:9007/ca.crl'
 DEFAULT_CRL_SERVER_PORT = 80
-
 CERT_TYPE = {
     '1': 'CBSD',
     '2': 'DP',
@@ -53,50 +51,55 @@ CLI_PROMPT_TEXT = '''CRL Server> '''
 
 
 class SimpleCrlServer(threading.Thread):
-  """Implements a CRL server by creating a HTTP server and
-  serving CRL files The CRL server runs as a separate thread.
+  """Implements a simple CRL server by creating a HTTP server.
+
+  A simple HTTP server that responds with the ca.crl file present in the 'harness/certs/crl/' directory serving CRL files.
+  The CRL server runs as a separate thread.
   """
 
   def __init__(self, crl_url, crl_file_path):
-    """ Constructor for simple CRL Server.
+    """Constructor for simple CRL Server.
 
     Args:
       crl_url: The URL that is mentioned in the CDP extension of the certificates.
         The CRL server runs on this URL and responds only to this URL with the CRL file.
       crl_file_path: Absolute path to the CRL file that will be served by this CRL server.
     """
+
     super(SimpleCrlServer, self).__init__()
     url_components = urlparse(crl_url)
     self.host_name = url_components.hostname
-    self.port = url_components.port if url_components.port is not None else DEFAULT_CRL_SERVER_PORT
+    self.port = url_components.port if url_components.port is not None else \
+      DEFAULT_CRL_SERVER_PORT
     self.crl_url_path = url_components.path
     self.crl_file_path = crl_file_path
     self.setDaemon(True)
 
   def run(self):
-    """ Starts the HTTPServer as background thread.
+    """Starts the HTTPServer as background thread.
 
     The run() method is an overridden method from thread class and it gets invoked
     when the thread is started using thread.start().
     """
 
-    # Setting the parameters for handler class
+    # Setting the parameters for handler class.
     logging.info("Started CRL Server at %s", self.host_name + ":" + str(self.port))
-    self.server = CrlHttpServer(self.crl_url_path, self.crl_file_path, (self.host_name, self.port),
-                                 CrlServerHttpHandler)
+    self.server = CrlHttpServer(self.crl_url_path, self.crl_file_path,
+                                (self.host_name, self.port),
+                                CrlServerHttpHandler)
     self.server.serve_forever()
 
   def stopServer(self):
     """This method is used to stop HTTPServer Socket"""
 
     self.server.shutdown()
-    logging.info('Stopped CRL Server at %s', self.host_name+":" + str(self.port))
-
+    logging.info('Stopped CRL Server at %s', self.host_name + ":" + str(self.port))
 
 class CrlHttpServer(HTTPServer):
-  """The class CrlHttpServer overrides built-in HTTPServer and takes the
-  parameter base_path used to serve the files. This is needed to have CRL Server
-  to serve files from different directories.
+  """The class CrlHttpServer overrides built-in HTTPServer.
+
+  It takes the parameter base_path used to serve the files.
+  This is needed to have CRL Server to serve files from different directories.
   """
 
   def __init__(self, crl_url_path, crl_file_path, server_address, RequestHandlerClass):
@@ -104,12 +107,15 @@ class CrlHttpServer(HTTPServer):
     self.crl_file_path = crl_file_path
     HTTPServer.__init__(self, server_address, RequestHandlerClass)
 
-
 class CrlServerHttpHandler(BaseHTTPRequestHandler):
-  """ This class implements the HTTP handlers for the CRL Server. """
+  """This class implements the HTTP handlers for the CRL Server.
+
+  CrlServerHttpHandler class inherits with BaseHTTPRequestHandler
+  to serve HTTP Response.
+  """
 
   def do_GET(self):
-    """ Handles Pull/GET Request and returns Path of the Request to callback Method. """
+    """Handles Pull/GET Request and returns path of the request to callback method."""
 
     parsed_path = urlparse(self.path)
     self.log_message('Received GET Request:{}'.format(parsed_path.path))
@@ -117,64 +123,61 @@ class CrlServerHttpHandler(BaseHTTPRequestHandler):
     # Handles the GET Requests.
     # If the GET request path does not match the CRL URL path then respond with 404 response.
     if parsed_path.path != self.server.crl_url_path:
-      self.log_message('Requested url :{0} does not match with CRL Server URL path:{1}'.format(
-        parsed_path.path, self.server.crl_url_path))
+      self.log_message('Requested url :{0} does not match with CRL Server URL '
+                       'path:{1}'.format(parsed_path.path, self.server.crl_url_path))
       self.send_response(404)
       return
 
-    # If the crl_file_path does not exist then respond with 404 response.
-    if not os.path.exists(self.server.crl_file_path):
-      self.log_message('Requested file:{} not found'.format(self.server.crl_file_path))
+    # Load the ca.crl and write content in HTTP response stream with 200 OK response.
+    # If any exception occurs while reading CRL chain and handle error and respond
+    # with 404 'Not Found' response.
+    try:
+      with open(os.path.join(self.server.crl_file_path)) as file_handle:
+        self.wfile.write(file_handle.read())
+    except IOError:
+      self.log_message('There is an error reading file:{}'.format(
+          self.server.crl_file_path))
       self.send_response(404)
       return
-    self.send_response(200)
-    self.send_header("Content-type", "application/pkix-crl")
-    self.end_headers()
-    with open(os.path.join(self.server.crl_file_path)) as file_handle:
-      self.wfile.write(file_handle.read())
+    else:
+      self.send_response(200)
+      self.send_header("Content-type", "application/pkix-crl")
+      self.end_headers()
+      return
 
 def getCertsDirectoryAbsolutePath():
-  """ This function will return absolute path of certs directory. """
+  """This function will return absolute path of 'certs' directory."""
 
   harness_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
   path = os.path.join(harness_dir, 'certs')
   return path
 
-def generateCrlChain():
-  """ Generates the CRL for all intermediate CAs and root CA and then concatenates them. """
+def getCertificateNameToBlacklist():
+  """Allows the user to select the certificate to blacklist from a displayed list."""
 
-  revoke_cert_command = "cd {0} && ./revoke_and_generate_crl.sh -u".format(
-      getCertsDirectoryAbsolutePath())
-  command_exit_status = subprocess.call(revoke_cert_command, shell=True)
-  if command_exit_status:
-    raise Exception("RunTimeError:Generate CRL Chain is failed:exit_code:{}".format(
-        command_exit_status))
-
-def getCertNameToBlacklist():
-  """ Allows the user to select the certificate to blacklist from a displayed list. """
-
-  # Gets the all certificate files that are ends with .cert present in the default certs directory.
-  cert_files = [cert_file_name for cert_file_name in os.listdir(getCertsDirectoryAbsolutePath())
-                if cert_file_name.endswith('.cert')]
+  # Gets the all certificate files that are ends with .cert present in the
+  # default certs directory.
+  cert_files = [cert_file_name for cert_file_name in os.listdir(
+      getCertsDirectoryAbsolutePath()) if cert_file_name.endswith('.cert')]
 
   # Creates the mapping menu ID for each certificate file to displayed list.
   cert_files_with_options = dict(zip(range(len(cert_files)), sorted(cert_files)))
-  print "select the certificate to blacklist:"
+  print "Select the certificate to blacklist:"
   print "\n".join("[%s] %s" % (cert_file_option_id, cert_file_name)
                   for (cert_file_option_id, cert_file_name) in
                   sorted(cert_files_with_options.iteritems()))
   option_id = int(raw_input(CLI_PROMPT_TEXT))
   if option_id not in cert_files_with_options:
-    raise Exception('RunTimeError:Invalid input:{}. Please select valid '
+    raise Exception('RunTimeError:Invalid input:{}. Please select a valid '
                     'certificate'.format(option_id))
   return cert_files_with_options[option_id]
 
 
 def revokeCertificate():
-  """ Revokes a leaf certificate and updates the CRL chain file. """
+  """Revokes a leaf certificate and updates the CRL chain file."""
 
   # Retrives the all certificates from certs directory.
-  cert_name = getCertNameToBlacklist()
+  cert_name = getCertificateNameToBlacklist()
   logging.info('Certificate selected to blacklist is:%s', cert_name)
   print "select the certificate type:"
   print "\n".join("[%s] %s" % (cert_id, cert_type)
@@ -195,21 +198,24 @@ def revokeCertificate():
   logging.info('%s is blacklisted successfully', cert_name)
 
 
-def updateCrlUrlAndRegenerateCerts():
-  """ Updates URI.0 field in the in openssl.cnf file with the CRL URL of this simple CRL server and
-  regenerates the certificates. """
+def updateCrlUrlAndRegenerateCertificates():
+  """Updates the CDP  field and re-generates certificates.
+
+  Updates URI.0 field in the in openssl.cnf file with the CRL URL of this simple CRL
+  server. Invokes the generate_fake_certs.sh script to regenerate all certificates.
+  """
 
   # Update CRL URL in openssl.cnf.
   crl_url = 'URI.0 = {}'.format(DEFAULT_CRL_URL)
-  update_crl_section_command = 'sed -i -e \'s~^URI.0\\s=\\s.*$~{}\'~1 ../../cert/openssl.cnf'.\
-    format(crl_url)
+  update_crl_section_command = (r"sed -i -e 's~^URI.0\s=\s.*$~%s'~1 ../../cert/openssl.cnf"
+                                % crl_url)
   command_exit_status = subprocess.call(update_crl_section_command, shell=True)
   if command_exit_status:
     raise Exception("RunTimeError:Could not update CRL URL in openssl.cnf:"
                     "exit_code:{}".format(command_exit_status))
   logging.info('CRL URL has been updated correctly in openssl.cnf')
 
-  # Re-generate certs.
+  # Re-generate certificates.
   script_name = './generate_fake_certs.sh'
   command = 'cd {0} && {1}'.format(getCertsDirectoryAbsolutePath(), script_name)
   command_exit_status = subprocess.call(command, shell=True)
@@ -218,40 +224,46 @@ def updateCrlUrlAndRegenerateCerts():
                     "exit_code:{}".format(command_exit_status))
   logging.info("The certs are regenerated successfully")
 
-  # Generates CRL Chain.
+  # Generate CRL Chain.
   generateCrlChain()
 
 
 def generateCrlChain():
-  """ It creates a CRL file for the intermediate CAs (CBSD CA, DP CA and SAS CA) and the root CA.
-  All the CRL files are concatenated to create CRL chain file named ca.crl and
-  placed in the harness/certs/crl/ directory. """
+  """ Generate CRL Chain for the intermediate CAs.
 
-  create_crl_chain_command = "cd {0} && ./revoke_and_generate_crl.sh -u".format(getCertsDirectoryAbsolutePath())
+  It creates a CRL file for the intermediate CAs (CBSD CA, DP CA and SAS CA) and the root CA.
+  All the CRL files are concatenated to create CRL chain file named ca.crl and
+  placed in the 'harness/certs/crl/' directory.
+  """
+
+  create_crl_chain_command = "cd {0} && ./revoke_and_generate_crl.sh -u".format(
+      getCertsDirectoryAbsolutePath())
   command_exit_status = subprocess.call(create_crl_chain_command, shell=True)
   if command_exit_status:
     raise Exception("RunTimeError:Creation CRL chain is failed:"
                     "exit_code:{}".format(command_exit_status))
-  if not os.path.exists(os.path.join(getCertsDirectoryAbsolutePath(), 'crl/ca.crl')):
+  if not os.path.exists(os.path.join(getCertsDirectoryAbsolutePath(),
+                                     'crl/ca.crl')):
     raise Exception("RunTimeError:crl/ca.crl is not found:"
                     "exit_code:{}".format(command_exit_status))
   logging.info('crl/ca.crl CRL chain is created successfully')
 
 
 def crlServerStart():
-  """ Start CRL server. """
+  """Start CRL server."""
 
-  # Create CRL chain for all intermediate certs CBSD,DP and SAS
+  # Create CRL chain containing CRLs of sub CAs and root CA.
   generateCrlChain()
 
-  crl_server = SimpleCrlServer(DEFAULT_CRL_URL, os.path.join(getCertsDirectoryAbsolutePath(), 'crl/ca.crl'))
+  crl_server = SimpleCrlServer(DEFAULT_CRL_URL, os.path.join(getCertsDirectoryAbsolutePath(),
+                                                             'crl/ca.crl'))
   crl_server.start()
   logging.info("CRL Server has been started")
 
   return crl_server
 
 def crlServerStop(crl_server):
-  """ Stop CRL Server.
+  """Stop CRL Server.
 
   Args:
     crl_server: A CRL Server object instance.
@@ -260,8 +272,7 @@ def crlServerStop(crl_server):
   crl_server.stopServer()
 
 def readInput():
-  """ This function is list out menu option supported in crl server and
-  read user input and execute the corresponding selected function. """
+  """Display the CRL server menu and executes the selected option."""
 
   print BANNER_TITLE + MENU_OPTIONS
   choice = raw_input(CLI_PROMPT_TEXT)
@@ -269,11 +280,12 @@ def readInput():
   return
 
 def executeSelectedMenu(choice):
-  """ Performs the action based on the chosen menu item.
+  """Performs the action based on the selected menu item.
 
   Args:
     choice: The selected index value from the main menu of CRL server.
   """
+
   if choice == '':
     MENU_ACTIONS[MENU_ID_MAIN_MENU]()
   else:
@@ -290,7 +302,7 @@ def executeSelectedMenu(choice):
 MENU_ACTIONS = {
     MENU_ID_MAIN_MENU: readInput,
     MENU_ID_REVOKE_CERT: revokeCertificate,
-    MENU_ID_CRL_UPDATE_REGENERATE: updateCrlUrlAndRegenerateCerts,
+    MENU_ID_CRL_UPDATE_REGENERATE: updateCrlUrlAndRegenerateCertificates,
     MENU_ID_QUIT: exit
 }
 

--- a/src/harness/simple_crl_server.py
+++ b/src/harness/simple_crl_server.py
@@ -260,7 +260,7 @@ def crlServerStart():
 
   try:
     crl_server = SimpleCrlServer(DEFAULT_CRL_URL, os.path.join(getCertsDirectoryAbsolutePath(),
-                                                             'crl/ca.crl'))
+                                                               'crl/ca.crl'))
     crl_server.start()
     logging.info("CRL Server has been started")
     logging.info('CRL Server URL:%s' % DEFAULT_CRL_URL)

--- a/src/harness/simple_crl_server.py
+++ b/src/harness/simple_crl_server.py
@@ -1,0 +1,105 @@
+#    Copyright 2018 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""
+    A implementation of Certificate Revocation list Server.
+"""
+import logging
+import os
+import threading
+import urlparse
+from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
+
+
+class CrlServerTestHarness(threading.Thread):
+  """
+  Implements a CRL server by creating a HTTP server and
+  serving CRL files The  CRL server runs as a separate thread
+  """
+
+  def __init__(self, host_name, port, crl_url, crl_file_name):
+    """
+    Constructor for  CRL test harness Requests from SAS Under Test
+    Args:
+        "host_name": Entity hosting the  crl server
+        "port"    : Port number at which  crl server will run
+        "crl_url" :  Name of the crl url to be validated
+        "crl_file_name" : Name of the crl file
+    Returns
+    """
+    super(CrlServerTestHarness, self).__init__()
+    self.host_name = host_name
+    self.port = int(port)
+    self.crl_url = crl_url
+    self.crl_file_name = crl_file_name
+    self.setDaemon(True)
+
+  def run(self):
+    """
+    Starts the HTTPServer as background thread.
+    The run() method is an overridden method from thread class and it gets invoked
+    when the thread is started using thread.start().
+    """
+    # Setting the parameters for handler class
+    logging.info("Started  CRL Server at %s",
+                 self.host_name + ":" + str(self.port))
+    self.server = CrlHttpServer(self.crl_url, self.crl_file_name,
+                                (self.host_name, self.port),
+                                CrlServerTestHarnessHandler)
+    self.server.serve_forever()
+
+  def stopServer(self):
+    """
+    This method is used to stop HTTPServer Socket
+    """
+    self.server.shutdown()
+    logging.info('Stopped CRL Server at %s',
+                 self.host_name+":" + str(self.port))
+
+
+class CrlHttpServer(HTTPServer):
+  """ The class CrlHttpServer overrides built-in HTTPServer and takes the
+  parameter base_path used to serve the files. This is needed to have CRL Server
+  to server files from different directories.
+  """
+  def __init__(self, crl_url, crl_file_name, server_address, RequestHandlerClass):
+    self.crl_url = crl_url
+    self.crl_file_name = crl_file_name
+    HTTPServer.__init__(self, server_address, RequestHandlerClass)
+
+
+class CrlServerTestHarnessHandler(BaseHTTPRequestHandler):
+  """
+  CrlServerTestHarnessHandler class is inherited with BaseHTTPRequestHandler
+  to serve HTTP Response.
+  """
+
+  def do_GET(self):
+    """
+    Handles Pull/GET Request and returns Path of the Request to callback Method.
+    """
+
+    parsed_path = urlparse.urlparse(self.path)
+    self.log_message('Received GET Request:{}'.format(parsed_path.path))
+    if parsed_path.path == self.server.crl_url:
+      # Handles the GET Requests
+      if not os.path.exists(self.server.crl_file_name):
+        self.log_message('Requested file:{} not found'.format(parsed_path.path))
+        self.send_response(404)
+        return
+      self.send_response(200)
+      self.send_header("Content-type", "application/pkix-crl")
+      self.end_headers()
+      with open(self.server.crl_file_name) as file_handle:
+        self.wfile.write(file_handle.read())

--- a/src/harness/simple_crl_server.py
+++ b/src/harness/simple_crl_server.py
@@ -1,105 +1,308 @@
-#    Copyright 2018 SAS Project Authors. All Rights Reserved.
+#  Copyright 2018 SAS Project Authors. All Rights Reserved.
 #
-#    Licensed under the Apache License, Version 2.0 (the "License");
-#    you may not use this file except in compliance with the License.
-#    You may obtain a copy of the License at
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
 #
-#        http://www.apache.org/licenses/LICENSE-2.0
+#    http://www.apache.org/licenses/LICENSE-2.0
 #
-#    Unless required by applicable law or agreed to in writing, software
-#    distributed under the License is distributed on an "AS IS" BASIS,
-#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-#    See the License for the specific language governing permissions and
-#    limitations under the License.
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
 
 """
-    A implementation of Certificate Revocation list Server.
+  A simple Certificate Revocation List (CRL) server implementation.
 """
+import inspect
 import logging
 import os
+import sys
+import subprocess
 import threading
-import urlparse
+from urlparse import urlparse
 from BaseHTTPServer import HTTPServer, BaseHTTPRequestHandler
 
+DEFAULT_CRL_URL = 'http://localhost:9007/ca.crl'
+DEFAULT_CRL_SERVER_PORT = 80
 
-class CrlServerTestHarness(threading.Thread):
-  """
-  Implements a CRL server by creating a HTTP server and
-  serving CRL files The  CRL server runs as a separate thread
+CERT_TYPE = {
+    '1': 'CBSD',
+    '2': 'DP',
+    '3': 'SAS'
+}
+MENU_ACTIONS = {}
+MENU_ID_MAIN_MENU = '-1'
+MENU_ID_QUIT = '0'
+MENU_ID_REVOKE_CERT = '1'
+MENU_ID_CRL_UPDATE_REGENERATE = '2'
+BANNER_TITLE = r'''   _____ _____  _         _____
+  / ____|  __ \| |       / ____|
+ | |    | |__) | |      | (___   ___ _ ____   _____ _ __
+ | |    |  _  /| |       \___ \ / _ \ '__\ \ / / _ \ '__|
+ | |____| | \ \| |____   ____) |  __/ |   \ V /  __/ |
+  \_____|_|  \_\______| |_____/ \___|_|    \_/ \___|_|
+ '''
+MENU_OPTIONS = '''
+Please select the options:
+[1] Revoke Certificate
+[2] Update CRL URL and Re-generate certificates
+[0] Quit'''
+CLI_PROMPT_TEXT = '''CRL Server> '''
+
+
+class SimpleCrlServer(threading.Thread):
+  """Implements a CRL server by creating a HTTP server and
+  serving CRL files The CRL server runs as a separate thread.
   """
 
-  def __init__(self, host_name, port, crl_url, crl_file_name):
-    """
-    Constructor for  CRL test harness Requests from SAS Under Test
+  def __init__(self, crl_url, crl_file_path):
+    """ Constructor for simple CRL Server.
+
     Args:
-        "host_name": Entity hosting the  crl server
-        "port"    : Port number at which  crl server will run
-        "crl_url" :  Name of the crl url to be validated
-        "crl_file_name" : Name of the crl file
-    Returns
+      crl_url: The URL that is mentioned in the CDP extension of the certificates.
+        The CRL server runs on this URL and responds only to this URL with the CRL file.
+      crl_file_path: Absolute path to the CRL file that will be served by this CRL server.
     """
-    super(CrlServerTestHarness, self).__init__()
-    self.host_name = host_name
-    self.port = int(port)
-    self.crl_url = crl_url
-    self.crl_file_name = crl_file_name
+    super(SimpleCrlServer, self).__init__()
+    url_components = urlparse(crl_url)
+    self.host_name = url_components.hostname
+    self.port = url_components.port if url_components.port is not None else DEFAULT_CRL_SERVER_PORT
+    self.crl_url_path = url_components.path
+    self.crl_file_path = crl_file_path
     self.setDaemon(True)
 
   def run(self):
-    """
-    Starts the HTTPServer as background thread.
+    """ Starts the HTTPServer as background thread.
+
     The run() method is an overridden method from thread class and it gets invoked
     when the thread is started using thread.start().
     """
+
     # Setting the parameters for handler class
-    logging.info("Started  CRL Server at %s",
-                 self.host_name + ":" + str(self.port))
-    self.server = CrlHttpServer(self.crl_url, self.crl_file_name,
-                                (self.host_name, self.port),
-                                CrlServerTestHarnessHandler)
+    logging.info("Started CRL Server at %s", self.host_name + ":" + str(self.port))
+    self.server = CrlHttpServer(self.crl_url_path, self.crl_file_path, (self.host_name, self.port),
+                                 CrlServerHttpHandler)
     self.server.serve_forever()
 
   def stopServer(self):
-    """
-    This method is used to stop HTTPServer Socket
-    """
+    """This method is used to stop HTTPServer Socket"""
+
     self.server.shutdown()
-    logging.info('Stopped CRL Server at %s',
-                 self.host_name+":" + str(self.port))
+    logging.info('Stopped CRL Server at %s', self.host_name+":" + str(self.port))
 
 
 class CrlHttpServer(HTTPServer):
-  """ The class CrlHttpServer overrides built-in HTTPServer and takes the
+  """The class CrlHttpServer overrides built-in HTTPServer and takes the
   parameter base_path used to serve the files. This is needed to have CRL Server
-  to server files from different directories.
+  to serve files from different directories.
   """
-  def __init__(self, crl_url, crl_file_name, server_address, RequestHandlerClass):
-    self.crl_url = crl_url
-    self.crl_file_name = crl_file_name
+
+  def __init__(self, crl_url_path, crl_file_path, server_address, RequestHandlerClass):
+    self.crl_url_path = crl_url_path
+    self.crl_file_path = crl_file_path
     HTTPServer.__init__(self, server_address, RequestHandlerClass)
 
 
-class CrlServerTestHarnessHandler(BaseHTTPRequestHandler):
-  """
-  CrlServerTestHarnessHandler class is inherited with BaseHTTPRequestHandler
-  to serve HTTP Response.
-  """
+class CrlServerHttpHandler(BaseHTTPRequestHandler):
+  """ This class implements the HTTP handlers for the CRL Server. """
 
   def do_GET(self):
-    """
-    Handles Pull/GET Request and returns Path of the Request to callback Method.
-    """
+    """ Handles Pull/GET Request and returns Path of the Request to callback Method. """
 
-    parsed_path = urlparse.urlparse(self.path)
+    parsed_path = urlparse(self.path)
     self.log_message('Received GET Request:{}'.format(parsed_path.path))
-    if parsed_path.path == self.server.crl_url:
-      # Handles the GET Requests
-      if not os.path.exists(self.server.crl_file_name):
-        self.log_message('Requested file:{} not found'.format(parsed_path.path))
-        self.send_response(404)
-        return
-      self.send_response(200)
-      self.send_header("Content-type", "application/pkix-crl")
-      self.end_headers()
-      with open(self.server.crl_file_name) as file_handle:
-        self.wfile.write(file_handle.read())
+
+    # Handles the GET Requests.
+    # If the GET request path does not match the CRL URL path then respond with 404 response.
+    if parsed_path.path != self.server.crl_url_path:
+      self.log_message('Requested url :{0} does not match with CRL Server URL path:{1}'.format(
+        parsed_path.path, self.server.crl_url_path))
+      self.send_response(404)
+      return
+
+    # If the crl_file_path does not exist then respond with 404 response.
+    if not os.path.exists(self.server.crl_file_path):
+      self.log_message('Requested file:{} not found'.format(self.server.crl_file_path))
+      self.send_response(404)
+      return
+    self.send_response(200)
+    self.send_header("Content-type", "application/pkix-crl")
+    self.end_headers()
+    with open(os.path.join(self.server.crl_file_path)) as file_handle:
+      self.wfile.write(file_handle.read())
+
+def getCertsDirectoryAbsolutePath():
+  """ This function will return absolute path of certs directory. """
+
+  harness_dir = os.path.dirname(os.path.abspath(inspect.getfile(inspect.currentframe())))
+  path = os.path.join(harness_dir, 'certs')
+  return path
+
+def generateCrlChain():
+  """ Generates the CRL for all intermediate CAs and root CA and then concatenates them. """
+
+  revoke_cert_command = "cd {0} && ./revoke_and_generate_crl.sh -u".format(
+      getCertsDirectoryAbsolutePath())
+  command_exit_status = subprocess.call(revoke_cert_command, shell=True)
+  if command_exit_status:
+    raise Exception("RunTimeError:Generate CRL Chain is failed:exit_code:{}".format(
+        command_exit_status))
+
+def getCertNameToBlacklist():
+  """ Allows the user to select the certificate to blacklist from a displayed list. """
+
+  # Gets the all certificate files that are ends with .cert present in the default certs directory.
+  cert_files = [cert_file_name for cert_file_name in os.listdir(getCertsDirectoryAbsolutePath())
+                if cert_file_name.endswith('.cert')]
+
+  # Creates the mapping menu ID for each certificate file to displayed list.
+  cert_files_with_options = dict(zip(range(len(cert_files)), sorted(cert_files)))
+  print "select the certificate to blacklist:"
+  print "\n".join("[%s] %s" % (cert_file_option_id, cert_file_name)
+                  for (cert_file_option_id, cert_file_name) in
+                  sorted(cert_files_with_options.iteritems()))
+  option_id = int(raw_input(CLI_PROMPT_TEXT))
+  if option_id not in cert_files_with_options:
+    raise Exception('RunTimeError:Invalid input:{}. Please select valid '
+                    'certificate'.format(option_id))
+  return cert_files_with_options[option_id]
+
+
+def revokeCertificate():
+  """ Revokes a leaf certificate and updates the CRL chain file. """
+
+  # Retrives the all certificates from certs directory.
+  cert_name = getCertNameToBlacklist()
+  logging.info('Certificate selected to blacklist is:%s', cert_name)
+  print "select the certificate type:"
+  print "\n".join("[%s] %s" % (cert_id, cert_type)
+                  for (cert_id, cert_type) in sorted(CERT_TYPE.iteritems()))
+  cert_type = raw_input(CLI_PROMPT_TEXT)
+  if cert_type not in CERT_TYPE:
+    raise Exception("RunTimeError:Type of certificate to be blacklisted is incorrect."
+                    "Please select one of the values:%s" % CERT_TYPE.values())
+
+  revoke_cert_command = "cd {0} && ./revoke_and_generate_crl.sh " \
+                        "{1} {2}".format(getCertsDirectoryAbsolutePath(),
+                                         CERT_TYPE[cert_type],
+                                         cert_name)
+  command_exit_status = subprocess.call(revoke_cert_command, shell=True)
+  if command_exit_status:
+    raise Exception("RunTimeError:Certificate Revocation is failed:"
+                    "exit_code:{}".format(command_exit_status))
+  logging.info('%s is blacklisted successfully', cert_name)
+
+
+def updateCrlUrlAndRegenerateCerts():
+  """ Updates URI.0 field in the in openssl.cnf file with the CRL URL of this simple CRL server and
+  regenerates the certificates. """
+
+  # Update CRL URL in openssl.cnf.
+  crl_url = 'URI.0 = {}'.format(DEFAULT_CRL_URL)
+  update_crl_section_command = 'sed -i -e \'s~^URI.0\\s=\\s.*$~{}\'~1 ../../cert/openssl.cnf'.\
+    format(crl_url)
+  command_exit_status = subprocess.call(update_crl_section_command, shell=True)
+  if command_exit_status:
+    raise Exception("RunTimeError:Could not update CRL URL in openssl.cnf:"
+                    "exit_code:{}".format(command_exit_status))
+  logging.info('CRL URL has been updated correctly in openssl.cnf')
+
+  # Re-generate certs.
+  script_name = './generate_fake_certs.sh'
+  command = 'cd {0} && {1}'.format(getCertsDirectoryAbsolutePath(), script_name)
+  command_exit_status = subprocess.call(command, shell=True)
+  if command_exit_status:
+    raise Exception("RunTimeError:Regeneration of certificates failed:"
+                    "exit_code:{}".format(command_exit_status))
+  logging.info("The certs are regenerated successfully")
+
+  # Generates CRL Chain.
+  generateCrlChain()
+
+
+def generateCrlChain():
+  """ It creates a CRL file for the intermediate CAs (CBSD CA, DP CA and SAS CA) and the root CA.
+  All the CRL files are concatenated to create CRL chain file named ca.crl and
+  placed in the harness/certs/crl/ directory. """
+
+  create_crl_chain_command = "cd {0} && ./revoke_and_generate_crl.sh -u".format(getCertsDirectoryAbsolutePath())
+  command_exit_status = subprocess.call(create_crl_chain_command, shell=True)
+  if command_exit_status:
+    raise Exception("RunTimeError:Creation CRL chain is failed:"
+                    "exit_code:{}".format(command_exit_status))
+  if not os.path.exists(os.path.join(getCertsDirectoryAbsolutePath(), 'crl/ca.crl')):
+    raise Exception("RunTimeError:crl/ca.crl is not found:"
+                    "exit_code:{}".format(command_exit_status))
+  logging.info('crl/ca.crl CRL chain is created successfully')
+
+
+def crlServerStart():
+  """ Start CRL server. """
+
+  # Create CRL chain for all intermediate certs CBSD,DP and SAS
+  generateCrlChain()
+
+  crl_server = SimpleCrlServer(DEFAULT_CRL_URL, os.path.join(getCertsDirectoryAbsolutePath(), 'crl/ca.crl'))
+  crl_server.start()
+  logging.info("CRL Server has been started")
+
+  return crl_server
+
+def crlServerStop(crl_server):
+  """ Stop CRL Server.
+
+  Args:
+    crl_server: A CRL Server object instance.
+  """
+
+  crl_server.stopServer()
+
+def readInput():
+  """ This function is list out menu option supported in crl server and
+  read user input and execute the corresponding selected function. """
+
+  print BANNER_TITLE + MENU_OPTIONS
+  choice = raw_input(CLI_PROMPT_TEXT)
+  executeSelectedMenu(choice)
+  return
+
+def executeSelectedMenu(choice):
+  """ Performs the action based on the chosen menu item.
+
+  Args:
+    choice: The selected index value from the main menu of CRL server.
+  """
+  if choice == '':
+    MENU_ACTIONS[MENU_ID_MAIN_MENU]()
+  else:
+    try:
+      MENU_ACTIONS[choice]()
+    except KeyError:
+      print "Invalid selection, please try again"
+    except Exception as err:
+      logging.error(err.message)
+    MENU_ACTIONS[MENU_ID_MAIN_MENU]()
+  return
+
+# Mapping menu items to handler functions.
+MENU_ACTIONS = {
+    MENU_ID_MAIN_MENU: readInput,
+    MENU_ID_REVOKE_CERT: revokeCertificate,
+    MENU_ID_CRL_UPDATE_REGENERATE: updateCrlUrlAndRegenerateCerts,
+    MENU_ID_QUIT: exit
+}
+
+# Set the logger for CRL Server.
+logger = logging.getLogger()
+handler = logging.StreamHandler(sys.stdout)
+handler.setFormatter(logging.Formatter('[%(levelname)s] %(asctime)s %(message)s'))
+logger.addHandler(handler)
+logger.setLevel(logging.INFO)
+
+if __name__ == '__main__':
+  # Start Simple CRL Server and waits for user input.
+  crl_server_instance = crlServerStart()
+  readInput()
+  crlServerStop(crl_server_instance)

--- a/src/harness/simple_crl_server.py
+++ b/src/harness/simple_crl_server.py
@@ -207,7 +207,7 @@ def updateCrlUrlAndRegenerateCertificates():
 
   # Update CRL URL in openssl.cnf.
   crl_url = 'URI.0 = {}'.format(DEFAULT_CRL_URL)
-  update_crl_section_command = (r"sed -i -e 's~^URI.0\s=\s.*$~%s'~1 ../../cert/openssl.cnf"
+  update_crl_section_command = (r"sed -i -e 's~^URI.0\s=\s.*$~%s~1' ../../cert/openssl.cnf"
                                 % crl_url)
   command_exit_status = subprocess.call(update_crl_section_command, shell=True)
   if command_exit_status:


### PR DESCRIPTION
This is a Python implementation of simple CRL server (a.k.a CDP) using native openssl CRL capabilities for test cases like SCS/SDS/SSS.11, SCS/SDS/SSS.16. This server is a light-weighted but fully capable CRL server implemented using Python. The server can be deployed and run independently or can be included in the test codes run -- depends on final decision. 

This is the proposed solution for providing such CRL server capabilities to the ITS in supporting the corresponding test runs. Please review.

A reference of the openssl CRL capabilities can be found in https://jamielinux.com/docs/openssl-certificate-authority/certificate-revocation-lists.html 