### PR TITLE
Reference model general cleanup - Part 1

### DIFF
--- a/src/harness/reference_models/common/data.py
+++ b/src/harness/reference_models/common/data.py
@@ -20,6 +20,7 @@ the utility routines for creating them for example from FAD objects.
 from collections import namedtuple
 import enum
 from reference_models.geo import drive
+from sas_test_harness import generateCbsdReferenceId
 
 
 class ProtectedEntityType(enum.Enum):
@@ -49,7 +50,7 @@ class CbsdGrantInfo(namedtuple('CbsdGrantInfo',
                                 'is_managed_grant'])):
   """CbsdGrantInfo.
 
-  Holds all parameters of a CBSD grant.
+  Holds all parameters of a CBSD grant (registration and grant).
 
   Attributes:
     latitude: The CBSD latitude (degrees).
@@ -67,6 +68,21 @@ class CbsdGrantInfo(namedtuple('CbsdGrantInfo',
     is_managed_grant: True iff the grant belongs to the managing SAS.
   """
   __slots__ = ()
+
+
+# Define FSS Protection Point, i.e., a tuple with named fields of
+# 'latitude', 'longitude', 'height_agl', 'max_gain_dbi', 'pointing_azimuth',
+# 'pointing_elevation'
+FssInformation = namedtuple('FssInformation',
+                            ['height_agl', 'max_gain_dbi',
+                             'pointing_azimuth', 'pointing_elevation'])
+
+# Define ESC information, i.e., a tuple with named fields of
+# 'antenna_height', 'antenna_azimuth', 'antenna_gain_pattern'
+EscInformation = namedtuple('EscInformation',
+                            ['antenna_height', 'antenna_azimuth',
+                             'antenna_gain_pattern'])
+
 
 def constructCbsdGrantInfo(reg_request, grant_request, is_managing_sas=True):
   """Constructs a |CbsdGrantInfo| tuple from the given data."""
@@ -95,16 +111,41 @@ def constructCbsdGrantInfo(reg_request, grant_request, is_managing_sas=True):
       is_managed_grant=is_managing_sas)
 
 
-def getAllGrantInfoFromCbsdDataDump(cbsd_data_records, is_managing_sas=True):
+def getCbsdsNotPartOfPpaCluster(cbsds, ppa_record):
+    """Returns the CBSDs that are not part of a PPA cluster list.
+
+    Args:
+      cbsds : List of CBSDData objects.
+      ppa_record : A PPA record dictionary.
+    Returns:
+      A list of CBSDs that are not part of the PPA cluster list.
+    """
+    cbsds_not_part_of_ppa_cluster = []
+    # Compare the list of CBSDs with the PPA cluster list
+    for cbsd in cbsds:
+      cbsd_reference_id = generateCbsdReferenceId(cbsd['registration']['fccId'],
+                            cbsd['registration']['cbsdSerialNumber'])
+      if cbsd_reference_id not in ppa_record['ppaInfo']['cbsdReferenceId']:
+        cbsds_not_part_of_ppa_cluster.append(cbsd)
+
+    return cbsds_not_part_of_ppa_cluster
+
+
+def getAllGrantInfoFromCbsdDataDump(cbsd_data_records, is_managing_sas=True,
+                                    ppa_record=None):
   """Returns a list of |CbsdGrantInfo| from FAD object.
 
   Args:
     cbsd_data_records: A list of |CbsdData| objects retrieved from FAD records.
     is_managing_sas: Flag indicating if the `cbsd_data_record` from the managing SAS
       (True) or a peer SAS (False).
+    ppa_record: A PPA record dictionary. If None, ignored. If set, the returned grants
+      are not part of the PPA cluster list.
   """
 
   grant_objects = []
+  if ppa_record is not None:
+    cbsd_data_records = getCbsdsNotPartOfPpaCluster(cbsd_data_records, ppa_record)
 
   # Loop over each CBSD grant
   for cbsd_data_record in cbsd_data_records:
@@ -118,19 +159,22 @@ def getAllGrantInfoFromCbsdDataDump(cbsd_data_records, is_managing_sas=True):
   return grant_objects
 
 
-def getGrantObjectsFromFAD(sas_uut_fad_object, sas_th_fad_objects):
+def getGrantObjectsFromFAD(sas_uut_fad_object, sas_th_fad_objects,
+                           ppa_record=None):
   """Returns a list of |CbsdGrantInfo| for SAS UUT and peer SAS TH.
 
   Args:
     sas_uut_fad_object: FAD object from SAS UUT
     sas_th_fad_objects: a list of FAD objects from SAS Test Harness
+    ppa_record: A PPA record dictionary. If None, ignored. If set, the returned grants
+      are not part of the PPA cluster list.
   """
   # List of CBSD grant tuples extracted from FAD record
   grants = getAllGrantInfoFromCbsdDataDump(
-      sas_uut_fad_object.getCbsdRecords(), True)
+      sas_uut_fad_object.getCbsdRecords(), True, ppa_record)
   for fad in sas_th_fad_objects:
     grants.extend(getAllGrantInfoFromCbsdDataDump(
-        fad.getCbsdRecords(), False))
+        fad.getCbsdRecords(), False, ppa_record))
 
   return grants
 

--- a/src/harness/reference_models/common/mpool.py
+++ b/src/harness/reference_models/common/mpool.py
@@ -31,7 +31,6 @@ pool.map(...)
 # TODO(sbdt): review behavior in multiple platforms.
 
 import multiprocessing
-from concurrent import futures
 
 
 class _DummyPool(object):
@@ -97,5 +96,5 @@ def Configure(num_processes=-1, pool=None):
     if num_processes > num_cpus:
       num_processes = num_cpus
     if pool is None or num_processes != _num_processes:
-      _pool = futures.ProcessPoolExecutor(num_processes)
+      _pool = multiprocessing.Pool(processes=num_processes)
       _num_processes = num_processes

--- a/src/harness/reference_models/iap/iap_example.py
+++ b/src/harness/reference_models/iap/iap_example.py
@@ -23,126 +23,130 @@ import os
 import iap
 import time
 import multiprocessing
-from multiprocessing import Pool
+
+from reference_models.common import mpool
 from reference_models.interference import interference as interf
 from full_activity_dump import FullActivityDump
 
 # Number of processes for parallel execution
 NUM_OF_PROCESS = 30
 
-cbsd_0 = json.load(open(os.path.join('test_data', 'cbsd_0.json')))
-cbsd_1 = json.load(open(os.path.join('test_data', 'cbsd_1.json')))
-cbsd_2 = json.load(open(os.path.join('test_data', 'cbsd_2.json')))
-cbsd_3 = json.load(open(os.path.join('test_data', 'cbsd_3.json')))
-cbsd_4 = json.load(open(os.path.join('test_data', 'cbsd_4.json')))
-cbsd_5 = json.load(open(os.path.join('test_data', 'cbsd_5.json')))
-cbsd_6 = json.load(open(os.path.join('test_data', 'cbsd_6.json')))
-cbsd_7 = json.load(open(os.path.join('test_data', 'cbsd_7.json')))
-cbsd_8 = json.load(open(os.path.join('test_data', 'cbsd_8.json')))
-cbsd_9 = json.load(open(os.path.join('test_data', 'cbsd_9.json')))
-cbsd_10 = json.load(open(os.path.join('test_data', 'cbsd_10.json')))
-cbsd_11 = json.load(open(os.path.join('test_data', 'cbsd_11.json')))
-cbsd_12 = json.load(open(os.path.join('test_data', 'cbsd_12.json')))
-cbsd_13 = json.load(open(os.path.join('test_data', 'cbsd_13.json')))
-cbsd_14 = json.load(open(os.path.join('test_data', 'cbsd_14.json')))
-cbsd_15 = json.load(open(os.path.join('test_data', 'cbsd_15.json')))
-cbsd_16 = json.load(open(os.path.join('test_data', 'cbsd_16.json')))
-cbsd_17 = json.load(open(os.path.join('test_data', 'cbsd_17.json')))
-cbsd_18 = json.load(open(os.path.join('test_data', 'cbsd_18.json')))
-cbsd_19 = json.load(open(os.path.join('test_data', 'cbsd_19.json')))
-cbsd_20 = json.load(open(os.path.join('test_data', 'cbsd_20.json')))
-cbsd_21 = json.load(open(os.path.join('test_data', 'cbsd_21.json')))
-cbsd_22 = json.load(open(os.path.join('test_data', 'cbsd_22.json')))
-cbsd_23 = json.load(open(os.path.join('test_data', 'cbsd_23.json')))
+if __name__ == '__main__':
+
+  # Configure the multiprocess pool
+  mpool.Configure(NUM_OF_PROCESS)
+
+  cbsd_0 = json.load(open(os.path.join('test_data', 'cbsd_0.json')))
+  cbsd_1 = json.load(open(os.path.join('test_data', 'cbsd_1.json')))
+  cbsd_2 = json.load(open(os.path.join('test_data', 'cbsd_2.json')))
+  cbsd_3 = json.load(open(os.path.join('test_data', 'cbsd_3.json')))
+  cbsd_4 = json.load(open(os.path.join('test_data', 'cbsd_4.json')))
+  cbsd_5 = json.load(open(os.path.join('test_data', 'cbsd_5.json')))
+  cbsd_6 = json.load(open(os.path.join('test_data', 'cbsd_6.json')))
+  cbsd_7 = json.load(open(os.path.join('test_data', 'cbsd_7.json')))
+  cbsd_8 = json.load(open(os.path.join('test_data', 'cbsd_8.json')))
+  cbsd_9 = json.load(open(os.path.join('test_data', 'cbsd_9.json')))
+  cbsd_10 = json.load(open(os.path.join('test_data', 'cbsd_10.json')))
+  cbsd_11 = json.load(open(os.path.join('test_data', 'cbsd_11.json')))
+  cbsd_12 = json.load(open(os.path.join('test_data', 'cbsd_12.json')))
+  cbsd_13 = json.load(open(os.path.join('test_data', 'cbsd_13.json')))
+  cbsd_14 = json.load(open(os.path.join('test_data', 'cbsd_14.json')))
+  cbsd_15 = json.load(open(os.path.join('test_data', 'cbsd_15.json')))
+  cbsd_16 = json.load(open(os.path.join('test_data', 'cbsd_16.json')))
+  cbsd_17 = json.load(open(os.path.join('test_data', 'cbsd_17.json')))
+  cbsd_18 = json.load(open(os.path.join('test_data', 'cbsd_18.json')))
+  cbsd_19 = json.load(open(os.path.join('test_data', 'cbsd_19.json')))
+  cbsd_20 = json.load(open(os.path.join('test_data', 'cbsd_20.json')))
+  cbsd_21 = json.load(open(os.path.join('test_data', 'cbsd_21.json')))
+  cbsd_22 = json.load(open(os.path.join('test_data', 'cbsd_22.json')))
+  cbsd_23 = json.load(open(os.path.join('test_data', 'cbsd_23.json')))
 
 
-fss_0 = json.load(open(os.path.join('test_data', 'fss_0.json')))
-fss_1 = json.load(open(os.path.join('test_data', 'fss_1.json')))
+  fss_0 = json.load(open(os.path.join('test_data', 'fss_0.json')))
+  fss_1 = json.load(open(os.path.join('test_data', 'fss_1.json')))
 
-ppa_0 = json.load(open(os.path.join('test_data', 'ppa_0.json')))
-ppa_1 = json.load(open(os.path.join('test_data', 'ppa_1.json')))
-ppa_2 = json.load(open(os.path.join('test_data', 'ppa_2.json')))
-ppa_3 = json.load(open(os.path.join('test_data', 'ppa_3.json')))
+  ppa_0 = json.load(open(os.path.join('test_data', 'ppa_0.json')))
+  ppa_1 = json.load(open(os.path.join('test_data', 'ppa_1.json')))
+  ppa_2 = json.load(open(os.path.join('test_data', 'ppa_2.json')))
+  ppa_3 = json.load(open(os.path.join('test_data', 'ppa_3.json')))
 
-esc_0 = json.load(open(os.path.join('test_data', 'esc_0.json')))
+  esc_0 = json.load(open(os.path.join('test_data', 'esc_0.json')))
 
-gwpz_0 = json.load(open(os.path.join('test_data', 'gwpz_0.json')))
-gwpz_1 = json.load(open(os.path.join('test_data', 'gwpz_1.json')))
+  gwpz_0 = json.load(open(os.path.join('test_data', 'gwpz_0.json')))
+  gwpz_1 = json.load(open(os.path.join('test_data', 'gwpz_1.json')))
 
-pal_0 = json.load(open(os.path.join('test_data', 'pal_0.json')))
-pal_1 = json.load(open(os.path.join('test_data', 'pal_1.json')))
-pal_2 = json.load(open(os.path.join('test_data', 'pal_2.json')))
-pal_3 = json.load(open(os.path.join('test_data', 'pal_3.json')))
+  pal_0 = json.load(open(os.path.join('test_data', 'pal_0.json')))
+  pal_1 = json.load(open(os.path.join('test_data', 'pal_1.json')))
+  pal_2 = json.load(open(os.path.join('test_data', 'pal_2.json')))
+  pal_3 = json.load(open(os.path.join('test_data', 'pal_3.json')))
 
-sas_uut = FullActivityDump({
-          'cbsd': [cbsd_0, cbsd_1, cbsd_2, cbsd_3, cbsd_4, cbsd_5, cbsd_6,cbsd_7, cbsd_8, cbsd_9, cbsd_10, cbsd_11, cbsd_12, cbsd_13, cbsd_14, cbsd_15, cbsd_16, cbsd_17, cbsd_18, cbsd_19],
-          'esc_sensor': [], 
-          'zone': []
-        })  
-sas_th1 = FullActivityDump({
-          'cbsd': [cbsd_20], 
-          'esc_sensor': [],
-          'zone': []
-        }) 
-sas_th2 = FullActivityDump({
-          'cbsd': [cbsd_22, cbsd_23], 
-          'esc_sensor': [],
-          'zone': [],
-        })  
-pal_records = [pal_0, pal_1, pal_2, pal_3]
-fss_records = [fss_0, fss_1]
-esc_records = [esc_0]
-gwpz_records = [gwpz_0, gwpz_1]
-ppa_records = [ppa_0, ppa_1, ppa_2, ppa_3]
+  sas_uut = FullActivityDump({
+            'cbsd': [cbsd_0, cbsd_1, cbsd_2, cbsd_3, cbsd_4, cbsd_5, cbsd_6,cbsd_7, cbsd_8, cbsd_9, cbsd_10, cbsd_11, cbsd_12, cbsd_13, cbsd_14, cbsd_15, cbsd_16, cbsd_17, cbsd_18, cbsd_19],
+            'esc_sensor': [], 
+            'zone': []
+          })  
+  sas_th1 = FullActivityDump({
+            'cbsd': [cbsd_20], 
+            'esc_sensor': [],
+            'zone': []
+          }) 
+  sas_th2 = FullActivityDump({
+            'cbsd': [cbsd_22, cbsd_23], 
+            'esc_sensor': [],
+            'zone': [],
+          })  
+  pal_records = [pal_0, pal_1, pal_2, pal_3]
+  fss_records = [fss_0, fss_1]
+  esc_records = [esc_0]
+  gwpz_records = [gwpz_0, gwpz_1]
+  ppa_records = [ppa_0, ppa_1, ppa_2, ppa_3]
 
-sas_th_fad_objects = [sas_th1, sas_th2]
+  sas_th_fad_objects = [sas_th1, sas_th2]
 
-start_time = time.time()
+  start_time = time.time()
 
-for fss_record in fss_records:
-  # Get the frequency range of the FSS
-  fss_freq_range = fss_record['record']['deploymentParam'][0]\
-      ['operationParam']['operationFrequencyRange']
-  fss_low_freq = fss_freq_range['lowFrequency']
-  fss_high_freq = fss_freq_range['highFrequency']
+  for fss_record in fss_records:
+    # Get the frequency range of the FSS
+    fss_freq_range = fss_record['record']['deploymentParam'][0]\
+        ['operationParam']['operationFrequencyRange']
+    fss_low_freq = fss_freq_range['lowFrequency']
+    fss_high_freq = fss_freq_range['highFrequency']
 
-  # Get FSS T&C Flag value
-  fss_ttc_flag = fss_record['ttc']
-  
-  # FSS Passband is between 3600 and 4200
-  if (fss_low_freq >= interf.FSS_LOW_FREQ_HZ and 
-            fss_low_freq < interf.CBRS_HIGH_FREQ_HZ):
-    fss_cochannel_allowed_interference = iap.performIapForFssCochannel(fss_record, sas_uut, sas_th_fad_objects)
-    print('$$$$ IAP Reference Model Output for FSS Co-Channel: AP_IAP_Ref (mW/IAPBW)$$$$' +
-                                                  str(fss_cochannel_allowed_interference))
-    fss_blocking_allowed_interference = iap.performIapForFssBlocking(fss_record, sas_uut, sas_th_fad_objects)
-    print('$$$$ IAP Reference Model Output for FSS Blocking: AP_IAP_Ref (mW/IAPBW)$$$$' +
-                                                  str(fss_blocking_allowed_interference))
-  # FSS Passband is between 3700 and 4200 and TT&C flag is set to TRUE
-  elif (fss_low_freq >= interf.FSS_TTC_LOW_FREQ_HZ and 
-          fss_high_freq <= interf.FSS_TTC_HIGH_FREQ_HZ and
-          fss_ttc_flag is True):
-    fss_blocking_allowed_interference = iap.performIapForFssBlocking(fss_record, sas_uut, sas_th_fad_objects)
-    print('$$$$ IAP Reference Model Output for FSS Blocking: AP_IAP_Ref (mW/IAPBW)$$$$' +
-                                                  str(fss_blocking_allowed_interference))
-for esc_record in esc_records:
-  esc_allowed_interference = iap.performIapForEsc(esc_record, sas_uut, sas_th_fad_objects)
-  print('$$$$ IAP Reference Model Output for ESC: AP_IAP_Ref (mW/IAPBW)$$$$' +
-                                                  str(esc_allowed_interference))
-for gwpz_record in gwpz_records:
-  pool = Pool(processes=min(multiprocessing.cpu_count(), NUM_OF_PROCESS))
-  gwpz_allowed_interference = iap.performIapForGwpz(gwpz_record, sas_uut, sas_th_fad_objects)
-  print('$$$$ IAP Reference Model Output for GWPZ: AP_IAP_Ref (mW/IAPBW)$$$$' +
-                                                  str(gwpz_allowed_interference))
-for ppa_record in ppa_records:
-  pool = Pool(processes=min(multiprocessing.cpu_count(), NUM_OF_PROCESS))
-  ppa_allowed_interference = iap.performIapForPpa(ppa_record, sas_uut, sas_th_fad_objects, pal_records, pool)
-  print('$$$$ IAP Reference Model Output for PPA: AP_IAP_Ref (mW/IAPBW)$$$$' +
-                                                  str(ppa_allowed_interference))
+    # Get FSS T&C Flag value
+    fss_ttc_flag = fss_record['ttc']
 
-end_time = time.time()
+    # FSS Passband is between 3600 and 4200
+    if (fss_low_freq >= interf.FSS_LOW_FREQ_HZ and 
+              fss_low_freq < interf.CBRS_HIGH_FREQ_HZ):
+      fss_cochannel_allowed_interference = iap.performIapForFssCochannel(fss_record, sas_uut, sas_th_fad_objects)
+      print('$$$$ IAP Reference Model Output for FSS Co-Channel: AP_IAP_Ref (mW/IAPBW)$$$$' +
+                                                    str(fss_cochannel_allowed_interference))
+      fss_blocking_allowed_interference = iap.performIapForFssBlocking(fss_record, sas_uut, sas_th_fad_objects)
+      print('$$$$ IAP Reference Model Output for FSS Blocking: AP_IAP_Ref (mW/IAPBW)$$$$' +
+                                                    str(fss_blocking_allowed_interference))
+    # FSS Passband is between 3700 and 4200 and TT&C flag is set to TRUE
+    elif (fss_low_freq >= interf.FSS_TTC_LOW_FREQ_HZ and 
+            fss_high_freq <= interf.FSS_TTC_HIGH_FREQ_HZ and
+            fss_ttc_flag is True):
+      fss_blocking_allowed_interference = iap.performIapForFssBlocking(fss_record, sas_uut, sas_th_fad_objects)
+      print('$$$$ IAP Reference Model Output for FSS Blocking: AP_IAP_Ref (mW/IAPBW)$$$$' +
+                                                    str(fss_blocking_allowed_interference))
+  for esc_record in esc_records:
+    esc_allowed_interference = iap.performIapForEsc(esc_record, sas_uut, sas_th_fad_objects)
+    print('$$$$ IAP Reference Model Output for ESC: AP_IAP_Ref (mW/IAPBW)$$$$' +
+                                                    str(esc_allowed_interference))
+  for gwpz_record in gwpz_records:
+    gwpz_allowed_interference = iap.performIapForGwpz(gwpz_record, sas_uut, sas_th_fad_objects)
+    print('$$$$ IAP Reference Model Output for GWPZ: AP_IAP_Ref (mW/IAPBW)$$$$' +
+                                                    str(gwpz_allowed_interference))
+  for ppa_record in ppa_records:
+    ppa_allowed_interference = iap.performIapForPpa(ppa_record, sas_uut, sas_th_fad_objects, pal_records)
+    print('$$$$ IAP Reference Model Output for PPA: AP_IAP_Ref (mW/IAPBW)$$$$' +
+                                                    str(ppa_allowed_interference))
 
-print('$$$$ Computation time: $$$$' + str(end_time - start_time))
+  end_time = time.time()
+
+  print('$$$$ Computation time: $$$$' + str(end_time - start_time))
 
 
 

--- a/src/harness/reference_models/interference/aggregate_interference.py
+++ b/src/harness/reference_models/interference/aggregate_interference.py
@@ -43,8 +43,8 @@ from reference_models.interference import interference as interf
 from reference_models.geo import utils
 
 # The grid resolution for area based protection entities.
-GWPZ_GRID_RES_ARCSEC = 10
-PPA_GRID_RES_ARCSEC = 10
+GWPZ_GRID_RES_ARCSEC = 2
+PPA_GRID_RES_ARCSEC = 2
 
 
 def calculateAggregateInterferenceForFssCochannel(fss_record, cbsd_list):

--- a/src/harness/reference_models/interference/aggregate_interference_example.py
+++ b/src/harness/reference_models/interference/aggregate_interference_example.py
@@ -13,10 +13,10 @@
 #    limitations under the License.
 
 # =============================================================================
-# Test Aggregate Interference calculation for GWPZ, PPA, FSS Co-Channel, 
+# Test Aggregate Interference calculation for GWPZ, PPA, FSS Co-Channel,
 # FSS Blocking and ESC Sensor incumbent types.
 # Expected result is dictionary containing aggregate interference
-# value at a protection constraint. 
+# value at a protection constraint.
 # =============================================================================
 import json
 import os
@@ -29,7 +29,7 @@ from reference_models.interference import interference as interf
 
 import aggregate_interference
 
-# Number of parallel processes 
+# Number of parallel processes
 NUM_OF_PROCESS = 30
 
 
@@ -48,14 +48,14 @@ if __name__ == '__main__':
 
   # Configure the multiprocess pool
   mpool.Configure(NUM_OF_PROCESS)
-  
+
   # Data directory
   current_dir = os.getcwd()
   _BASE_DATA_DIR = os.path.join(current_dir, 'test_data')
 
   # Populate a list of CBSD registration requests
   cbsd_filename = ['cbsd_0.json',
-                   'cbsd_1.json', 'cbsd_2.json', 'cbsd_3.json', 
+                   'cbsd_1.json', 'cbsd_2.json', 'cbsd_3.json',
                    'cbsd_4.json', 'cbsd_5.json', 'cbsd_6.json',
                    'cbsd_7.json', 'cbsd_8.json', 'cbsd_9.json',
                    'cbsd_10.json', 'cbsd_11.json', 'cbsd_12.json',
@@ -68,9 +68,9 @@ if __name__ == '__main__':
   for cbsd_file in cbsd_filename:
     cbsd_record = json.load(open(os.path.join(_BASE_DATA_DIR, cbsd_file)))
     cbsd_list.append(cbsd_record)
-  
+
   fss_filename = ['fss_0.json', 'fss_1.json']
-   
+
   fss_list = []
   for fss_file in fss_filename:
     # load and inject FSS data with Overlapping Frequency of CBSD
@@ -78,28 +78,28 @@ if __name__ == '__main__':
     fss_list.append(fss_record)
 
   esc_filename = ['esc_0.json']
-  
+
   esc_list = []
   for esc_file in esc_filename:
     # load and inject ESC data with Overlapping Frequency of CBSD
     esc_record = json.load(
       open(os.path.join(_BASE_DATA_DIR, esc_file)))
     esc_list.append(esc_record)
-  
+
   gwpz_filename = ['gwpz_0.json', 'gwpz_1.json']
 
   gwpz_list = []
-  
+
   for gwpz_file in gwpz_filename:
     # load and inject GWPZ data with Overlapping Frequency of CBSD
     gwpz_record = json.load(
       open(os.path.join(_BASE_DATA_DIR, gwpz_file)))
     gwpz_list.append(gwpz_record)
-  
+
   ppa_filename = ['ppa_0.json', 'ppa_1.json', 'ppa_2.json', 'ppa_3.json']
 
   ppa_list = []
-  
+
   for ppa_file in ppa_filename:
     # load and inject PPA data with Overlapping Frequency of CBSD
     ppa_record = json.load(open(os.path.join(_BASE_DATA_DIR, ppa_file)))
@@ -112,7 +112,7 @@ if __name__ == '__main__':
   for pal_file in pal_filename:
       pal_record = json.load(open(os.path.join(_BASE_DATA_DIR, pal_file)))
       pal_list.append(pal_record)
-  
+
   # Determine aggregate interference caused by the grants in the neighborhood
   start_time = time.time()
 
@@ -125,31 +125,31 @@ if __name__ == '__main__':
 
     # Get FSS T&C Flag value
     fss_ttc_flag = fss_record['ttc']
-  
+
     # FSS Passband is between 3600 and 4200
-    if (fss_low_freq >= interf.FSS_LOW_FREQ_HZ and 
+    if (fss_low_freq >= interf.FSS_LOW_FREQ_HZ and
             fss_low_freq < interf.CBRS_HIGH_FREQ_HZ):
       fss_cochannel_aggr_interference = aggregate_interference.\
         calculateAggregateInterferenceForFssCochannel(fss_record, cbsd_list)
-      print('Aggregate Interference (mW) output at FSS co-channel: ' + 
+      print('Aggregate Interference (mW) output at FSS co-channel: ' +
             str(CvtToList(fss_cochannel_aggr_interference)))
       fss_blocking_aggr_interference = aggregate_interference.\
         calculateAggregateInterferenceForFssBlocking(fss_record, cbsd_list)
-      print('\nAggregate Interference (mW) output at FSS blocking: \n' + 
+      print('\nAggregate Interference (mW) output at FSS blocking: \n' +
             str(CvtToList(fss_blocking_aggr_interference)))
     # FSS Passband is between 3700 and 4200 and TT&C flag is set to TRUE
-    elif (fss_low_freq >= interf.FSS_TTC_LOW_FREQ_HZ and 
+    elif (fss_low_freq >= interf.FSS_TTC_LOW_FREQ_HZ and
             fss_high_freq <= interf.FSS_TTC_HIGH_FREQ_HZ and
             fss_ttc_flag is True):
       fss_blocking_aggr_interference = aggregate_interference.\
         calculateAggregateInterferenceForFssBlocking(fss_record, cbsd_list)
-      print('\nAggregate Interference (mW) output at FSS blocking: \n' + 
+      print('\nAggregate Interference (mW) output at FSS blocking: \n' +
             str(CvtToList(fss_blocking_aggr_interference)))
 
   for esc_record in esc_list:
     esc_aggr_interference = aggregate_interference.\
       calculateAggregateInterferenceForEsc(esc_record, cbsd_list)
-    print('\nAggregate Interference (mW) output at ESC: \n' + 
+    print('\nAggregate Interference (mW) output at ESC: \n' +
           str(CvtToList(esc_aggr_interference)))
   for gwpz_record in gwpz_list:
     gwpz_aggr_interference = aggregate_interference.\

--- a/src/harness/reference_models/interference/aggregate_interference_example.py
+++ b/src/harness/reference_models/interference/aggregate_interference_example.py
@@ -33,6 +33,17 @@ import aggregate_interference
 NUM_OF_PROCESS = 30
 
 
+def CvtToList(data):
+  """Convert interf to a sorted list suitable for comparison."""
+  out_dict = {}
+  for k0, v0 in data.items():
+    for k1, v1 in v0.items():
+      out_dict[(k0, k1)] = v1
+
+  out_list = list(out_dict.items())
+  out_list.sort()
+  return out_list
+
 if __name__ == '__main__':
 
   # Configure the multiprocess pool
@@ -121,11 +132,11 @@ if __name__ == '__main__':
       fss_cochannel_aggr_interference = aggregate_interference.\
         calculateAggregateInterferenceForFssCochannel(fss_record, cbsd_list)
       print('Aggregate Interference (mW) output at FSS co-channel: ' + 
-                    str(fss_cochannel_aggr_interference))
+            str(CvtToList(fss_cochannel_aggr_interference)))
       fss_blocking_aggr_interference = aggregate_interference.\
         calculateAggregateInterferenceForFssBlocking(fss_record, cbsd_list)
       print('\nAggregate Interference (mW) output at FSS blocking: \n' + 
-                    str(fss_blocking_aggr_interference))
+            str(CvtToList(fss_blocking_aggr_interference)))
     # FSS Passband is between 3700 and 4200 and TT&C flag is set to TRUE
     elif (fss_low_freq >= interf.FSS_TTC_LOW_FREQ_HZ and 
             fss_high_freq <= interf.FSS_TTC_HIGH_FREQ_HZ and
@@ -133,22 +144,22 @@ if __name__ == '__main__':
       fss_blocking_aggr_interference = aggregate_interference.\
         calculateAggregateInterferenceForFssBlocking(fss_record, cbsd_list)
       print('\nAggregate Interference (mW) output at FSS blocking: \n' + 
-                    str(fss_blocking_aggr_interference))
+            str(CvtToList(fss_blocking_aggr_interference)))
 
   for esc_record in esc_list:
     esc_aggr_interference = aggregate_interference.\
       calculateAggregateInterferenceForEsc(esc_record, cbsd_list)
     print('\nAggregate Interference (mW) output at ESC: \n' + 
-                    str(esc_aggr_interference))
+          str(CvtToList(esc_aggr_interference)))
   for gwpz_record in gwpz_list:
     gwpz_aggr_interference = aggregate_interference.\
       calculateAggregateInterferenceForGwpz(gwpz_record, cbsd_list)
-    print('\nAggregate Interference (mW) output at GWPZ: \n' + str(gwpz_aggr_interference) )
+    print('\nAggregate Interference (mW) output at GWPZ: \n' + str(CvtToList(gwpz_aggr_interference)))
 
   for ppa_record in ppa_list:
     ppa_aggr_interference = aggregate_interference.\
       calculateAggregateInterferenceForPpa(ppa_record, pal_list, cbsd_list)
-    print('\nAggregate Interference (mW) output at PPA: \n' + str(ppa_aggr_interference))
+    print('\nAggregate Interference (mW) output at PPA: \n' + str(CvtToList(ppa_aggr_interference)))
 
   end_time = time.time()
   print('\nComputation time: \n' + str(end_time - start_time))

--- a/src/harness/reference_models/interference/aggregate_interference_example.py
+++ b/src/harness/reference_models/interference/aggregate_interference_example.py
@@ -22,11 +22,12 @@ import json
 import os
 from pykml import parser
 from collections import namedtuple
-import aggregate_interference
 import time
-from multiprocessing import Pool
-import multiprocessing
+
+from reference_models.common import mpool
 from reference_models.interference import interference as interf
+
+import aggregate_interference
 
 # Number of parallel processes 
 NUM_OF_PROCESS = 30
@@ -34,6 +35,9 @@ NUM_OF_PROCESS = 30
 
 if __name__ == '__main__':
 
+  # Configure the multiprocess pool
+  mpool.Configure(NUM_OF_PROCESS)
+  
   # Data directory
   current_dir = os.getcwd()
   _BASE_DATA_DIR = os.path.join(current_dir, 'test_data')
@@ -137,15 +141,13 @@ if __name__ == '__main__':
     print('\nAggregate Interference (mW) output at ESC: \n' + 
                     str(esc_aggr_interference))
   for gwpz_record in gwpz_list:
-    pool = Pool(processes=min(multiprocessing.cpu_count(), NUM_OF_PROCESS))
     gwpz_aggr_interference = aggregate_interference.\
-      calculateAggregateInterferenceForGwpz(gwpz_record, cbsd_list, pool)
+      calculateAggregateInterferenceForGwpz(gwpz_record, cbsd_list)
     print('\nAggregate Interference (mW) output at GWPZ: \n' + str(gwpz_aggr_interference) )
 
   for ppa_record in ppa_list:
-    pool = Pool(processes=min(multiprocessing.cpu_count(), NUM_OF_PROCESS))
     ppa_aggr_interference = aggregate_interference.\
-      calculateAggregateInterferenceForPpa(ppa_record, pal_list, cbsd_list, pool)
+      calculateAggregateInterferenceForPpa(ppa_record, pal_list, cbsd_list)
     print('\nAggregate Interference (mW) output at PPA: \n' + str(ppa_aggr_interference))
 
   end_time = time.time()

--- a/src/harness/reference_models/interference/aggregate_interference_test.py
+++ b/src/harness/reference_models/interference/aggregate_interference_test.py
@@ -12,6 +12,8 @@
 #    See the License for the specific language governing permissions and
 #    limitations under the License.
 
+# See the test_results/aggregate_interference_unit_test_calc_sheet.xlsx
+# for a detail on the calculations.
 
 import os
 import unittest
@@ -28,28 +30,27 @@ class TestAggregateInterference(unittest.TestCase):
 
   @classmethod
   def setUpClass(cls):
-
-    # Load the list of CBSD records with registration and grant details 
+    # Load the list of CBSD records with registration and grant details
     cbsd_filename = ['cbsd_uut_ut.json', 'cbsd_th1_ut.json']
     cls.cbsd_list = []
     for cbsd_file in cbsd_filename:
       cbsd_record = json.load(open(os.path.join(TEST_DIR, cbsd_file)))
       cls.cbsd_list.append(cbsd_record)
 
-    # Load the protection entity data with overlapping frequency of CBSD grants 
+    # Load the protection entity data with overlapping frequency of CBSD grants
     cls.fss_record = json.load(open(os.path.join(TEST_DIR, 'fss_ut.json')))
     cls.ppa_record = json.load(open(os.path.join(TEST_DIR, 'ppa_ut.json')))
     cls.pal_record = json.load(open(os.path.join(TEST_DIR, 'pal_ut.json')))
-    cls.gwpz_record = json.load(open(os.path.join(TEST_DIR, 'gwpz_ut.json'))) 
+    cls.gwpz_record = json.load(open(os.path.join(TEST_DIR, 'gwpz_ut.json')))
     cls.esc_record = json.load(open(os.path.join(TEST_DIR, 'esc_ut.json')))
-
 
   def setUp(self):
     self.original_interference = interf.computeInterference
 
   def tearDown(self):
     interf.computeInterference = self.original_interference
-   
+
+
   def test_AggregateInterferenceFssCochannel(self):
     expected_interference = {34.4116: {-100.57114: [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, \
         2.2316393176900284, 2.2316393176900284, 0, 0, 0, 0, 0, 0, 0, 0]}}
@@ -57,39 +58,39 @@ class TestAggregateInterference(unittest.TestCase):
     interf.computeInterference = testutils.FakeInterferenceCalculator()
     allowed_interference = aggregate_interference.calculateAggregateInterferenceForFssCochannel(
                              TestAggregateInterference.fss_record, TestAggregateInterference.cbsd_list)
-    self.assertSameInterference(allowed_interference, expected_interference) 
-  
+    self.assertSameInterference(allowed_interference, expected_interference)
+
   def test_AggregateInterferenceFssBlocking(self):
-    expected_interference = {34.4116: {-100.57114: [4.462898399659984]}} 
+    expected_interference = {34.4116: {-100.57114: [4.462898399659984]}}
 
     interf.computeInterference = testutils.FakeInterferenceCalculator()
     allowed_interference = aggregate_interference.calculateAggregateInterferenceForFssBlocking(
                              TestAggregateInterference.fss_record, TestAggregateInterference.cbsd_list)
     self.assertSameInterference(allowed_interference, expected_interference)
-  
+
   def test_AggregateInterferenceEsc(self):
     expected_interference = {34.41029: {-100.56683: [0, 0, 2.229908301599665, 2.229908301599665,\
          0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 2.2323074278051225, 2.2323074278051225,\
-          0, 0, 0, 0]}} 
-      
+          0, 0, 0, 0]}}
+
     interf.computeInterference = testutils.FakeInterferenceCalculator()
 
     allowed_interference = aggregate_interference.calculateAggregateInterferenceForEsc(
                              TestAggregateInterference.esc_record, TestAggregateInterference.cbsd_list)
     self.assertSameInterference(allowed_interference, expected_interference)
-    
+
   def test_AggregateInterferencePpa(self):
     expected_interference = {34.40888888888889: {-100.57222222222222: [2.5022498449008137,\
         2.5022498449008137]}, 34.40944444444444: {-100.57277777777779: [2.5022498449008053,\
-        2.5022498449008053], -100.57222222222222: [2.50256995666338, 2.50256995666338]}} 
+        2.5022498449008053], -100.57222222222222: [2.50256995666338, 2.50256995666338]}}
 
     interf.computeInterference = testutils.FakeInterferenceCalculator()
     allowed_interference = aggregate_interference.calculateAggregateInterferenceForPpa(
-                             TestAggregateInterference.ppa_record, 
-                             [TestAggregateInterference.pal_record], 
+                             TestAggregateInterference.ppa_record,
+                             [TestAggregateInterference.pal_record],
                              TestAggregateInterference.cbsd_list)
     self.assertSameInterference(allowed_interference, expected_interference)
- 
+
   def test_AggregateInterferenceGwpz(self):
     expected_interference = {34.40888888888889: {-100.57222222222222: [2.5022498449008137,\
          2.5022498449008137, 0, 0, 0]}, 34.40944444444444: {-100.57277777777779: [2.5022498449008053,\
@@ -100,7 +101,7 @@ class TestAggregateInterference(unittest.TestCase):
     allowed_interference = aggregate_interference.calculateAggregateInterferenceForGwpz(
                              TestAggregateInterference.gwpz_record, TestAggregateInterference.cbsd_list)
     self.assertSameInterference(allowed_interference, expected_interference)
-  
+
   def assertSameInterference(self, allowed_interference, expected_interference):
     return self.assertEqual(expected_interference, allowed_interference)
 


### PR DESCRIPTION
This is one step of various cleanup to bring the ref models in a better coherent state.

In this step:
  - reuse the common objects for GrantInfo, etc..
  - migrate some objects in the common/data.py  (FssInfo and EscInfo)
  - misc API cleanup by removing unused parameters
  - misc cosmetic cleanup

Note: preliminary - will continue on the iap and pre_iap directory (note that this last one was left broken last week)