### PR TITLE
fix sas version variable name

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_HBT_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_HBT_testcase.py
@@ -259,8 +259,10 @@ class HeartbeatTestcase(sas_testcase.SasTestCase):
       grant_ids.append(resp['grantId'])
     del request, response
 
+    # Save sas version
+    version = self._sas.cbsd_sas_version
     # Use higher than supported version.
-    self._sas._sas_version = 'v2.0'
+    self._sas.cbsd_sas_version = 'v5.0'
 
     # First Heartbeat with unsupported SAS-CBSD protocol version.
     heartbeat_request = []
@@ -281,10 +283,12 @@ class HeartbeatTestcase(sas_testcase.SasTestCase):
         transmit_expire_time = datetime.strptime(resp['transmitExpireTime'],
                                                  '%Y-%m-%dT%H:%M:%SZ')
         self.assertLessEqual(transmit_expire_time, datetime.utcnow())
-
     except HTTPError as e:
       # Allow HTTP status 404.
       self.assertEqual(e.error_code, 404)
+    finally:
+      # Put sas version back
+      self._sas.cbsd_sas_version = version
 
   @winnforum_testcase
   def test_WINNF_FT_S_HBT_4(self):

--- a/src/harness/testcases/WINNF_FT_S_HBT_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_HBT_testcase.py
@@ -259,8 +259,6 @@ class HeartbeatTestcase(sas_testcase.SasTestCase):
       grant_ids.append(resp['grantId'])
     del request, response
 
-    # Save sas version
-    version = self._sas.cbsd_sas_version
     # Use higher than supported version.
     self._sas.cbsd_sas_version = 'v5.0'
 
@@ -286,9 +284,6 @@ class HeartbeatTestcase(sas_testcase.SasTestCase):
     except HTTPError as e:
       # Allow HTTP status 404.
       self.assertEqual(e.error_code, 404)
-    finally:
-      # Put sas version back
-      self._sas.cbsd_sas_version = version
 
   @winnforum_testcase
   def test_WINNF_FT_S_HBT_4(self):

--- a/src/harness/testcases/WINNF_FT_S_REG_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_REG_testcase.py
@@ -901,8 +901,6 @@ class RegistrationTestcase(sas_testcase.SasTestCase):
     The response should be FAILURE 100.
     """
 
-    # Save sas version
-    version = self._sas.cbsd_sas_version
     # Use higher than supported version
     self._sas.cbsd_sas_version = 'v5.0'
 
@@ -927,9 +925,6 @@ class RegistrationTestcase(sas_testcase.SasTestCase):
     except HTTPError as e:
       # Allow HTTP status 404
       self.assertEqual(e.error_code, 404)
-    finally:
-      # Put sas version back
-      self._sas.cbsd_sas_version = version
 
   def generate_REG_11_default_config(self, filename):
     """Generates the WinnForum configuration for REG.11."""
@@ -1153,8 +1148,6 @@ class RegistrationTestcase(sas_testcase.SasTestCase):
     # Very light checking of the config file.
     self.assertEqual(len(config['fccIds']), len(config['userIds']))
     self.assertEqual(len(config['fccIds']), len(config['registrationRequests']))
-    # Save sas version
-    version = self._sas.cbsd_sas_version
     # Use the (higher) SAS version set in the config file.
     self._sas.cbsd_sas_version  = config['sasVersion']
 
@@ -1182,6 +1175,3 @@ class RegistrationTestcase(sas_testcase.SasTestCase):
     except HTTPError as e:
       # Allow HTTP status 404
       self.assertEqual(e.error_code, 404)
-    finally:
-      # Put sas version back
-      self._sas.cbsd_sas_version = version

--- a/src/harness/testcases/WINNF_FT_S_REG_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_REG_testcase.py
@@ -901,8 +901,10 @@ class RegistrationTestcase(sas_testcase.SasTestCase):
     The response should be FAILURE 100.
     """
 
+    # Save sas version
+    version = self._sas.cbsd_sas_version
     # Use higher than supported version
-    self._sas._sas_version = 'v2.0'
+    self._sas.cbsd_sas_version = 'v5.0'
 
     # Load Devices
     device_a = json.load(
@@ -925,6 +927,9 @@ class RegistrationTestcase(sas_testcase.SasTestCase):
     except HTTPError as e:
       # Allow HTTP status 404
       self.assertEqual(e.error_code, 404)
+    finally:
+      # Put sas version back
+      self._sas.cbsd_sas_version = version
 
   def generate_REG_11_default_config(self, filename):
     """Generates the WinnForum configuration for REG.11."""
@@ -1148,8 +1153,10 @@ class RegistrationTestcase(sas_testcase.SasTestCase):
     # Very light checking of the config file.
     self.assertEqual(len(config['fccIds']), len(config['userIds']))
     self.assertEqual(len(config['fccIds']), len(config['registrationRequests']))
+    # Save sas version
+    version = self._sas.cbsd_sas_version
     # Use the (higher) SAS version set in the config file.
-    self._sas._sas_version  = config['sasVersion']
+    self._sas.cbsd_sas_version  = config['sasVersion']
 
     # Whitelist N1 FCC ID.
     for fcc_id, max_eirp_dbm_per_10_mhz in config['fccIds']:
@@ -1175,3 +1182,6 @@ class RegistrationTestcase(sas_testcase.SasTestCase):
     except HTTPError as e:
       # Allow HTTP status 404
       self.assertEqual(e.error_code, 404)
+    finally:
+      # Put sas version back
+      self._sas.cbsd_sas_version = version

--- a/src/harness/testcases/WINNF_FT_S_RLQ_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_RLQ_testcase.py
@@ -365,9 +365,9 @@ class RelinquishmentTestcase(sas_testcase.SasTestCase):
     del request, response
 
     # Save sas version
-    version = self._sas._sas_version
+    version = self._sas.cbsd_sas_version
     # Use higher than supported version
-    self._sas._sas_version = 'v5.0'
+    self._sas.cbsd_sas_version = 'v5.0'
 
     # Relinquish the grants
     request = {'relinquishmentRequest': [
@@ -390,7 +390,7 @@ class RelinquishmentTestcase(sas_testcase.SasTestCase):
       self.assertEqual(e.error_code, 404)
     finally:
       # Put sas version back
-      self._sas._sas_version = version
+      self._sas.cbsd_sas_version = version
 
   @winnforum_testcase
   def test_WINNF_FT_S_RLQ_5(self):

--- a/src/harness/testcases/WINNF_FT_S_RLQ_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_RLQ_testcase.py
@@ -364,8 +364,6 @@ class RelinquishmentTestcase(sas_testcase.SasTestCase):
       grant_id.append(resp['grantId'])
     del request, response
 
-    # Save sas version
-    version = self._sas.cbsd_sas_version
     # Use higher than supported version
     self._sas.cbsd_sas_version = 'v5.0'
 
@@ -388,9 +386,6 @@ class RelinquishmentTestcase(sas_testcase.SasTestCase):
     except HTTPError as e:
       # Allow HTTP status 404
       self.assertEqual(e.error_code, 404)
-    finally:
-      # Put sas version back
-      self._sas.cbsd_sas_version = version
 
   @winnforum_testcase
   def test_WINNF_FT_S_RLQ_5(self):


### PR DESCRIPTION
The following testcases need updated sas cbsd version variable names:

RLQ.4
REG.10
REG.13
HBT.3

self._sas._sas_version should be self._sas.cbsd_sas_version

Also, REG.10, REG.13, and RLQ.4 set the CBSD SAS version to a higher version, but do not put the version back. Added the logic to put the version numbers back to the original config version.