### PR TITLE
Initial IPR.1 testcase

### DIFF
--- a/src/harness/full_activity_dump_helper_test.py
+++ b/src/harness/full_activity_dump_helper_test.py
@@ -25,7 +25,7 @@ class FullActivityDumpHelperTest(unittest.TestCase):
   """Full Activity Dump Helper unit tests."""
 
   @staticmethod
-  def getFullActivityDumpHelper(ssl_cert, ssl_key):
+  def getFullActivityDumpHelper(ssl_cert=None, ssl_key=None):
     """Provides a generic dump to use for tests. Setting the generation date to
        now is needed for SAS UUT unit test.
     """
@@ -55,14 +55,13 @@ class FullActivityDumpHelperTest(unittest.TestCase):
             'version': 'some version',
             'recordType': 'cbsd'
         }],
-        'generationDateTime':
-            '%sZ' % datetime.utcnow().replace(microsecond=0).isoformat(),
+        'generationDateTime': datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%SZ'),
         'description':
             'mock for testing full activity dump'
     }
 
   @staticmethod
-  def downloadFileHelper(url, ssl_cert, ssl_key):
+  def downloadFileHelper(url, ssl_cert=None, ssl_key=None):
     """Helper to return test dump content."""
     logging.debug('CALLED: %s %s %s', url, ssl_cert, ssl_key)
     if url == 'cbsd/cbsd_test_url.json':
@@ -88,7 +87,7 @@ class FullActivityDumpHelperTest(unittest.TestCase):
     mock_sas = FullActivityDumpHelperTest.getMockSasInterface()
     mock_sas_admin = mock.MagicMock()
     fad = full_activity_dump_helper.getFullActivityDumpSasUut(
-        mock_sas, mock_sas_admin, None, None)
+        mock_sas, mock_sas_admin)
     mock_sas.GetFullActivityDump.assert_called()
     mock_sas.DownloadFile.assert_called()
     self.assertDictEqual(
@@ -102,7 +101,7 @@ class FullActivityDumpHelperTest(unittest.TestCase):
     """Tests that a FullActivityDump can be created for a test harness."""
     mock_sas = FullActivityDumpHelperTest.getMockSasInterface()
     fad = full_activity_dump_helper.getFullActivityDumpSasTestHarness(
-        mock_sas, None, None)
+        mock_sas)
     mock_sas.GetFullActivityDump.assert_called_once()
     mock_sas.DownloadFile.assert_called()
     self.assertDictEqual(

--- a/src/harness/sas.py
+++ b/src/harness/sas.py
@@ -27,6 +27,22 @@ def GetTestingSas():
   sas_admin_id = config_parser.get('SasConfig', 'AdminId')
   return SasImpl(base_url, version, sas_admin_id), SasAdminImpl(base_url)
 
+def getDefaultCbsdSSLCertPath():
+  return os.path.join('certs', 'client.cert')
+
+
+def getDefaultCbsdSSLKeyPath():
+  return os.path.join('certs', 'client.key')
+
+
+def getDefaultSasSSLCertPath():
+  return os.path.join('certs', 'client.cert')
+
+
+def getDefaultSasSSLKeyPath():
+  return os.path.join('certs', 'client.key')
+
+
 class SasImpl(sas_interface.SasInterface):
   """Implementation of SasInterface for SAS certification testing."""
 
@@ -56,7 +72,7 @@ class SasImpl(sas_interface.SasInterface):
 
   def GetEscSensorRecord(self, request, ssl_cert=None, ssl_key=None):
     return self._SasRequest('esc_sensor', request, ssl_cert, ssl_key)
-    
+
   def GetFullActivityDump(self, ssl_cert=None, ssl_key=None):
     return self._SasRequest('dump', None, ssl_cert, ssl_key)
 
@@ -66,35 +82,22 @@ class SasImpl(sas_interface.SasInterface):
       url += '/%s' % request
     return RequestGet(url,
                       self._tls_config.WithClientCertificate(
-                          ssl_cert or self._GetDefaultSasSSLCertPath(),
-                          ssl_key or self._GetDefaultSasSSLKeyPath()))
+                          ssl_cert or GetDefaultSasSSLCertPath(),
+                          ssl_key or GetDefaultSasSSLKeyPath()))
 
   def _CbsdRequest(self, method_name, request, ssl_cert=None, ssl_key=None):
     return RequestPost('https://%s/%s/%s' % (self._base_url, self._sas_version,
                                              method_name), request,
                        self._tls_config.WithClientCertificate(
-                           ssl_cert or self._GetDefaultCbsdSSLCertPath(),
-                           ssl_key or self._GetDefaultCbsdSSLKeyPath()))
-    
+                           ssl_cert or GetDefaultCbsdSSLCertPath(),
+                           ssl_key or GetDefaultCbsdSSLKeyPath()))
+
   def DownloadFile(self, url, ssl_cert=None, ssl_key=None):
     return RequestGet(url,
                       self._tls_config.WithClientCertificate(
                           ssl_cert if ssl_cert else
-                          self._GetDefaultSasSSLCertPath(), ssl_key
-                          if ssl_key else self._GetDefaultSasSSLKeyPath()))
-
-  def _GetDefaultCbsdSSLCertPath(self):
-    return os.path.join('certs', 'client.cert')
-
-  def _GetDefaultCbsdSSLKeyPath(self):
-    return os.path.join('certs', 'client.key')
-
-  def _GetDefaultSasSSLCertPath(self):
-    return os.path.join('certs', 'client.cert')
-
-  def _GetDefaultSasSSLKeyPath(self):
-    return os.path.join('certs', 'client.key')
-
+                          GetDefaultSasSSLCertPath(), ssl_key
+                          if ssl_key else GetDefaultSasSSLKeyPath()))
 
 class SasAdminImpl(sas_interface.SasAdminInterface):
   """Implementation of SasAdminInterface for SAS certification testing."""
@@ -221,7 +224,7 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
   def TriggerDpaDeactivation(self, request):
     RequestPost('https://%s/admin/trigger/dpa_deactivation' % self._base_url,
                 request, self._tls_config)
-    
+
   def TriggerFullActivityDump(self):
     RequestPost(
         'https://%s/admin/trigger/create_full_activity_dump' % self._base_url,
@@ -241,4 +244,3 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
     return RequestPost(
       'https://%s/admin/get_ppa_status' % self._base_url, None,
       self._tls_config)
-    

--- a/src/harness/sas_testcase.py
+++ b/src/harness/sas_testcase.py
@@ -104,6 +104,7 @@ class SasTestCase(unittest.TestCase):
     response = self._sas.Registration(
         request, ssl_cert=ssl_cert, ssl_key=ssl_key)['registrationResponse']
 
+    self.assertEqual(len(response), len(registration_request))
     # Check the registration response; collect CBSD IDs
     cbsd_ids = []
     for resp in response:
@@ -271,6 +272,42 @@ class SasTestCase(unittest.TestCase):
         break
     self.assertTrue(is_frequency_included_in_range,
                     'Channel is not included in list of frequency ranges')
+
+  def assertValidConfig(self, config, required_fields, optional_fields={}):
+    """Does basic checking of a testing config.
+
+    Checks that the given config contains the required fields of the correct
+    type and present optional fields are the correct type.
+
+    Args:
+      config: The test configuration as a dictionary.
+      required_fields: Dictionary of the required fields where the key is the
+        field name and the value is the expected data type.
+      optional_fields: Optional. Dictionary of the optional fields where the
+        key is the field name and the value is the expected data type.
+
+    Raises:
+      AssertError: When the given config does not include the required and
+      optional fields or the config contains unexpected keys.
+    """
+    for key, field_type in required_fields.iteritems():
+      self.assertTrue(key in config,
+                      'Required config field \'%s\' is not present.')
+      self.assertTrue(
+          isinstance(config[key], field_type),
+          'Required config field \'%s\' is of type(%s) when it should be type(%s).'
+          % (key, type(config[key]).__name__, field_type.__name__))
+    for key, field_type in optional_fields.iteritems():
+      if key in config:
+        self.assertTrue(
+            isinstance(config[key], field_type),
+            'Optional config field \'%s\' is of type(%s) when it should be type(%s).'
+            % (key, type(config[key]).__name__, field_type.__name__))
+    # Check the config only contains the checked fields
+    for key in config:
+      self.assertTrue(
+          key in required_fields or key in optional_fields,
+          'Config field \'%s\' is neither required nor optional.' % key)
 
   def TriggerFullActivityDumpAndWaitUntilComplete(self, server_cert, server_key):
     request_time = datetime.utcnow().replace(microsecond=0)

--- a/src/harness/sas_testcase.py
+++ b/src/harness/sas_testcase.py
@@ -292,7 +292,7 @@ class SasTestCase(unittest.TestCase):
     """
     for key, field_type in required_fields.iteritems():
       self.assertTrue(key in config,
-                      'Required config field \'%s\' is not present.')
+                      'Required config field \'%s\' is not present.' % key)
       self.assertTrue(
           isinstance(config[key], field_type),
           'Required config field \'%s\' is of type(%s) when it should be type(%s).'

--- a/src/harness/security_testcase.py
+++ b/src/harness/security_testcase.py
@@ -160,8 +160,8 @@ class SecurityTestCase(sas_testcase.SasTestCase):
       client_key: path to associated key file in PEM format to use with the optionally
         given |client_cert|. If 'None' path to the default CBSD key file will be used.
     """
-    client_cert = client_cert or self._sas._GetDefaultCbsdSSLCertPath()
-    client_key = client_key or self._sas._GetDefaultCbsdSSLKeyPath()
+    client_cert = client_cert or sas.GetDefaultCbsdSSLCertPath()
+    client_key = client_key or sas.GetDefaultCbsdSSLKeyPath()
 
     # Using pyOpenSSL low level API, does the SAS UUT server TLS session checks.
     self.assertTlsHandshakeSucceed(self._sas_admin._base_url, [cipher],
@@ -204,12 +204,12 @@ class SecurityTestCase(sas_testcase.SasTestCase):
       client_cert: optional client certificate file in PEM format to use.
         If 'None' the default CBSD certificate will be used.
       client_key: associated key file in PEM format to use with the optionally
-        given |client_cert|. If 'None' the default CBSD key file will be used.  
+        given |client_cert|. If 'None' the default CBSD key file will be used.
       ciphers: optional cipher method
       ssl_method: optional ssl_method
     """
-    client_cert = client_cert or self._sas._GetDefaultCbsdSSLCertPath()
-    client_key = client_key or self._sas._GetDefaultCbsdSSLKeyPath()
+    client_cert = client_cert or sas.GetDefaultCbsdSSLCertPath()
+    client_key = client_key or sas.GetDefaultCbsdSSLKeyPath()
 
     url = urlparse.urlparse('https://' + self._sas_admin._base_url)
     client = socket.socket()
@@ -231,7 +231,7 @@ class SecurityTestCase(sas_testcase.SasTestCase):
 
     ctx.use_certificate_file(client_cert)
     ctx.use_privatekey_file(client_key)
-    
+
     client_ssl_informations = []
     def _InfoCb(conn, where, ok):
       client_ssl_informations.append(conn.get_state_string())
@@ -242,7 +242,7 @@ class SecurityTestCase(sas_testcase.SasTestCase):
     client_ssl = SSL.Connection(ctx, client)
     client_ssl.set_connect_state()
     client_ssl.set_tlsext_host_name(url.hostname)
-    
+
     try:
       client_ssl.do_handshake()
       logging.debug('TLS handshake: succeed')

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -139,7 +139,6 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
 
     # Steps 2 & 3 can be interleaved.
     test_harnesses = []
-    test_harness_sas_interfaces = []
     for test_harness_config in config['sasTestHarnessConfigs']:
       # Create test harness, notify the SAS UUT, and load FAD records.
       test_harness = SasTestHarnessServer(

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -223,7 +223,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
       dpa = dpa_mgr.BuildDpa(dpa_config['dpaId'], dpa_config['points_builder'])
       freq_range_low = dpa_config['frequencyRange']['lowFrequency'] / ONE_MHZ
       freq_range_high = dpa_config['frequencyRange']['highFrequency'] / ONE_MHZ
-      dpa.SetFreqRange([(freq_range_low, freq_range_high)])
+      dpa.ResetFreqRange([(freq_range_low, freq_range_high)])
       dpa.SetGrantsFromFad(sas_uut_fad, test_harness_fads)
       dpa.ComputeMoveLists()
       dpas.append(dpa)
@@ -231,6 +231,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
     n2_domain_proxy.heartbeatForAllActiveGrants()
     n3_domain_proxy.heartbeatForAllActiveGrants()
     # Get CbsdGrantInfo list of SAS UUT grants that are in an authorized state.
+    # TODO: Update with correct function name/import when it is added.
     grant_info = getGrantsFromDomainProxies([n2_domain_proxy, n3_domain_proxy])
 
     # Check grants do not exceed each DPAs interference threshold.

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -29,6 +29,7 @@ LOW_FREQUENCY_LIMIT_HZ = 3550000000
 HIGH_FREQUENCY_LIMIT_HZ = 3650000000
 ONE_MHZ = 1000000
 
+
 class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
 
   def setUp(self):
@@ -39,15 +40,15 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
     pass
 
   def frequencyInBand(self, low_frequency, high_frequency):
-    """Returns True iff the given range overlaps with the 3550MHz to 3650MHz range."""
+    """Returns True iff the given range overlaps with the 3550-3650MHz range."""
     return (LOW_FREQUENCY_LIMIT_HZ <= low_frequency <= HIGH_FREQUENCY_LIMIT_HZ
             or
             LOW_FREQUENCY_LIMIT_HZ <= high_frequency <= HIGH_FREQUENCY_LIMIT_HZ)
 
   def generate_IPR_1_default_config(self, filename):
-    """Generates the WinnForum configuration for IPR_1"""
+    """Generates the WinnForum configuration for IPR_1."""
 
-    # Load Devices
+    # Load Devices.
     device_a = json.load(
         open(os.path.join('testcases', 'testdata', 'device_a.json')))
     device_a['installationParam']['latitude'] = 30.71570
@@ -111,10 +112,13 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
     }
 
     dpa_1 = {
-       'dpaId': 'east_dpa_4',
-       'frequencyRange': {'lowFrequency': 3620000000, 'highFrequency': 3630000000},
-       'points_builder': 'default (25, 10, 10, 10)',
-       'movelistMargin': 10
+        'dpaId': 'east_dpa_4',
+        'frequencyRange': {
+            'lowFrequency': 3620000000,
+            'highFrequency': 3630000000
+        },
+        'points_builder': 'default (25, 10, 10, 10)',
+        'movelistMargin': 10
     }
 
     config = {
@@ -190,12 +194,12 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
 
     # None of the N3 CBSDS should be authorized.
     for cbsd in n3_domain_proxy.getCbsdsWithAtLeastOneAuthorizedGrant():
-      for operationParam in cbsd.getOperationParamsOfAllAuthorizedGrants():
+      for operation_param in cbsd.getOperationParamsOfAllAuthorizedGrants():
         # By definition the N3 CBSDs are in a DPA neighborhood. Check frequency.
         self.assertFalse(
             self.frequencyInBand(
-                operationParam['operationFrequencyRange']['lowFrequency'],
-                operationParam['operationFrequencyRange']['highFrequency']),
+                operation_param['operationFrequencyRange']['lowFrequency'],
+                operation_param['operationFrequencyRange']['highFrequency']),
             msg='CBSD (cbsd_id=%s, fcc_id=%s, sn=%s) '
             'is authorized after IPR.1 step 7. SAS UUT FAILS this test. '
             '(If this config is new please verify the CBSD is in a DPA)' %
@@ -233,4 +237,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
     for dpa, dpa_config in zip(dpas, config['dpas']):
       freq_range_low = dpa_config['frequencyRange']['lowFrequency'] / ONE_MHZ
       freq_range_high = dpa_config['frequencyRange']['highFrequency'] / ONE_MHZ
-      self.assertTrue(dpa.CheckInterference(channel=(freq_range_low, freq_range_high), sas_uut_active_grants=grant_info, margin_db=dpa_config['movelistMargin']))
+      self.assertTrue(dpa.CheckInterference(
+          channel=(freq_range_low, freq_range_high),
+          sas_uut_active_grants=grant_info,
+          margin_db=dpa_config['movelistMargin']))

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -1,0 +1,221 @@
+#    Copyright 2018 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+import logging
+import json
+import os
+
+import sas
+import sas_testcase
+
+from util import configurable_testcase, writeConfig, loadConfig, getCertificateFingerprint
+from test_harness_objects import DomainProxy
+from full_activity_dump_helper import getFullActivityDumpSasTestHarness, getFullActivityDumpSasUut
+from sas_test_harness import SasTestHarnessServer, generateCbsdRecords
+
+LOW_FREQUENCY_LIMIT_HZ = 3550000000
+HIGH_FREQUENCY_LIMIT_HZ = 3650000000
+
+
+class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
+
+  def setUp(self):
+    self._sas, self._sas_admin = sas.GetTestingSas()
+    self._sas_admin.Reset()
+
+  def tearDown(self):
+    pass
+
+  def frequencyInBand(self, low_frequency, high_frequency):
+    """Returns True iff the given range overlaps with the 3550MHz to 3650MHz range."""
+    return (LOW_FREQUENCY_LIMIT_HZ <= low_frequency <= HIGH_FREQUENCY_LIMIT_HZ
+            or
+            LOW_FREQUENCY_LIMIT_HZ <= high_frequency <= HIGH_FREQUENCY_LIMIT_HZ)
+
+  def generate_IPR_1_default_config(self, filename):
+    """Generates the WinnForum configuration for IPR_1"""
+
+    # Load Devices
+    device_a = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_a.json')))
+    device_b = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_b.json')))
+    device_c = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_c.json')))
+
+    # Pre-load conditionals and remove reg conditional fields from registration
+    # request.
+    conditional_keys = [
+        'cbsdCategory', 'fccId', 'cbsdSerialNumber', 'airInterface',
+        'installationParam', 'measCapability'
+    ]
+    reg_conditional_keys = [
+        'cbsdCategory', 'airInterface', 'installationParam', 'measCapability'
+    ]
+    conditionals_b = {key: device_b[key] for key in conditional_keys}
+    conditionals_c = {key: device_c[key] for key in conditional_keys}
+    device_b = {
+        key: device_b[key]
+        for key in device_b
+        if key not in reg_conditional_keys
+    }
+    device_c = {
+        key: device_c[key]
+        for key in device_c
+        if key not in reg_conditional_keys
+    }
+
+    # Load grant requests.
+    grant_a = json.load(
+        open(os.path.join('testcases', 'testdata', 'grant_0.json')))
+    grant_b = json.load(
+        open(os.path.join('testcases', 'testdata', 'grant_0.json')))
+    grant_c = json.load(
+        open(os.path.join('testcases', 'testdata', 'grant_0.json')))
+
+    sas_test_harness_config = {
+        'sasTestHarnessName':
+            'SAS-Test-Harness-1',
+        'hostName':
+            'localhost',
+        'port':
+            9001,
+        'serverCert':
+            os.path.join('certs', 'server.cert'),
+        'serverKey':
+            os.path.join('certs', 'server.key'),
+        'caCert':
+            os.path.join('certs', 'ca.cert'),
+        'fullActivityDumpRecords': [
+            generateCbsdRecords([device_a], [[grant_a]])
+        ]
+    }
+
+    dpa_1 = {
+       'dpaId': 'east_dpa_4',
+       'frequencyRange': {'lowFrequency': 3550000000, 'highFrequency': 3650000000}
+    }
+
+    config = {
+        'sasTestHarnessConfigs': [sas_test_harness_config],
+        'registrationRequestsN2': [device_b],
+        'grantRequestsN2': [grant_b],
+        'conditionalRegistrationDataN2': [conditionals_b],
+        'registrationRequestsN3': [device_c],
+        'grantRequestsN3': [grant_c],
+        'conditionalRegistrationDataN3': [conditionals_c],
+        'dpas': [dpa_1]
+    }
+    writeConfig(filename, config)
+
+  @configurable_testcase(generate_IPR_1_default_config)
+  def test_WINNF_FT_S_IPR_1(self, config_filename):
+    """In the absence of an ESC, SAS protects all ESC-monitored DPAs."""
+    config = loadConfig(config_filename)
+    self.assertValidConfig(
+        config, {
+            'sasTestHarnessConfigs': list,
+            'registrationRequestsN2': list,
+            'grantRequestsN2': list,
+            'registrationRequestsN3': list,
+            'grantRequestsN3': list,
+            'conditionalRegistrationDataN2': list,
+            'conditionalRegistrationDataN3': list,
+            'dpas', list
+        })
+    # SAS UUT loads DPAs.
+    self._sas_admin.TriggerLoadDpas()
+
+    # Steps 2 & 3 can be interleaved.
+    test_harnesses = []
+    test_harness_sas_interfaces = []
+    for test_harness_config in config['sasTestHarnessConfigs']:
+      # Create test harness, notify the SAS UUT, and load FAD records.
+      test_harness = SasTestHarnessServer(
+          test_harness_config['sasTestHarnessName'],
+          test_harness_config['hostName'], test_harness_config['port'],
+          test_harness_config['serverCert'], test_harness_config['serverKey'],
+          test_harness_config['caCert'])
+      test_harness.start()
+      self._sas_admin.InjectPeerSas({
+          'certificateHash':
+              getCertificateFingerprint(test_harness_config['serverCert']),
+          'url':
+              test_harness.getBaseUrl()
+      })
+      test_harness.writeFadRecords(
+          test_harness_config['fullActivityDumpRecords'])
+      test_harnesses.append(test_harness)
+
+    # Register N2 CBSDs with the SAS UUT and request Grants.
+    n2_domain_proxy = DomainProxy(self)
+    n2_domain_proxy.registerCbsdsAndRequestGrants(
+        config['registrationRequestsN2'],
+        config['grantRequestsN2'],
+        conditional_registration_data=config['conditionalRegistrationDataN2'])
+
+    # Trigger CPAS.
+    self.TriggerDailyActivitiesImmediatelyAndWaitUntilComplete()
+
+    # Register N3 CBSDs with the SAS UUT and request Grants.
+    n3_domain_proxy = DomainProxy(self)
+    n3_domain_proxy.registerCbsdsAndRequestGrants(
+        config['registrationRequestsN3'],
+        config['grantRequestsN3'],
+        conditional_registration_data=config['conditionalRegistrationDataN3'])
+
+    # Heartbeat all SAS UUT CBSDS
+    n2_domain_proxy.heartbeatForAllActiveGrants()
+    n3_domain_proxy.heartbeatForAllActiveGrants()
+
+    # None of the N3 CBSDS should be authorized.
+    for cbsd in n3_domain_proxy.getCbsdsWithAtLeastOneAuthorizedGrant():
+      for operationParam in cbsd.getOperationParamsOfAllAuthorizedGrants():
+        # By definition the N3 CBSDs are in a DPA neighborhood. Check frequency.
+        self.assertFalse(
+            self.frequencyInBand(
+                operationParam['operationFrequencyRange']['lowFrequency'],
+                operationParam['operationFrequencyRange']['highFrequency']),
+            msg='CBSD (cbsd_id=%s, fcc_id=%s, sn=%s) '
+            'is authorized after IPR.1 step 7. SAS UUT FAILS this test. '
+            '(If this config is new please verify the CBSD is in a DPA)' %
+            (cbsd.getCbsdId(), cbsd.getRegistrationRequest()['fccId'],
+             cbsd.getRegistrationRequest()['cbsdSerialNumber']))
+
+    # Get SAS UUT FAD and Test Harness FADs.
+    sas_uut_fad = getFullActivityDumpSasUut(self._sas, self._sas_admin)
+    test_harness_fads = []
+    for test_harness in test_harnesses:
+      test_harness_fads.append(
+          getFullActivityDumpSasTestHarness(
+              test_harness.getSasTestHarnessInterface()))
+
+    # Trigger CPAS.
+    self.TriggerDailyActivitiesImmediatelyAndWaitUntilComplete()
+
+    # Initialize DPA objects and calculate movelist for each DPA.
+    # TODO(taran): Update once DPA movelist reference model changes are reviewed.
+    dpas = [Dpa(dpa) for dpa in config['dpas']]
+    for dpa in dpas:
+      dpa.SetGrantsFromFad(sas_uut_fad, test_harness_fads)
+      dpa.CalcMoveLists()
+    # Heartbeat SAS UUT grants.
+    n2_domain_proxy.heartbeatForAllActiveGrants()
+    n3_domain_proxy.heartbeatForAllActiveGrants()
+    # Get CbsdGrantInfo list of SAS UUT grants that are in an authorized state.
+    grant_info = getGrantsFromDomainProxies([n2_domain_proxy, n3_domain_proxy])
+
+    # Check grants do not exceed each DPAs interference threshold.
+    for dpa in dpas:
+      self.assertTrue(dpa.CheckInterference(channel=(3550, 3650), sas_uut_active_grants=grant_info, margin_db=10))


### PR DESCRIPTION
- Initial IPR.1 testcase (Note: The DPA movelist initialization and access methods will almost certainly be changed, as will the default config, at present it is just an example and probably does not include CBSDs in a DPA).
Minor fixes:
- Move default cert function out of sas object, so they may be used by other objects (In this case domain proxy).
- Make sas testcase assertRegistered check the length of responses matches the length of requests.
- Add conditional registration data support to domain proxy.
- Allow domain proxy to use default certs (Note: This modifies the domain proxy init interface).