### PR TITLE
A few security fixes

### DIFF
--- a/src/harness/security_testcase.py
+++ b/src/harness/security_testcase.py
@@ -184,15 +184,15 @@ class SecurityTestCase(sas_testcase.SasTestCase):
       client_url: base URL of the (peer) SAS client.
     """
     self._sas.UpdateSasRequestUrl(cipher)
-    # Using pyOpenSSL low level API, does the SAS UUT server TLS session checks.
-    self.assertTlsHandshakeSucceed(self._sas.sas_sas_active_base_url, [cipher],
-                                   client_cert, client_key)
 
     # Does a regular SAS registration
     self.SasReset()
     certificate_hash = getCertificateFingerprint(client_cert)
     self._sas_admin.InjectPeerSas({'certificateHash': certificate_hash,
                                    'url': client_url})
+    # Using pyOpenSSL low level API, does the SAS UUT server TLS session checks.
+    self.assertTlsHandshakeSucceed(self._sas.sas_sas_active_base_url, [cipher],
+                                   client_cert, client_key)
     self._sas_admin.TriggerFullActivityDump()
     with CiphersOverload(self._sas, [cipher], client_cert, client_key):
       self._sas.GetFullActivityDump(client_cert, client_key)

--- a/src/harness/testcases/WINNF_FT_S_SSS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SSS_testcase.py
@@ -366,7 +366,7 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     certificate_hash = getCertificateFingerprint(config['sasCert'])
     self._sas_admin.InjectPeerSas({'certificateHash': certificate_hash,\
                                      'url': SAS_TEST_HARNESS_URL })
-    self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'], SAS_CERT, SAS_KEY)
+    self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'], config['sasCert'], config['sasKey'])
     trigger_succeed = False
     # Initiate Full Activity Dump
     try:


### PR DESCRIPTION
1. src/harness/security_testcase.py

These changes are to ensure the Peer SAS injection occurs before TLS checks.
Move code from line 188 to line 196: 
self.assertTlsHandshakeSucceed(self._sas_admin._base_url, [cipher],
client_cert, client_key)

2. src/harness/testcases/WINNF_FT_S_SSS_testcase.py

Test harness injects Peer SAS fingerprint's for config['sasCert'] but then performs original line 369 for TLS handshake success using SAS_CERT. This will never succeed because only config['sasCert'] has fingerprints in the SAS UUT, so line 369 should be changed to use config's key and certificate.

original: 
self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'], SAS_CERT, SAS_KEY)
proposed change: 
self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'], config['sasCert'], config['sasKey'])