### PR TITLE
Prop Models: Implement minimum height of 1m

### DIFF
--- a/src/harness/reference_models/propagation/wf_hybrid.py
+++ b/src/harness/reference_models/propagation/wf_hybrid.py
@@ -160,6 +160,8 @@ def CalcHybridPropagationLoss(lat_cbsd, lon_cbsd, height_cbsd,
                           Value in [0,1]: returns the CDF quantile
                           -1: returns the mean path loss
     region:             Region type among 'URBAN', 'SUBURBAN, 'RURAL'
+    is_height_cbsd_amsl: If True, the CBSD height shall be considered as AMSL (Average
+                         mean sea level).
 
   Returns:
     A namedtuple of:
@@ -202,7 +204,6 @@ def CalcHybridPropagationLoss(lat_cbsd, lon_cbsd, height_cbsd,
                                                  lat2=lat_rx, lon2=lon_rx,
                                                  target_res_meter=30.,
                                                  do_interp=True, max_points=1501)
-
 
   # Structural CBSD and mobile height corrections
   height_cbsd = max(height_cbsd, 20.)

--- a/src/harness/reference_models/propagation/wf_hybrid.py
+++ b/src/harness/reference_models/propagation/wf_hybrid.py
@@ -132,7 +132,8 @@ def CalcHybridPropagationLoss(lat_cbsd, lon_cbsd, height_cbsd,
                               cbsd_indoor=False,
                               reliability=-1,
                               freq_mhz=3625.,
-                              region='RURAL'):
+                              region='RURAL',
+                              is_height_cbsd_amsl=False):
   """Implements the Hybrid ITM/eHata NTIA propagation model.
 
   As specified by Winforum, see:
@@ -184,16 +185,16 @@ def CalcHybridPropagationLoss(lat_cbsd, lon_cbsd, height_cbsd,
     Exception if input parameters invalid or out of range.
   """
   # Sanity checks on input parameters
-  if height_cbsd < 1 or height_rx < 1:
-    raise Exception('End-point height less than 1m.')
-  if height_cbsd > 1000 or height_rx > 1000:
-    raise Exception('End-point height greater than 1000m.')
   if freq_mhz < 40 or freq_mhz > 10000:
     raise Exception('Frequency outside range [40MHz - 10GHz].')
   if region not in ['RURAL', 'URBAN', 'SUBURBAN']:
     raise Exception('Region %s not allowed' % region)
   if reliability not in (-1, 0.5):
     raise Exception('Hybrid model only computes the median or the mean.')
+
+  if is_height_cbsd_amsl:
+    altitude_cbsd = drive.terrain_driver.GetTerrainElevation(lat_cbsd, lon_cbsd)
+    height_cbsd = height_cbsd - altitude_cbsd
 
   # Get the terrain profile, using Vincenty great circle route, and WF
   # standard (bilinear interp; 1501 pts for all distances over 45 km)

--- a/src/harness/reference_models/propagation/wf_hybrid_test.py
+++ b/src/harness/reference_models/propagation/wf_hybrid_test.py
@@ -202,5 +202,20 @@ class TestWfHybrid(unittest.TestCase):
     offset = wf_hybrid._GetMedianToMeanOffsetDb(3625, True)
     self.assertAlmostEqual(median + offset, -signal_mean, 2)
 
+  def test_small_height(self):
+    lat1, lng1 = 37.756672, -122.508512
+    lat2, lng2 = 37.754406, -122.388342
+    res_bad = wf_hybrid.CalcHybridPropagationLoss(
+        lat1, lng1, 0, lat2, lng2, -1,
+        cbsd_indoor=False,
+        reliability=0.5, freq_mhz=3625., region='SUBURBAN')
+    res_expected = wf_hybrid.CalcHybridPropagationLoss(
+        lat1, lng1, 1, lat2, lng2, 1,
+        cbsd_indoor=False,
+        reliability=0.5, freq_mhz=3625., region='SUBURBAN')
+    self.assertEqual(res_bad.db_loss, res_expected.db_loss)
+    self.assertEqual(res_bad.incidence_angles, res_expected.incidence_angles)
+
+
 if __name__ == '__main__':
   unittest.main()

--- a/src/harness/reference_models/propagation/wf_itm.py
+++ b/src/harness/reference_models/propagation/wf_itm.py
@@ -100,7 +100,8 @@ def CalcItmPropagationLoss(lat_cbsd, lon_cbsd, height_cbsd,
     freq_mhz:            Frequency (MHz). Default is mid-point of band.
     its_elev:            Optional profile to use (in ITM format). Default=None
                            If not specified, it is extracted from the terrain.
-
+    is_height_cbsd_amsl: If True, the CBSD height shall be considered as AMSL (Average
+                         mean sea level).
   Returns:
     A namedtuple of:
       db_loss            Path Loss in dB, either a scalar if reliability is scalar

--- a/src/harness/reference_models/propagation/wf_itm.py
+++ b/src/harness/reference_models/propagation/wf_itm.py
@@ -74,8 +74,10 @@ _IncidenceAngles = namedtuple('_IncidenceAngles',
 def CalcItmPropagationLoss(lat_cbsd, lon_cbsd, height_cbsd,
                            lat_rx, lon_rx, height_rx,
                            cbsd_indoor=False,
-                           reliability=0.5, freq_mhz=3625.,
-                           its_elev=None):
+                           reliability=0.5,
+                           freq_mhz=3625.,
+                           its_elev=None,
+                           is_height_cbsd_amsl=False):
   """Implements the WinnForum-compliant ITM point-to-point propagation model.
 
   According to WinnForum spec R2-SGN-17, R2-SGN-22 and R2-SGN-5 to 10.
@@ -121,12 +123,18 @@ def CalcItmPropagationLoss(lat_cbsd, lon_cbsd, height_cbsd,
     Exception if input parameters invalid or out of range.
   """
   # Sanity checks on input parameters
-  if height_cbsd < 1 or height_rx < 1:
-    raise Exception('Endpoint height less than 1m')
-  if height_cbsd > 1000 or height_rx > 1000:
-    raise Exception('Endpoint height greater than 1000m')
   if freq_mhz < 40.0 or freq_mhz > 10000:
     raise Exception('Frequency outside range [40MHz - 10GHz]')
+
+  if is_height_cbsd_amsl:
+    altitude_cbsd = drive.terrain_driver.GetTerrainElevation(lat_cbsd, lon_cbsd)
+    height_cbsd = height_cbsd - altitude_cbsd
+
+  # Ensure minimum height of 1 meter
+  if height_cbsd < 1:
+    height_cbsd = 1
+  if height_rx < 1:
+    height_rx = 1
 
   # Internal ITM parameters are always set to following values in WF version:
   confidence = 0.5     # Confidence (always 0.5)

--- a/src/harness/reference_models/propagation/wf_itm_test.py
+++ b/src/harness/reference_models/propagation/wf_itm_test.py
@@ -111,6 +111,18 @@ class TestWfItm(unittest.TestCase):
     self.assertEqual(np.max(np.abs(
         np.array(res_indoor.db_loss) - np.array(res_outdoor.db_loss) - 15)), 0)
 
+  def test_small_height(self):
+    lat1, lng1 = 37.756672, -122.508512
+    lat2, lng2 = 37.754406, -122.388342
+
+    res_bad = wf_itm.CalcItmPropagationLoss(lat1, lng1, 0, lat2, lng2, -1,
+                                            cbsd_indoor=False,
+                                            reliability=0.5, freq_mhz=3625.)
+    res_expected = wf_itm.CalcItmPropagationLoss(lat1, lng1, 1, lat2, lng2, 1,
+                                                 cbsd_indoor=False,
+                                                 reliability=0.5, freq_mhz=3625.)
+    self.assertEqual(res_bad.db_loss, res_expected.db_loss)
+    self.assertEqual(res_bad.incidence_angles, res_expected.incidence_angles)
 
   def test_hor_angles(self):
     # Using the ITM test profile Path2200


### PR DESCRIPTION
As proposed in WG1 specification change (note: not yet integrated in spec), to use minimum of 1m height.
Also add following changes:
 - remove the exception check for maximum height
 - add a flag parameter to specify if CBSD height is a AMSL height. Using this flag will simplify the test harness code logic, as it wont need to do the test for AMSL and correction in various places. 

Background:
The models are not designed for negative height, and would return bogus results.
Normally AGL height should always be positive (except for CBSD in basement or tunnels or subway), although an error in configuration would go through the SAS-CBSD protocol. 
Problematic also is the height being specified as AMSL. This AMSL would be transformed into an AGL height by removing the terrain height coming from the terrain database, which may be inaccurate, and thus leading to a negative height for purpose of propagation modeling.

To avoid having the bogus result preventing a CBSD interference to be taken into account during incumbents protection, a minimum height of 1m is taken into account.
Most likely, valid underground CBSD will be handled as part of a future extension of the SAS specification, with a specific modeling and specific flag for categorizing those

