### PR TITLE
IPR.2 fix

### DIFF
--- a/src/harness/fake_sas.py
+++ b/src/harness/fake_sas.py
@@ -291,6 +291,9 @@ class FakeSasAdmin(sas_interface.SasAdminInterface):
   def TriggerDailyActivitiesImmediately(self):
     pass
 
+  def TriggerEnableNtiaExclusionZones(self):
+    pass
+
   def TriggerEnableScheduledDailyActivities(self):
     pass
 

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -282,7 +282,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         'hostName':
             'localhost',
         'port':
-            9001,
+            9002,
         'serverCert':
             os.path.join('certs', 'server.cert'),
         'serverKey':
@@ -492,7 +492,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         'hostName':
             'localhost',
         'port':
-            9001,
+            9006,
         'serverCert':
             os.path.join('certs', 'server.cert'),
         'serverKey':

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -354,9 +354,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
     self.assertValidConfig(
         config, {
             'sasTestHarnessConfigs': list,
-            'registrationRequests': list,
-            'grantRequests': list,
-            'conditionalRegistrationData': list,
+            'domainProxies': list,
             'dpas': list,
             'pauseTime': int
         })


### PR DESCRIPTION
- Fixes a bug in IPR.2 where the expected config did not match the actual config.
- Updates IPR testcases to use different port numbers for each default config.
- Updates fake sas to be non-abstract