### PR TITLE
SSS.18: fix certificate injection

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_SSS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SSS_testcase.py
@@ -450,7 +450,7 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     self.SasReset()
 
     # Notify SAS UUT about peer SAS
-    certificate_hash = getCertificateFingerprint(SAS_CERT)
+    certificate_hash = getCertificateFingerprint(config['validCertKeyPair']['cert'])
     self._sas_admin.InjectPeerSas({'certificateHash': certificate_hash,\
                                      'url': SAS_TEST_HARNESS_URL })
     # Load a Device


### PR DESCRIPTION
Fix certificate injection to be from config file for SSS.18 instead of default certificate. Otherwise, the SAS peer injected and the FAD request to that SAS peer could have different certificates.