### PR TITLE
fix issue #519

### DIFF
--- a/src/harness/security_testcase.py
+++ b/src/harness/security_testcase.py
@@ -305,7 +305,7 @@ class SecurityTestCase(sas_testcase.SasTestCase):
     cert_path = os.path.join(harness_dir, 'certs')
 
     # Build short lived certificate command
-    command = "cd {0} && ./generate_short_lived_certs.sh {1} {2} {3}".format(cert_path, client_type,
+    command = "cd {0} && bash ./generate_short_lived_certs.sh {1} {2} {3}".format(cert_path, client_type,
                                                                              cert_name, str(cert_duration_minutes))
     # Create the short lived certificate
     command_exit_status = subprocess.call(command, shell=True)

--- a/src/harness/simple_crl_server.py
+++ b/src/harness/simple_crl_server.py
@@ -177,7 +177,7 @@ def revokeCertificate():
   # Retrives the all certificates from certs directory.
   cert_name = getCertificateNameToBlacklist()
   logging.info('Certificate selected to blacklist is:%s', cert_name)
-  revoke_cert_command = "cd {0} && ./revoke_and_generate_crl.sh " \
+  revoke_cert_command = "cd {0} && bash ./revoke_and_generate_crl.sh " \
                         "-r {1}".format(getCertsDirectoryAbsolutePath(),
                                          cert_name)
   command_exit_status = subprocess.call(revoke_cert_command, shell=True)
@@ -225,7 +225,7 @@ def generateCrlChain():
   placed in the 'harness/certs/crl/' directory.
   """
 
-  create_crl_chain_command = "cd {0} && ./revoke_and_generate_crl.sh -u".format(
+  create_crl_chain_command = "cd {0} && bash ./revoke_and_generate_crl.sh -u".format(
       getCertsDirectoryAbsolutePath())
   command_exit_status = subprocess.call(create_crl_chain_command, shell=True)
   if command_exit_status:

--- a/src/harness/testcases/WINNF_FT_S_SCS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SCS_testcase.py
@@ -312,6 +312,9 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
 
     Checks that SAS UUT response with fatal alert message.
     """
+    # Reset the SAS UUT
+    self.SasReset()
+
     device_cert_name = "short_lived_client"
     cert_duration_minutes = 1  # in minutes
 
@@ -356,6 +359,9 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
 
     Checks that SAS UUT response with fatal alert message.
     """
+    # Reset the SAS UUT
+    self.SasReset()
+
     device_cert_name = "short_lived_client"
     cert_duration_minutes = 1  # in minutes
 
@@ -403,6 +409,9 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
 
     Checks that SAS UUT response with fatal alert message.
     """
+    # Reset the SAS UUT
+    self.SasReset()
+
     device_cert_name = "short_lived_client"
     cert_duration_minutes = 1  # in minutes
 

--- a/src/harness/testcases/WINNF_FT_S_SDS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SDS_testcase.py
@@ -324,6 +324,9 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
 
     Checks that SAS UUT response with fatal alert message.
     """
+    # Reset the SAS UUT
+    self.SasReset()
+
     device_cert_name = "short_lived_domain_proxy"
     cert_duration_minutes = 1  # in minutes
 
@@ -367,6 +370,9 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
 
     Checks that SAS UUT response with fatal alert message.
     """
+    # Reset the SAS UUT
+    self.SasReset()
+
     device_cert_name = "short_lived_domain_proxy"
     cert_duration_minutes = 1  # in minutes
 
@@ -413,6 +419,9 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
 
     Checks that SAS UUT response with fatal alert message.
     """
+    # Reset the SAS UUT
+    self.SasReset()
+
     device_cert_name = "short_lived_domain_proxy"
     cert_duration_minutes = 1  # in minutes
 


### PR DESCRIPTION
This PR addresses the following issues as described in issue #519.


[1]Some   testcases doesn’t call the SasReset() before injections/registrations, reset   is needed.     Comment:     All the testcases need to reset SAS UUT to the baseline state. This is   required in the test spec.     However, many of SxS don’t send admin/reset to the SAS UUT.            Please add self.SasReset() for each   testcase.         For example, some testcases call   assertRegistered() or assertRegisteredAndGranted() without admin/reset. They   don’t have admin/reset. Only doCbsdTestCipher have admin/reset which is used   in SxS.1~5. | WINNF_FT_S_SCS_testcase.py     WINNF_FT_S_SDS_testcase.py | Done | We have added   sas.Reset() call  to the test cases   SCS/SDS 17,18 & 19 as pre condition.
-- | -- | -- | --
[2]The code calls generate_short_lived_certs.sh but it gives   error     security_testcase.py line277     276 # Build short lived certificate command     277 command = "cd {0} && ./generate_short_lived_certs.sh {1}   {2} {3}".format(cert_path, client_type,     278 cert_name, str(cert_duration_minutes))     279 # Create the short lived certificate     280 command_exit_status = subprocess.call(command, shell=True)     (1)I think command needs to include ‘bash’            Comment:     line 280: command_exit_status = subprocess.call(command, shell=True)          this doesn’t run.          If I give ‘bash’ like below, it   runs.          command = "cd {0}   && bash ./generate_short_lived_certs.sh {1} {2}…     command_exit_status = subprocess.call(command, shell=True)               I suggest to add ‘bash’ like   above. | 1.security_testcase.py     2.simple_crl_server.py | Done | Prepended   the bash accordingly to the line , where exist a call to the following   scripts     1.revoke_and_generate_crl.sh     2.generate_short_lived_certs.sh     Changes would look like below     revoke_cert_command = "cd {0} && bash ./revoke_and_generate_crl.sh " \                             "-r   {1}".format(getCertsDirectoryAbsolutePath(),                                                cert_name)
(2)file generate_short_lived_certs.sh includes ‘\r’.            Comment:     “generate_short_lived_certs.sh” runs itself, but when called from   subprocess(), it gives error.             If I remove ‘\r’ in the file, it   runs.                       simple_crl_server.py is the same   situation when it calls revoke_and_geerate_crl.sh.             I suggest to remove ‘\r’ from the   .sh files. | 1.revoke_and_generate_crl.sh     2.generate_short_lived_certs.sh | Done | Removed   '\r' from the both scripts , Basically I did dos2unix for these files.

