### PR TITLE
Fix default cert function name

### DIFF
--- a/src/harness/sas.py
+++ b/src/harness/sas.py
@@ -27,19 +27,19 @@ def GetTestingSas():
   sas_admin_id = config_parser.get('SasConfig', 'AdminId')
   return SasImpl(base_url, version, sas_admin_id), SasAdminImpl(base_url)
 
-def getDefaultCbsdSSLCertPath():
+def GetDefaultCbsdSSLCertPath():
   return os.path.join('certs', 'client.cert')
 
 
-def getDefaultCbsdSSLKeyPath():
+def GetDefaultCbsdSSLKeyPath():
   return os.path.join('certs', 'client.key')
 
 
-def getDefaultSasSSLCertPath():
+def GetDefaultSasSSLCertPath():
   return os.path.join('certs', 'client.cert')
 
 
-def getDefaultSasSSLKeyPath():
+def GetDefaultSasSSLKeyPath():
   return os.path.join('certs', 'client.key')
 
 

--- a/src/harness/test_harness_objects.py
+++ b/src/harness/test_harness_objects.py
@@ -15,7 +15,7 @@
 """Implementation of multiple objects (Grant, Cbsd and DomainProxy).
    Mainly used in MCP and related test cases."""
 import logging
-from sas import getDefaultSasSSLCertPath, getDefaultSasSSLKeyPath
+from sas import GetDefaultSasSSLCertPath, GetDefaultSasSSLKeyPath
 from common_types import ResponseCodes
 
 class Grant(object):
@@ -137,8 +137,8 @@ class DomainProxy(object):
       ssl_key: Path to SSL key file.
       testcase: test case object from the caller.
     """
-    self.ssl_cert = ssl_cert if ssl_cert else getDefaultSasSSLCertPath()
-    self.ssl_key = ssl_key if ssl_key else getDefaultSasSSLKeyPath()
+    self.ssl_cert = ssl_cert if ssl_cert else GetDefaultSasSSLCertPath()
+    self.ssl_key = ssl_key if ssl_key else GetDefaultSasSSLKeyPath()
     self.cbsd_objects = {}
     self.testcase = testcase
 


### PR DESCRIPTION
Changes the ```getDefault*Path``` functions to ```GetDefault*Path```. This is consistent with the rest of the file and what most of the code assumes.