### PR TITLE
Injecting FCC IDs for GRA5 before CPAS so SUUT will know about them 

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_GRA_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_GRA_testcase.py
@@ -350,6 +350,12 @@ class GrantTestcase(sas_testcase.SasTestCase):
     grant_g1 = config['grantRequestG1']
     grant_g2 = config['grantRequestG2']
     sas_test_harness_dump_records = [config['sasTestHarnessDumpRecords']['cbsdRecords']]
+    
+    # Inserting FCC IDs on SUUT before CPAS so SUUT will know about them
+    self._sas_admin.InjectFccId({'fccId': device_c1['fccId']})
+    self._sas_admin.InjectFccId({'fccId': device_c2['fccId']})
+
+
 
     # Create the SAS Test Harness.
     sas_test_harness_server = SasTestHarnessServer(


### PR DESCRIPTION
Injecting FCC IDs into SUUT before SUUT does CPAS and gets a FAD that includes them, otherwise SUUT will not know about them.  When we go to register the CBSDs on the next step the FCC IDs will get injected again but the SUUT should just overwrite them without an error