### PR TITLE
Create config for FPR.2 and FPR.4 testcases

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
@@ -49,10 +49,10 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
     # frequency range outside of FSS band.
     device_1 = json.load(
         open(os.path.join('testcases', 'testdata', 'device_a.json')))
-    device_1['installationParam'][
-        'latitude'] = fss_record['installationParam']['latitude'] + 0.20
-    device_1['installationParam'][
-        'longitude'] = fss_record['installationParam']['longitude']
+    device_1['installationParam']['latitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['latitude'] + 0.20
+    device_1['installationParam']['longitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['longitude']
     grant_request_1 = json.load(
         open(os.path.join('testcases', 'testdata', 'grant_0.json')))
     grant_request_1['operationParam'][
@@ -64,10 +64,10 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
     # frequency range outside of FSS band, overlapping device 1 band.
     device_2 = json.load(
         open(os.path.join('testcases', 'testdata', 'device_b.json')))
-    device_2['installationParam'][
-        'latitude'] = fss_record['installationParam']['latitude']
-    device_2['installationParam'][
-        'longitude'] = fss_record['installationParam']['longitude'] + 0.20
+    device_2['installationParam']['latitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['latitude']
+    device_2['installationParam']['longitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['longitude'] + 0.20
     grant_request_2 = json.load(
         open(os.path.join('testcases', 'testdata', 'grant_0.json')))
     grant_request_2['operationParam'][
@@ -79,10 +79,10 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
     # frequency range outside of FSS band.
     device_3 = json.load(
         open(os.path.join('testcases', 'testdata', 'device_c.json')))
-    device_3['installationParam'][
-        'latitude'] = fss_record['installationParam']['latitude'] + 0.05
-    device_3['installationParam'][
-        'longitude'] = fss_record['installationParam']['longitude'] + 0.05
+    device_3['installationParam']['latitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['latitude'] + 0.05
+    device_3['installationParam']['longitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['longitude'] + 0.05
     grant_request_3 = json.load(
         open(os.path.join('testcases', 'testdata', 'grant_0.json')))
     grant_request_3['operationParam'][
@@ -94,10 +94,10 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
     # frequency range overlapping FSS band.
     device_4 = json.load(
         open(os.path.join('testcases', 'testdata', 'device_d.json')))
-    device_4['installationParam'][
-        'latitude'] = fss_record['installationParam']['latitude'] - 0.05
-    device_4['installationParam'][
-        'longitude'] = fss_record['installationParam']['longitude'] - 0.05
+    device_4['installationParam']['latitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['latitude'] - 0.05
+    device_4['installationParam']['longitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['longitude'] - 0.05
     grant_request_4 = json.load(
         open(os.path.join('testcases', 'testdata', 'grant_0.json')))
     grant_request_4['operationParam'][
@@ -109,10 +109,10 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
     # frequency range inside of FSS band.
     device_5 = json.load(
         open(os.path.join('testcases', 'testdata', 'device_e.json')))
-    device_5['installationParam'][
-        'latitude'] = fss_record['installationParam']['latitude'] + 0.05
-    device_5['installationParam'][
-        'longitude'] = fss_record['installationParam']['longitude'] - 0.05
+    device_5['installationParam']['latitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['latitude'] + 0.05
+    device_5['installationParam']['longitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['longitude'] - 0.05
     grant_request_5 = json.load(
         open(os.path.join('testcases', 'testdata', 'grant_0.json')))
     grant_request_5['operationParam'][
@@ -124,10 +124,10 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
     # frequency range inside of FSS band.
     device_6 = json.load(
         open(os.path.join('testcases', 'testdata', 'device_f.json')))
-    device_6['installationParam'][
-        'latitude'] = fss_record['installationParam']['latitude'] + 1.0
-    device_6['installationParam'][
-        'longitude'] = fss_record['installationParam']['longitude']
+    device_6['installationParam']['latitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['latitude'] + 1.00
+    device_6['installationParam']['longitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['longitude']
     grant_request_6 = json.load(
         open(os.path.join('testcases', 'testdata', 'grant_0.json')))
     grant_request_6['operationParam'][
@@ -139,10 +139,10 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
     # frequency range inside of FSS band.
     device_7 = json.load(
         open(os.path.join('testcases', 'testdata', 'device_g.json')))
-    device_7['installationParam'][
-        'latitude'] = fss_record['installationParam']['latitude'] + 1.5
-    device_7['installationParam'][
-        'longitude'] = fss_record['installationParam']['longitude'] + 0.5
+    device_7['installationParam']['latitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['latitude'] + 1.50
+    device_7['installationParam']['longitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['longitude'] + 0.50
     grant_request_7 = json.load(
         open(os.path.join('testcases', 'testdata', 'grant_0.json')))
     grant_request_7['operationParam'][
@@ -310,10 +310,10 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
     # frequency range outside of FSS band.
     device_1 = json.load(
         open(os.path.join('testcases', 'testdata', 'device_a.json')))
-    device_1['installationParam'][
-        'latitude'] = fss_record['installationParam']['latitude'] + 0.20
-    device_1['installationParam'][
-        'longitude'] = fss_record['installationParam']['longitude']
+    device_1['installationParam']['latitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['latitude'] + 0.20
+    device_1['installationParam']['longitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['longitude']
     grant_request_1 = json.load(
         open(os.path.join('testcases', 'testdata', 'grant_0.json')))
     grant_request_1['operationParam'][
@@ -325,10 +325,10 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
     # frequency range outside of FSS band, overlapping device 1 band.
     device_2 = json.load(
         open(os.path.join('testcases', 'testdata', 'device_b.json')))
-    device_2['installationParam'][
-        'latitude'] = fss_record['installationParam']['latitude']
-    device_2['installationParam'][
-        'longitude'] = fss_record['installationParam']['longitude'] + 0.20
+    device_2['installationParam']['latitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['latitude']
+    device_2['installationParam']['longitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['longitude'] + 0.20
     grant_request_2 = json.load(
         open(os.path.join('testcases', 'testdata', 'grant_0.json')))
     grant_request_2['operationParam'][
@@ -340,10 +340,10 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
     # frequency range outside of FSS band.
     device_3 = json.load(
         open(os.path.join('testcases', 'testdata', 'device_c.json')))
-    device_3['installationParam'][
-        'latitude'] = fss_record['installationParam']['latitude'] + 0.05
-    device_3['installationParam'][
-        'longitude'] = fss_record['installationParam']['longitude'] + 0.05
+    device_3['installationParam']['latitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['latitude'] + 0.05
+    device_3['installationParam']['longitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['longitude'] + 0.05
     grant_request_3 = json.load(
         open(os.path.join('testcases', 'testdata', 'grant_0.json')))
     grant_request_3['operationParam'][
@@ -355,10 +355,10 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
     # frequency range overlapping FSS band.
     device_4 = json.load(
         open(os.path.join('testcases', 'testdata', 'device_d.json')))
-    device_4['installationParam'][
-        'latitude'] = fss_record['installationParam']['latitude'] - 0.05
-    device_4['installationParam'][
-        'longitude'] = fss_record['installationParam']['longitude'] - 0.05
+    device_4['installationParam']['latitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['latitude'] - 0.05
+    device_4['installationParam']['longitude'] = fss_record[
+        'deploymentParam'][0]['installationParam']['longitude'] - 0.05
     grant_request_4 = json.load(
         open(os.path.join('testcases', 'testdata', 'grant_0.json')))
     grant_request_4['operationParam'][

--- a/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
@@ -11,14 +11,16 @@
 #    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
+"""Implementation of FPR test cases."""
 
 import json
 import os
 import sas
 import sas_testcase
-import logging
+from sas_test_harness import generateCbsdRecords
 from util import winnforum_testcase, writeConfig, loadConfig, configurable_testcase,\
  addCbsdIdsToRequests
+
 
 class FSSProtectionTestcase(sas_testcase.SasTestCase):
 
@@ -28,6 +30,483 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
 
   def tearDown(self):
     pass
+
+  def generate_FPR_2_default_config(self, filename):
+    """Generates the WinnForum configuration for FPR.2."""
+
+    # Load FSS station operating at range below 3700 to 4200 MHz, TT&C flag ON.
+    fss_data = json.load(
+        open(os.path.join('testcases', 'testdata', 'fss_record_0.json')))
+    fss_record = fss_data['record']
+    fss_record['deploymentParam'][0]['operationParam'][
+        'operationFrequencyRange']['lowFrequency'] = 3625000000
+    fss_record['deploymentParam'][0]['operationParam'][
+        'operationFrequencyRange']['highFrequency'] = 4200000000
+    fss_data['ttc'] = True
+
+    # Load devices and grant info for Scenario 1.
+    # Loading device_1 (Cat A) to a location within 40 km of FSS,
+    # frequency range outside of FSS band.
+    device_1 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_a.json')))
+    device_1['installationParam'][
+        'latitude'] = fss_record['installationParam']['latitude'] + 0.20
+    device_1['installationParam'][
+        'longitude'] = fss_record['installationParam']['longitude']
+    grant_request_1 = json.load(
+        open(os.path.join('testcases', 'testdata', 'grant_0.json')))
+    grant_request_1['operationParam'][
+        'operationFrequencyRange']['lowFrequency'] = 3560000000
+    grant_request_1['operationParam'][
+        'operationFrequencyRange']['highFrequency'] = 3570000000
+
+    # Loading device_2 (Cat B) to a location within 40 km of FSS,
+    # frequency range outside of FSS band, overlapping device 1 band.
+    device_2 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_b.json')))
+    device_2['installationParam'][
+        'latitude'] = fss_record['installationParam']['latitude']
+    device_2['installationParam'][
+        'longitude'] = fss_record['installationParam']['longitude'] + 0.20
+    grant_request_2 = json.load(
+        open(os.path.join('testcases', 'testdata', 'grant_0.json')))
+    grant_request_2['operationParam'][
+        'operationFrequencyRange']['lowFrequency'] = 3565000000
+    grant_request_2['operationParam'][
+        'operationFrequencyRange']['highFrequency'] = 3575000000
+
+    # Loading device_3 (Cat A) to a location within 40 km of FSS,
+    # frequency range outside of FSS band.
+    device_3 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_c.json')))
+    device_3['installationParam'][
+        'latitude'] = fss_record['installationParam']['latitude'] + 0.05
+    device_3['installationParam'][
+        'longitude'] = fss_record['installationParam']['longitude'] + 0.05
+    grant_request_3 = json.load(
+        open(os.path.join('testcases', 'testdata', 'grant_0.json')))
+    grant_request_3['operationParam'][
+        'operationFrequencyRange']['lowFrequency'] = 3590000000
+    grant_request_3['operationParam'][
+        'operationFrequencyRange']['highFrequency'] = 3600000000
+
+    # Loading device_4 (Cat B) to a location within 40 km of FSS,
+    # frequency range overlapping FSS band.
+    device_4 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_d.json')))
+    device_4['installationParam'][
+        'latitude'] = fss_record['installationParam']['latitude'] - 0.05
+    device_4['installationParam'][
+        'longitude'] = fss_record['installationParam']['longitude'] - 0.05
+    grant_request_4 = json.load(
+        open(os.path.join('testcases', 'testdata', 'grant_0.json')))
+    grant_request_4['operationParam'][
+        'operationFrequencyRange']['lowFrequency'] = 3620000000
+    grant_request_4['operationParam'][
+        'operationFrequencyRange']['highFrequency'] = 3630000000
+
+    # Loading device_5 (Cat A) to a location within 40 km of FSS,
+    # frequency range inside of FSS band.
+    device_5 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_e.json')))
+    device_5['installationParam'][
+        'latitude'] = fss_record['installationParam']['latitude'] + 0.05
+    device_5['installationParam'][
+        'longitude'] = fss_record['installationParam']['longitude'] - 0.05
+    grant_request_5 = json.load(
+        open(os.path.join('testcases', 'testdata', 'grant_0.json')))
+    grant_request_5['operationParam'][
+        'operationFrequencyRange']['lowFrequency'] = 3650000000
+    grant_request_5['operationParam'][
+        'operationFrequencyRange']['highFrequency'] = 3660000000
+
+    # Loading device_6 (Cat A) to a location between 40 to 150 km of FSS,
+    # frequency range inside of FSS band.
+    device_6 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_f.json')))
+    device_6['installationParam'][
+        'latitude'] = fss_record['installationParam']['latitude'] + 1.0
+    device_6['installationParam'][
+        'longitude'] = fss_record['installationParam']['longitude']
+    grant_request_6 = json.load(
+        open(os.path.join('testcases', 'testdata', 'grant_0.json')))
+    grant_request_6['operationParam'][
+        'operationFrequencyRange']['lowFrequency'] = 3690000000
+    grant_request_6['operationParam'][
+        'operationFrequencyRange']['highFrequency'] = 3700000000
+
+    # Loading device_7 (Cat A) to a location outside 150 km of FSS,
+    # frequency range inside of FSS band.
+    device_7 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_g.json')))
+    device_7['installationParam'][
+        'latitude'] = fss_record['installationParam']['latitude'] + 1.5
+    device_7['installationParam'][
+        'longitude'] = fss_record['installationParam']['longitude'] + 0.5
+    grant_request_7 = json.load(
+        open(os.path.join('testcases', 'testdata', 'grant_0.json')))
+    grant_request_7['operationParam'][
+        'operationFrequencyRange']['lowFrequency'] = 3670000000
+    grant_request_7['operationParam'][
+        'operationFrequencyRange']['highFrequency'] = 3680000000
+
+    # Load Conditional Data for Cat B devices (devices 2 and 4).
+    self.assertEqual(device_2['cbsdCategory'], 'B')
+    conditionals_device_2 = {
+        'cbsdCategory': device_2['cbsdCategory'],
+        'fccId': device_2['fccId'],
+        'cbsdSerialNumber': device_2['cbsdSerialNumber'],
+        'airInterface': device_2['airInterface'],
+        'installationParam': device_2['installationParam'],
+        'measCapability': device_2['measCapability']
+    }
+
+    self.assertEqual(device_4['cbsdCategory'], 'B')
+    conditionals_device_4 = {
+        'cbsdCategory': device_4['cbsdCategory'],
+        'fccId': device_4['fccId'],
+        'cbsdSerialNumber': device_4['cbsdSerialNumber'],
+        'airInterface': device_4['airInterface'],
+        'installationParam': device_4['installationParam'],
+        'measCapability': device_4['measCapability']
+    }
+
+    conditionals = [conditionals_device_2, conditionals_device_4]
+
+    # Remove conditionals from registration
+    del device_2['cbsdCategory']
+    del device_2['airInterface']
+    del device_2['installationParam']
+    del device_2['measCapability']
+    del device_4['cbsdCategory']
+    del device_4['airInterface']
+    del device_4['installationParam']
+    del device_4['measCapability']
+
+    # DP Registration and grant records
+    cbsd_records_domain_proxy_0 = {
+        'registrationRequests': [device_1, device_2, device_6],
+        'grantRequests': [grant_request_1, grant_request_2, grant_request_6]
+    }
+    cbsd_records_domain_proxy_1 = {
+        'registrationRequests': [device_3, device_4, device_7],
+        'grantRequests': [grant_request_3, grant_request_4, grant_request_7]
+    }
+
+    # Protected entity record
+    protected_entities = {
+        'fssRecords': [fss_record]
+    }
+
+    # SAS Test Harnesses configurations,
+    # Following configurations are for two SAS test harnesses
+    sas_test_harness_device_1 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_a.json')))
+    sas_test_harness_device_1['fccId'] = 'test_fcc_id_1'
+    sas_test_harness_device_1['userId'] = 'test_user_id_1'
+
+    sas_test_harness_device_2 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_b.json')))
+    sas_test_harness_device_2['fccId'] = 'test_fcc_id_2'
+    sas_test_harness_device_2['userId'] = 'test_user_id_2'
+
+    sas_test_harness_device_3 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_c.json')))
+    sas_test_harness_device_3['fccId'] = 'test_fcc_id_3'
+    sas_test_harness_device_3['userId'] = 'test_user_id_3'
+
+    # Generate Cbsd FAD Records for SAS Test Harness 0
+    cbsd_fad_records_sas_test_harness_0 = generateCbsdRecords(
+        [sas_test_harness_device_1], [[grant_request_1]])
+
+    # Generate Cbsd FAD Records for SAS Test Harness 1
+    cbsd_fad_records_sas_test_harness_1 = generateCbsdRecords(
+        [sas_test_harness_device_2, sas_test_harness_device_3],
+        [[grant_request_4], [grant_request_6]])
+
+    # SAS Test Harnesses configuration
+    sas_test_harness_0_config = {
+        'sasTestHarnessName': 'SAS-TH-1',
+        'hostName': 'localhost',
+        'port': 9001,
+        'serverCert': os.path.join('certs', 'server.cert'),
+        'serverKey': os.path.join('certs', 'server.key'),
+        'caCert': os.path.join('certs', 'ca.cert')
+    }
+    sas_test_harness_1_config = {
+        'sasTestHarnessName': 'SAS-TH-2',
+        'hostName': 'localhost',
+        'port': 9002,
+        'serverCert': os.path.join('certs', 'server.cert'),
+        'serverKey': os.path.join('certs', 'server.key'),
+        'caCert': os.path.join('certs', 'ca.cert')
+    }
+
+    # Generate SAS Test Harnesses dump records
+    dump_records_sas_test_harness_0 = {
+        'cbsdRecords': cbsd_fad_records_sas_test_harness_0
+    }
+    dump_records_sas_test_harness_1 = {
+        'cbsdRecords': cbsd_fad_records_sas_test_harness_1
+    }
+
+    iteration_config = {
+        'cbsdRequestsWithDomainProxies': [cbsd_records_domain_proxy_0,
+                                          cbsd_records_domain_proxy_1],
+        'cbsdRecords': [
+            {'registrationRequest': device_5,
+             'grantRequest': grant_request_5,
+             'clientCert': os.path.join('certs', 'client.cert'),
+             'clientKey': os.path.join('certs', 'client.key')}],
+        'protectedEntities': protected_entities,
+        'dpaActivationList': [],
+        'dpaDeactivationList': [],
+        'sasTestHarnessData': [dump_records_sas_test_harness_0,
+                               dump_records_sas_test_harness_1]
+    }
+
+    # Create the actual config.
+    config = {
+        'conditionalRegistrationData': conditionals,
+        'iterationData': [iteration_config],
+        'sasTestHarnessConfigs': [sas_test_harness_0_config,
+                                  sas_test_harness_1_config],
+        'domainProxyConfigs': [
+            {'cert': os.path.join('certs', 'dp_1_client.cert'),
+             'key': os.path.join('certs', 'dp_1_client.key')},
+            {'cert': os.path.join('certs', 'dp_2_client.cert'),
+             'key': os.path.join('certs', 'dp_2_client.key')}
+        ],
+        'deltaIap': 2
+    }
+    writeConfig(filename, config)
+
+  @configurable_testcase(generate_FPR_2_default_config)
+  def test_WINNF_FT_S_FPR_2(self, config_filename):
+    """Multiple CBSDs from Multiple SASs Inside and Outside the Neighborhood
+    of an FSS Station for Scenario 1 with TT&C Flag = ON.
+    """
+    config = loadConfig(config_filename)
+    # TODO
+    # test_type= enum (MCP, FSS)
+    # Invoke MCP test steps 1 through 22.
+    # self.executeMcpTestSteps(config, test_type)
+
+  def generate_FPR_4_default_config(self, filename):
+    """Generates the WinnForum configuration for FPR.4."""
+
+    # Load FSS station operating at range 3700 to 4200 MHz, TT&C flag ON.
+    fss_data = json.load(
+        open(os.path.join('testcases', 'testdata', 'fss_record_0.json')))
+    fss_record = fss_data['record']
+    fss_record['deploymentParam'][0]['operationParam'][
+        'operationFrequencyRange']['lowFrequency'] = 3700000000
+    fss_record['deploymentParam'][0]['operationParam'][
+        'operationFrequencyRange']['highFrequency'] = 4200000000
+    fss_data['ttc'] = True
+
+    # Load devices and grant info for Scenario 1.
+    # Loading device_1 (Cat A) to a location within 40 km of FSS,
+    # frequency range outside of FSS band.
+    device_1 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_a.json')))
+    device_1['installationParam'][
+        'latitude'] = fss_record['installationParam']['latitude'] + 0.20
+    device_1['installationParam'][
+        'longitude'] = fss_record['installationParam']['longitude']
+    grant_request_1 = json.load(
+        open(os.path.join('testcases', 'testdata', 'grant_0.json')))
+    grant_request_1['operationParam'][
+        'operationFrequencyRange']['lowFrequency'] = 3560000000
+    grant_request_1['operationParam'][
+        'operationFrequencyRange']['highFrequency'] = 3570000000
+
+    # Loading device_2 (Cat B) to a location within 40 km of FSS,
+    # frequency range outside of FSS band, overlapping device 1 band.
+    device_2 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_b.json')))
+    device_2['installationParam'][
+        'latitude'] = fss_record['installationParam']['latitude']
+    device_2['installationParam'][
+        'longitude'] = fss_record['installationParam']['longitude'] + 0.20
+    grant_request_2 = json.load(
+        open(os.path.join('testcases', 'testdata', 'grant_0.json')))
+    grant_request_2['operationParam'][
+        'operationFrequencyRange']['lowFrequency'] = 3565000000
+    grant_request_2['operationParam'][
+        'operationFrequencyRange']['highFrequency'] = 3575000000
+
+    # Loading device_3 (Cat A) to a location within 40 km of FSS,
+    # frequency range outside of FSS band.
+    device_3 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_c.json')))
+    device_3['installationParam'][
+        'latitude'] = fss_record['installationParam']['latitude'] + 0.05
+    device_3['installationParam'][
+        'longitude'] = fss_record['installationParam']['longitude'] + 0.05
+    grant_request_3 = json.load(
+        open(os.path.join('testcases', 'testdata', 'grant_0.json')))
+    grant_request_3['operationParam'][
+        'operationFrequencyRange']['lowFrequency'] = 3590000000
+    grant_request_3['operationParam'][
+        'operationFrequencyRange']['highFrequency'] = 3600000000
+
+    # Loading device_4 (Cat B) to a location within 40 km of FSS,
+    # frequency range overlapping FSS band.
+    device_4 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_d.json')))
+    device_4['installationParam'][
+        'latitude'] = fss_record['installationParam']['latitude'] - 0.05
+    device_4['installationParam'][
+        'longitude'] = fss_record['installationParam']['longitude'] - 0.05
+    grant_request_4 = json.load(
+        open(os.path.join('testcases', 'testdata', 'grant_0.json')))
+    grant_request_4['operationParam'][
+        'operationFrequencyRange']['lowFrequency'] = 3620000000
+    grant_request_4['operationParam'][
+        'operationFrequencyRange']['highFrequency'] = 3630000000
+
+    # Load Conditional Data for Cat B devices (devices 2 and 4).
+    self.assertEqual(device_2['cbsdCategory'], 'B')
+    conditionals_device_2 = {
+        'cbsdCategory': device_2['cbsdCategory'],
+        'fccId': device_2['fccId'],
+        'cbsdSerialNumber': device_2['cbsdSerialNumber'],
+        'airInterface': device_2['airInterface'],
+        'installationParam': device_2['installationParam'],
+        'measCapability': device_2['measCapability']
+    }
+
+    self.assertEqual(device_4['cbsdCategory'], 'B')
+    conditionals_device_4 = {
+        'cbsdCategory': device_4['cbsdCategory'],
+        'fccId': device_4['fccId'],
+        'cbsdSerialNumber': device_4['cbsdSerialNumber'],
+        'airInterface': device_4['airInterface'],
+        'installationParam': device_4['installationParam'],
+        'measCapability': device_4['measCapability']
+    }
+
+    conditionals = [conditionals_device_2, conditionals_device_4]
+
+    # Remove conditionals from registration
+    del device_2['cbsdCategory']
+    del device_2['airInterface']
+    del device_2['installationParam']
+    del device_2['measCapability']
+    del device_4['cbsdCategory']
+    del device_4['airInterface']
+    del device_4['installationParam']
+    del device_4['measCapability']
+
+    # DP Registration and grant records
+    cbsd_records_domain_proxy_0 = {
+        'registrationRequests': [device_1, device_2],
+        'grantRequests': [grant_request_1, grant_request_2]
+    }
+    cbsd_records_domain_proxy_1 = {
+        'registrationRequests': [device_3],
+        'grantRequests': [grant_request_3]
+    }
+
+    # Protected entity record
+    protected_entities = {
+        'fssRecords': [fss_record]
+    }
+
+    # SAS Test Harnesses configurations,
+    # Following configurations are for two SAS test harnesses
+    sas_test_harness_device_1 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_a.json')))
+    sas_test_harness_device_1['fccId'] = 'test_fcc_id_1'
+    sas_test_harness_device_1['userId'] = 'test_user_id_1'
+
+    sas_test_harness_device_2 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_b.json')))
+    sas_test_harness_device_2['fccId'] = 'test_fcc_id_2'
+    sas_test_harness_device_2['userId'] = 'test_user_id_2'
+
+    sas_test_harness_device_3 = json.load(
+        open(os.path.join('testcases', 'testdata', 'device_c.json')))
+    sas_test_harness_device_3['fccId'] = 'test_fcc_id_3'
+    sas_test_harness_device_3['userId'] = 'test_user_id_3'
+
+    # Generate Cbsd FAD Records for SAS Test Harness 0
+    cbsd_fad_records_sas_test_harness_0 = generateCbsdRecords(
+        [sas_test_harness_device_1], [[grant_request_1]])
+
+    # Generate Cbsd FAD Records for SAS Test Harness 1
+    cbsd_fad_records_sas_test_harness_1 = generateCbsdRecords(
+        [sas_test_harness_device_2, sas_test_harness_device_3],
+        [[grant_request_2], [grant_request_3]])
+
+    # SAS Test Harnesses configuration
+    sas_test_harness_0_config = {
+        'sasTestHarnessName': 'SAS-TH-1',
+        'hostName': 'localhost',
+        'port': 9001,
+        'serverCert': os.path.join('certs', 'server.cert'),
+        'serverKey': os.path.join('certs', 'server.key'),
+        'caCert': os.path.join('certs', 'ca.cert')
+    }
+    sas_test_harness_1_config = {
+        'sasTestHarnessName': 'SAS-TH-2',
+        'hostName': 'localhost',
+        'port': 9002,
+        'serverCert': os.path.join('certs', 'server.cert'),
+        'serverKey': os.path.join('certs', 'server.key'),
+        'caCert': os.path.join('certs', 'ca.cert')
+    }
+
+    # Generate SAS Test Harnesses dump records
+    dump_records_sas_test_harness_0 = {
+        'cbsdRecords': cbsd_fad_records_sas_test_harness_0
+    }
+    dump_records_sas_test_harness_1 = {
+        'cbsdRecords': cbsd_fad_records_sas_test_harness_1
+    }
+
+    iteration_config = {
+        'cbsdRequestsWithDomainProxies': [cbsd_records_domain_proxy_0,
+                                          cbsd_records_domain_proxy_1],
+        'cbsdRecords': [
+            {'registrationRequest': device_4,
+             'grantRequest': grant_request_4,
+             'clientCert': os.path.join('certs', 'client.cert'),
+             'clientKey': os.path.join('certs', 'client.key')}],
+        'protectedEntities': protected_entities,
+        'dpaActivationList': [],
+        'dpaDeactivationList': [],
+        'sasTestHarnessData': [dump_records_sas_test_harness_0,
+                               dump_records_sas_test_harness_1]
+    }
+
+    # Create the actual config.
+    config = {
+        'conditionalRegistrationData': conditionals,
+        'iterationData': [iteration_config],
+        'sasTestHarnessConfigs': [sas_test_harness_0_config,
+                                  sas_test_harness_1_config],
+        'domainProxyConfigs': [
+            {'cert': os.path.join('certs', 'dp_1_client.cert'),
+             'key': os.path.join('certs', 'dp_1_client.key')},
+            {'cert': os.path.join('certs', 'dp_2_client.cert'),
+             'key': os.path.join('certs', 'dp_2_client.key')}
+        ],
+        'deltaIap': 2
+    }
+    writeConfig(filename, config)
+
+  @configurable_testcase(generate_FPR_4_default_config)
+  def test_WINNF_FT_S_FPR_4(self, config_filename):
+    """Multiple CBSDs from Multiple SASs Inside and Outside the Neighborhood
+    of an FSS Station for Scenario 2 with TT&C Flag = ON.
+    """
+    config = loadConfig(config_filename)
+    # TODO
+    # test_type= enum (MCP, FSS)
+    # Invoke MCP test steps 1 through 22.
+    # self.executeMcpTestSteps(config, test_type)
     
   def generate_FPR_5_default_config(self, filename):
     """Generates the WinnForum configuration for FPR.5."""

--- a/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
@@ -195,7 +195,7 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
 
     # Protected entity record
     protected_entities = {
-        'fssRecords': [fss_record]
+        'fssRecords': [fss_data]
     }
 
     # SAS Test Harnesses configurations,
@@ -229,16 +229,16 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
         'sasTestHarnessName': 'SAS-TH-1',
         'hostName': 'localhost',
         'port': 9001,
-        'serverCert': os.path.join('certs', 'server.cert'),
-        'serverKey': os.path.join('certs', 'server.key'),
+        'serverCert': os.path.join('certs', 'sas.cert'),
+        'serverKey': os.path.join('certs', 'sas.key'),
         'caCert': os.path.join('certs', 'ca.cert')
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
         'hostName': 'localhost',
         'port': 9002,
-        'serverCert': os.path.join('certs', 'server.cert'),
-        'serverKey': os.path.join('certs', 'server.key'),
+        'serverCert': os.path.join('certs', 'sas_1.cert'),
+        'serverKey': os.path.join('certs', 'sas_1.key'),
         'caCert': os.path.join('certs', 'ca.cert')
     }
 
@@ -272,10 +272,10 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
         'sasTestHarnessConfigs': [sas_test_harness_0_config,
                                   sas_test_harness_1_config],
         'domainProxyConfigs': [
-            {'cert': os.path.join('certs', 'dp_1_client.cert'),
-             'key': os.path.join('certs', 'dp_1_client.key')},
-            {'cert': os.path.join('certs', 'dp_2_client.cert'),
-             'key': os.path.join('certs', 'dp_2_client.key')}
+            {'cert': os.path.join('certs', 'domain_proxy.cert'),
+             'key': os.path.join('certs', 'domain_proxy.key')},
+            {'cert': os.path.join('certs', 'domain_proxy_1.cert'),
+             'key': os.path.join('certs', 'domain_proxy_1.key')}
         ],
         'deltaIap': 2
     }
@@ -411,7 +411,7 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
 
     # Protected entity record
     protected_entities = {
-        'fssRecords': [fss_record]
+        'fssRecords': [fss_data]
     }
 
     # SAS Test Harnesses configurations,
@@ -445,16 +445,16 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
         'sasTestHarnessName': 'SAS-TH-1',
         'hostName': 'localhost',
         'port': 9001,
-        'serverCert': os.path.join('certs', 'server.cert'),
-        'serverKey': os.path.join('certs', 'server.key'),
+        'serverCert': os.path.join('certs', 'sas.cert'),
+        'serverKey': os.path.join('certs', 'sas.key'),
         'caCert': os.path.join('certs', 'ca.cert')
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
         'hostName': 'localhost',
         'port': 9002,
-        'serverCert': os.path.join('certs', 'server.cert'),
-        'serverKey': os.path.join('certs', 'server.key'),
+        'serverCert': os.path.join('certs', 'sas_1.cert'),
+        'serverKey': os.path.join('certs', 'sas_1.key'),
         'caCert': os.path.join('certs', 'ca.cert')
     }
 
@@ -488,10 +488,10 @@ class FSSProtectionTestcase(sas_testcase.SasTestCase):
         'sasTestHarnessConfigs': [sas_test_harness_0_config,
                                   sas_test_harness_1_config],
         'domainProxyConfigs': [
-            {'cert': os.path.join('certs', 'dp_1_client.cert'),
-             'key': os.path.join('certs', 'dp_1_client.key')},
-            {'cert': os.path.join('certs', 'dp_2_client.cert'),
-             'key': os.path.join('certs', 'dp_2_client.key')}
+            {'cert': os.path.join('certs', 'domain_proxy.cert'),
+             'key': os.path.join('certs', 'domain_proxy.key')},
+            {'cert': os.path.join('certs', 'domain_proxy_1.cert'),
+             'key': os.path.join('certs', 'domain_proxy_1.key')}
         ],
         'deltaIap': 2
     }


### PR DESCRIPTION
Noticed that we use 2 peer SASs in these configs, but they use same certs.
This is also the case for similar testcases EPR, GPR, PPR.

Will address this issue in a separate PR.