### PR TITLE
Fixed FullActivityDumpHelper to correctly use the ssl cert/key

### DIFF
--- a/src/harness/full_activity_dump_helper.py
+++ b/src/harness/full_activity_dump_helper.py
@@ -89,7 +89,7 @@ def _triggerFullActivityDumpAndWaitUntilComplete(sas, sas_admin, ssl_cert,
   signal.alarm(7200)
   # Check generation date of full activity dump.
   while True:
-    dump_message = sas.GetFullActivityDump()
+    dump_message = sas.GetFullActivityDump(ssl_cert, ssl_key)
     dump_time = datetime.strptime(dump_message['generationDateTime'],
                                   '%Y-%m-%dT%H:%M:%SZ')
     if request_time <= dump_time:


### PR DESCRIPTION
Fix per Sony's review comment in "Tests Review Notification (full_activity_dump_helper.py in master)" on the 17th of April.

Corrects the full activity dump helper to request a FAD using the given cert/key, previously the cert/key was passed but never used.