### PR TITLE
Give DomainProxy it's own default cert/key

### DIFF
--- a/src/harness/sas.py
+++ b/src/harness/sas.py
@@ -30,22 +30,8 @@ def GetTestingSas():
   sas_sas_version = config_parser.get('SasConfig', 'SasSasVersion')
   sas_admin_id = config_parser.get('SasConfig', 'AdminId')
   return SasImpl(cbsd_sas_rsa_base_url, cbsd_sas_ec_base_url, sas_sas_rsa_base_url,\
-    sas_sas_ec_base_url, cbsd_sas_version, sas_sas_version, sas_admin_id), SasAdminImpl(admin_api_base_url)  
+    sas_sas_ec_base_url, cbsd_sas_version, sas_sas_version, sas_admin_id), SasAdminImpl(admin_api_base_url)
 
-def GetDefaultCbsdSSLCertPath():
-  return os.path.join('certs', 'client.cert')
-
-
-def GetDefaultCbsdSSLKeyPath():
-  return os.path.join('certs', 'client.key')
-
-
-def GetDefaultSasSSLCertPath():
-  return os.path.join('certs', 'client.cert')
-
-
-def GetDefaultSasSSLKeyPath():
-  return os.path.join('certs', 'client.key')
 
 class SasImpl(sas_interface.SasInterface):
   """Implementation of SasInterface for SAS certification testing."""
@@ -94,22 +80,34 @@ class SasImpl(sas_interface.SasInterface):
       url += '/%s' % request
     return RequestGet(url,
                       self._tls_config.WithClientCertificate(
-                          ssl_cert or GetDefaultSasSSLCertPath(),
-                          ssl_key or GetDefaultSasSSLKeyPath()))
+                          ssl_cert or self.GetDefaultSasSSLCertPath(),
+                          ssl_key or self.GetDefaultSasSSLKeyPath()))
 
   def _CbsdRequest(self, method_name, request, ssl_cert=None, ssl_key=None):
     return RequestPost('https://%s/%s/%s' % (self.cbsd_sas_active_base_url, self.cbsd_sas_version,
                                              method_name), request,
                        self._tls_config.WithClientCertificate(
-                           ssl_cert or GetDefaultCbsdSSLCertPath(),
-                           ssl_key or GetDefaultCbsdSSLKeyPath()))
+                           ssl_cert or self.GetDefaultCbsdSSLCertPath(),
+                           ssl_key or self.GetDefaultCbsdSSLKeyPath()))
 
   def DownloadFile(self, url, ssl_cert=None, ssl_key=None):
     return RequestGet(url,
                       self._tls_config.WithClientCertificate(
                           ssl_cert if ssl_cert else
-                          GetDefaultSasSSLCertPath(), ssl_key
-                          if ssl_key else GetDefaultSasSSLKeyPath()))
+                          self.GetDefaultSasSSLCertPath(), ssl_key
+                          if ssl_key else self.GetDefaultSasSSLKeyPath()))
+
+  def GetDefaultCbsdSSLCertPath(self):
+    return os.path.join('certs', 'client.cert')
+
+  def GetDefaultCbsdSSLKeyPath(self):
+    return os.path.join('certs', 'client.key')
+
+  def GetDefaultSasSSLCertPath(self):
+   return os.path.join('certs', 'sas.cert')
+
+  def GetDefaultSasSSLKeyPath(self):
+    return os.path.join('certs', 'sas.key')
 
   def UpdateSasRequestUrl(self, cipher):
     if 'ECDSA' in cipher:

--- a/src/harness/security_testcase.py
+++ b/src/harness/security_testcase.py
@@ -160,8 +160,8 @@ class SecurityTestCase(sas_testcase.SasTestCase):
       client_key: path to associated key file in PEM format to use with the optionally
         given |client_cert|. If 'None' path to the default CBSD key file will be used.
     """
-    client_cert = client_cert or sas.GetDefaultCbsdSSLCertPath()
-    client_key = client_key or sas.GetDefaultCbsdSSLKeyPath()
+    client_cert = client_cert or self._sas.GetDefaultCbsdSSLCertPath()
+    client_key = client_key or self._sas.GetDefaultCbsdSSLKeyPath()
     self._sas.UpdateCbsdRequestUrl(cipher)
     # Using pyOpenSSL low level API, does the SAS UUT server TLS session checks.
     self.assertTlsHandshakeSucceed(self._sas.cbsd_sas_active_base_url, [cipher],
@@ -208,8 +208,8 @@ class SecurityTestCase(sas_testcase.SasTestCase):
       ciphers: optional cipher method
       ssl_method: optional ssl_method
     """
-    client_cert = client_cert or sas.GetDefaultCbsdSSLCertPath()
-    client_key = client_key or sas.GetDefaultCbsdSSLKeyPath()
+    client_cert = client_cert or self._sas.GetDefaultCbsdSSLCertPath()
+    client_key = client_key or self._sas.GetDefaultCbsdSSLKeyPath()
 
     url = urlparse.urlparse('https://' + self._sas_admin._base_url)
     client = socket.socket()

--- a/src/harness/test_harness_objects.py
+++ b/src/harness/test_harness_objects.py
@@ -15,7 +15,6 @@
 """Implementation of multiple objects (Grant, Cbsd and DomainProxy).
    Mainly used in MCP and related test cases."""
 import logging
-from sas import GetDefaultSasSSLCertPath, GetDefaultSasSSLKeyPath
 from common_types import ResponseCodes
 
 class Grant(object):
@@ -137,8 +136,8 @@ class DomainProxy(object):
       ssl_key: Path to SSL key file.
       testcase: test case object from the caller.
     """
-    self.ssl_cert = ssl_cert if ssl_cert else GetDefaultSasSSLCertPath()
-    self.ssl_key = ssl_key if ssl_key else GetDefaultSasSSLKeyPath()
+    self.ssl_cert = ssl_cert if ssl_cert else self.GetDefaultDomainProxySSLCertPath()
+    self.ssl_key = ssl_key if ssl_key else self.GetDefaultDomainProxySSLKeyPath()
     self.cbsd_objects = {}
     self.testcase = testcase
 
@@ -351,3 +350,9 @@ class DomainProxy(object):
       if cbsd_object.hasAuthorizedGrant():
         cbsd_objects.append(cbsd_object)
     return cbsd_objects
+
+  def GetDefaultDomainProxySSLCertPath(self):
+  return os.path.join('certs', 'client.cert')
+
+  def GetDefaultDomainProxySSLKeyPath(self):
+    return os.path.join('certs', 'client.key')


### PR DESCRIPTION
- Moves default cert/key functions back into sas object.
- Gives Domain Proxy it's own default cert/key functions.
- Sets default sas cert/key to 'sas.cert' and 'sas.key'

Please review.