### PR TITLE
specify content-type for headers for POST

### DIFF
--- a/src/harness/request_handler.py
+++ b/src/harness/request_handler.py
@@ -83,23 +83,15 @@ def RequestPostJson(url, request, config):
   return _Request(url, request, config, True, 'application/json')
 
 
-def RequestGetEmpty(url, config):
-  return _Request(url, None, config, False, None)
-
-
-def RequestGetJson(url, request, config):
-  return _Request(url, request, config, False, 'application/json')
-
-
-def _RequestPost(url, request, config, content_type):
+def RequestPost(url, request, config, content_type):
   return _Request(url, request, config, True, content_type)
 
 
-def _RequestGet(url, request, config, content_type):
-  return _Request(url, request, config, False, content_type)
+def RequestGet(url, request, config):
+  return _Request(url, request, config, False)
 
 
-def _Request(url, request, config, is_post_method, content_type):
+def _Request(url, request, config, is_post_method, content_type=None):
   """Sends HTTPS request.
 
   Args:

--- a/src/harness/request_handler.py
+++ b/src/harness/request_handler.py
@@ -75,7 +75,7 @@ class TlsConfig(object):
     return ret
 
 
-def RequestPostEmpty(url, config):
+def RequestPostNoContentType(url, config):
   return _Request(url, None, config, True, None)
 
 
@@ -83,16 +83,8 @@ def RequestPostJson(url, request, config):
   return _Request(url, request, config, True, 'application/json')
 
 
-def RequestGetEmpty(url, config):
+def RequestGet(url, config):
   return _Request(url, None, config, False, None)
-
-
-def _RequestPost(url, request, config, content_type):
-  return _Request(url, request, config, True, content_type)
-
-
-def _RequestGet(url, request, config):
-  return _Request(url, request, config, False)
 
 
 def _Request(url, request, config, is_post_method, content_type=None):

--- a/src/harness/request_handler.py
+++ b/src/harness/request_handler.py
@@ -83,11 +83,15 @@ def RequestPostJson(url, request, config):
   return _Request(url, request, config, True, 'application/json')
 
 
-def RequestPost(url, request, config, content_type):
+def RequestGetEmpty(url, config):
+  return _Request(url, None, config, False, None)
+
+
+def _RequestPost(url, request, config, content_type):
   return _Request(url, request, config, True, content_type)
 
 
-def RequestGet(url, request, config):
+def _RequestGet(url, request, config):
   return _Request(url, request, config, False)
 
 

--- a/src/harness/request_handler.py
+++ b/src/harness/request_handler.py
@@ -75,15 +75,31 @@ class TlsConfig(object):
     return ret
 
 
-def RequestPost(url, request, config):
-  return _Request(url, request, config, True)
+def RequestPostEmpty(url, config):
+  return _Request(url, None, config, True, None)
 
 
-def RequestGet(url, config):
-  return _Request(url, None, config, False)
+def RequestPostJson(url, request, config):
+  return _Request(url, request, config, True, 'application/json')
 
 
-def _Request(url, request, config, is_post_method):
+def RequestGetEmpty(url, config):
+  return _Request(url, None, config, False, None)
+
+
+def RequestGetJson(url, request, config):
+  return _Request(url, request, config, False, 'application/json')
+
+
+def _RequestPost(url, request, config, content_type):
+  return _Request(url, request, config, True, content_type)
+
+
+def _RequestGet(url, request, config, content_type):
+  return _Request(url, request, config, False, content_type)
+
+
+def _Request(url, request, config, is_post_method, content_type):
   """Sends HTTPS request.
 
   Args:
@@ -104,10 +120,9 @@ def _Request(url, request, config, is_post_method):
   conn = pycurl.Curl()
   conn.setopt(conn.URL, url)
   conn.setopt(conn.WRITEFUNCTION, response.write)
-  header = [
-      'Host: %s' % urlparse.urlparse(url).hostname,
-      'content-type: application/json'
-  ]
+  header = ['Host: %s' % urlparse.urlparse(url).hostname]
+  if content_type:
+    header.append('content-type: %s' % content_type)
   conn.setopt(
       conn.VERBOSE,
       3  # Improve readability.

--- a/src/harness/sas.py
+++ b/src/harness/sas.py
@@ -14,7 +14,7 @@
 """Implementation of SasInterface."""
 
 import ConfigParser
-from request_handler import TlsConfig, RequestPostJson, RequestPostEmpty, RequestGet
+from request_handler import TlsConfig, RequestPostJson, RequestPostEmpty, RequestGetEmpty
 import os
 import sas_interface
 
@@ -93,7 +93,7 @@ class SasImpl(sas_interface.SasInterface):
     url = 'https://%s/%s/%s' % (self.sas_sas_active_base_url, self.sas_sas_version, method_name)
     if request is not None:
       url += '/%s' % request
-    return RequestGet(url,
+    return RequestGetEmpty(url,
                       self._tls_config.WithClientCertificate(
                           ssl_cert or GetDefaultSasSSLCertPath(),
                           ssl_key or GetDefaultSasSSLKeyPath()))
@@ -106,7 +106,7 @@ class SasImpl(sas_interface.SasInterface):
                            ssl_key or GetDefaultCbsdSSLKeyPath()))
 
   def DownloadFile(self, url, ssl_cert=None, ssl_key=None):
-    return RequestGet(url,
+    return RequestGetEmpty(url,
                       self._tls_config.WithClientCertificate(
                           ssl_cert if ssl_cert else
                           GetDefaultSasSSLCertPath(), ssl_key
@@ -245,7 +245,7 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
     pass
 
   def GetDailyActivitiesStatus(self):
-    return RequestGet(
+    return RequestGetEmpty(
         'https://%s/admin/get_daily_activities_status' % self._base_url,
         self._tls_config)
 
@@ -289,6 +289,6 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
                 request, self._tls_config)
 
   def GetPpaCreationStatus(self):
-    return RequestGet(
+    return RequestGetEmpty(
       'https://%s/admin/get_ppa_status' % self._base_url,
       self._tls_config)

--- a/src/harness/sas.py
+++ b/src/harness/sas.py
@@ -14,7 +14,7 @@
 """Implementation of SasInterface."""
 
 import ConfigParser
-from request_handler import TlsConfig, RequestPostJson, RequestPostEmpty, RequestGetEmpty
+from request_handler import TlsConfig, RequestPostJson, RequestPostEmpty, RequestGet
 import os
 import sas_interface
 
@@ -93,7 +93,7 @@ class SasImpl(sas_interface.SasInterface):
     url = 'https://%s/%s/%s' % (self.sas_sas_active_base_url, self.sas_sas_version, method_name)
     if request is not None:
       url += '/%s' % request
-    return RequestGetEmpty(url,
+    return RequestGet(url,
                       self._tls_config.WithClientCertificate(
                           ssl_cert or GetDefaultSasSSLCertPath(),
                           ssl_key or GetDefaultSasSSLKeyPath()))
@@ -106,7 +106,7 @@ class SasImpl(sas_interface.SasInterface):
                            ssl_key or GetDefaultCbsdSSLKeyPath()))
 
   def DownloadFile(self, url, ssl_cert=None, ssl_key=None):
-    return RequestGetEmpty(url,
+    return RequestGet(url,
                       self._tls_config.WithClientCertificate(
                           ssl_cert if ssl_cert else
                           GetDefaultSasSSLCertPath(), ssl_key
@@ -245,7 +245,7 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
     pass
 
   def GetDailyActivitiesStatus(self):
-    return RequestGetEmpty(
+    return RequestGet(
         'https://%s/admin/get_daily_activities_status' % self._base_url,
         self._tls_config)
 
@@ -289,6 +289,6 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
                 request, self._tls_config)
 
   def GetPpaCreationStatus(self):
-    return RequestGetEmpty(
+    return RequestGet(
       'https://%s/admin/get_ppa_status' % self._base_url,
       self._tls_config)

--- a/src/harness/sas.py
+++ b/src/harness/sas.py
@@ -14,7 +14,7 @@
 """Implementation of SasInterface."""
 
 import ConfigParser
-from request_handler import TlsConfig, RequestPostJson, RequestPostEmpty, RequestGetEmpty
+from request_handler import TlsConfig, RequestPostJson, RequestPostNoContentType, RequestGet
 import os
 import sas_interface
 
@@ -93,7 +93,7 @@ class SasImpl(sas_interface.SasInterface):
     url = 'https://%s/%s/%s' % (self.sas_sas_active_base_url, self.sas_sas_version, method_name)
     if request is not None:
       url += '/%s' % request
-    return RequestGetEmpty(url,
+    return RequestGet(url,
                       self._tls_config.WithClientCertificate(
                           ssl_cert or GetDefaultSasSSLCertPath(),
                           ssl_key or GetDefaultSasSSLKeyPath()))
@@ -106,7 +106,7 @@ class SasImpl(sas_interface.SasInterface):
                            ssl_key or GetDefaultCbsdSSLKeyPath()))
 
   def DownloadFile(self, url, ssl_cert=None, ssl_key=None):
-    return RequestGetEmpty(url,
+    return RequestGet(url,
                       self._tls_config.WithClientCertificate(
                           ssl_cert if ssl_cert else
                           GetDefaultSasSSLCertPath(), ssl_key
@@ -135,8 +135,8 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
     self.injected_user_ids = set()
 
   def Reset(self):
-    RequestPostEmpty('https://%s/admin/reset' % self._base_url,
-                self._tls_config)
+    RequestPostNoContentType('https://%s/admin/reset' % self._base_url,
+                             self._tls_config)
 
   def InjectFccId(self, request):
     # Avoid injecting the same FCC ID twice in the same test case.
@@ -216,8 +216,8 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
                 % self._base_url, None, self._tls_config)
 
   def TriggerMeasurementReportHeartbeat(self):
-    RequestPostEmpty('https://%s/admin/trigger/meas_report_in_heartbeat_response' %
-                self._base_url, self._tls_config)
+    RequestPostNoContentType('https://%s/admin/trigger/meas_report_in_heartbeat_response' %
+                             self._base_url, self._tls_config)
 
   def InjectEscSensorDataRecord(self, request):
     RequestPostJson('https://%s/admin/injectdata/esc_sensor' % self._base_url,
@@ -228,24 +228,24 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
                        request, self._tls_config)
 
   def TriggerDailyActivitiesImmediately(self):
-    RequestPostEmpty('https://%s/admin/trigger/daily_activities_immediately' %
-                self._base_url, self._tls_config)
+    RequestPostNoContentType('https://%s/admin/trigger/daily_activities_immediately' %
+                             self._base_url, self._tls_config)
 
   def TriggerEnableScheduledDailyActivities(self):
-    RequestPostEmpty('https://%s/admin/trigger/enable_scheduled_daily_activities' %
-                self._base_url, self._tls_config)
+    RequestPostNoContentType('https://%s/admin/trigger/enable_scheduled_daily_activities' %
+                             self._base_url, self._tls_config)
 
   def QueryPropagationAndAntennaModel(self, request):
     return RequestPostJson('https://%s/admin/query/propagation_and_antenna_model' %
                        self._base_url, request, self._tls_config)
 
   def TriggerEnableNtiaExclusionZones(self):
-    RequestPostEmpty('https://%s/admin/trigger/enable_ntia_15_517' %
-                 self._base_url, self._tls_config)
+    RequestPostNoContentType('https://%s/admin/trigger/enable_ntia_15_517' %
+                             self._base_url, self._tls_config)
     pass
 
   def GetDailyActivitiesStatus(self):
-    return RequestGetEmpty(
+    return RequestGet(
         'https://%s/admin/get_daily_activities_status' % self._base_url,
         self._tls_config)
 
@@ -254,8 +254,8 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
                 request, self._tls_config)
 
   def TriggerLoadDpas(self):
-    RequestPostEmpty('https://%s/admin/trigger/load_dpas' % self._base_url,
-                self._tls_config)
+    RequestPostNoContentType('https://%s/admin/trigger/load_dpas' % self._base_url,
+                             self._tls_config)
 
   def TriggerBulkDpaActivation(self, request):
     RequestPostJson('https://%s/admin/trigger/bulk_dpa_activation' % self._base_url,
@@ -270,11 +270,11 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
                 request, self._tls_config)
 
   def TriggerEscDisconnect(self):
-    RequestPostEmpty('https://%s/admin/trigger/disconnect_esc' % self._base_url,
-                self._tls_config)
+    RequestPostNoContentType('https://%s/admin/trigger/disconnect_esc' % self._base_url,
+                             self._tls_config)
 
   def TriggerFullActivityDump(self):
-    RequestPostEmpty(
+    RequestPostNoContentType(
         'https://%s/admin/trigger/create_full_activity_dump' % self._base_url,
         self._tls_config)
 
@@ -289,6 +289,6 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
                 request, self._tls_config)
 
   def GetPpaCreationStatus(self):
-    return RequestGetEmpty(
+    return RequestGet(
       'https://%s/admin/get_ppa_status' % self._base_url,
       self._tls_config)

--- a/src/harness/sas.py
+++ b/src/harness/sas.py
@@ -14,9 +14,10 @@
 """Implementation of SasInterface."""
 
 import ConfigParser
-from request_handler import TlsConfig, RequestPost, RequestGet
+from request_handler import TlsConfig, RequestPostJson, RequestPostEmpty, RequestGetEmpty
 import os
 import sas_interface
+
 
 def GetTestingSas():
   config_parser = ConfigParser.RawConfigParser()
@@ -92,20 +93,20 @@ class SasImpl(sas_interface.SasInterface):
     url = 'https://%s/%s/%s' % (self.sas_sas_active_base_url, self.sas_sas_version, method_name)
     if request is not None:
       url += '/%s' % request
-    return RequestGet(url,
+    return RequestGetEmpty(url,
                       self._tls_config.WithClientCertificate(
                           ssl_cert or GetDefaultSasSSLCertPath(),
                           ssl_key or GetDefaultSasSSLKeyPath()))
 
   def _CbsdRequest(self, method_name, request, ssl_cert=None, ssl_key=None):
-    return RequestPost('https://%s/%s/%s' % (self.cbsd_sas_active_base_url, self.cbsd_sas_version,
+    return RequestPostJson('https://%s/%s/%s' % (self.cbsd_sas_active_base_url, self.cbsd_sas_version,
                                              method_name), request,
                        self._tls_config.WithClientCertificate(
                            ssl_cert or GetDefaultCbsdSSLCertPath(),
                            ssl_key or GetDefaultCbsdSSLKeyPath()))
 
   def DownloadFile(self, url, ssl_cert=None, ssl_key=None):
-    return RequestGet(url,
+    return RequestGetEmpty(url,
                       self._tls_config.WithClientCertificate(
                           ssl_cert if ssl_cert else
                           GetDefaultSasSSLCertPath(), ssl_key
@@ -134,7 +135,7 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
     self.injected_user_ids = set()
 
   def Reset(self):
-    RequestPost('https://%s/admin/reset' % self._base_url, None,
+    RequestPostEmpty('https://%s/admin/reset' % self._base_url,
                 self._tls_config)
 
   def InjectFccId(self, request):
@@ -143,7 +144,7 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
       return
     if 'fccMaxEirp' not in request:
       request['fccMaxEirp'] = 47
-    RequestPost('https://%s/admin/injectdata/fcc_id' % self._base_url, request,
+    RequestPostJson('https://%s/admin/injectdata/fcc_id' % self._base_url, request,
                 self._tls_config)
     self.injected_fcc_ids.add(request['fccId'])
 
@@ -151,131 +152,131 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
     # Avoid injecting the same user ID twice in the same test case.
     if request['userId'] in self.injected_user_ids:
       return
-    RequestPost('https://%s/admin/injectdata/user_id' % self._base_url, request,
+    RequestPostJson('https://%s/admin/injectdata/user_id' % self._base_url, request,
                 self._tls_config)
     self.injected_user_ids.add(request['userId'])
 
   def InjectEscZone(self, request):
-    return RequestPost('https://%s/admin/injectdata/esc_zone' % self._base_url,
+    return RequestPostJson('https://%s/admin/injectdata/esc_zone' % self._base_url,
                        request, self._tls_config)
 
   def InjectExclusionZone(self, request):
-    return RequestPost(
+    return RequestPostJson(
         'https://%s/admin/injectdata/exclusion_zone' % self._base_url, request,
         self._tls_config)
 
   def InjectZoneData(self, request):
-    return RequestPost('https://%s/admin/injectdata/zone' % self._base_url,
+    return RequestPostJson('https://%s/admin/injectdata/zone' % self._base_url,
                        request, self._tls_config)
 
   def InjectPalDatabaseRecord(self, request):
-    RequestPost(
+    RequestPostJson(
         'https://%s/admin/injectdata/pal_database_record' % self._base_url,
         request, self._tls_config)
 
   def InjectClusterList(self, request):
-    RequestPost('https://%s/admin/injectdata/cluster_list' % self._base_url,
+    RequestPostJson('https://%s/admin/injectdata/cluster_list' % self._base_url,
                 request, self._tls_config)
 
   def BlacklistByFccId(self, request):
-    RequestPost('https://%s/admin/injectdata/blacklist_fcc_id' % self._base_url,
+    RequestPostJson('https://%s/admin/injectdata/blacklist_fcc_id' % self._base_url,
                 request, self._tls_config)
 
   def BlacklistByFccIdAndSerialNumber(self, request):
-    RequestPost('https://%s/admin/injectdata/blacklist_fcc_id_and_serial_number'
+    RequestPostJson('https://%s/admin/injectdata/blacklist_fcc_id_and_serial_number'
                 % self._base_url, request, self._tls_config)
 
   def TriggerEscZone(self, request):
-    RequestPost('https://%s/admin/trigger/esc_detection' % self._base_url,
+    RequestPostJson('https://%s/admin/trigger/esc_detection' % self._base_url,
                 request, self._tls_config)
 
   def ResetEscZone(self, request):
-    RequestPost('https://%s/admin/trigger/esc_reset' % self._base_url, request,
+    RequestPostJson('https://%s/admin/trigger/esc_reset' % self._base_url, request,
                 self._tls_config)
 
   def PreloadRegistrationData(self, request):
-    RequestPost(
+    RequestPostJson(
         'https://%s/admin/injectdata/conditional_registration' % self._base_url,
         request, self._tls_config)
 
   def InjectFss(self, request):
-    RequestPost('https://%s/admin/injectdata/fss' % self._base_url, request,
+    RequestPostJson('https://%s/admin/injectdata/fss' % self._base_url, request,
                 self._tls_config)
 
   def InjectWisp(self, request):
-    RequestPost('https://%s/admin/injectdata/wisp' % self._base_url, request,
+    RequestPostJson('https://%s/admin/injectdata/wisp' % self._base_url, request,
                 self._tls_config)
 
   def InjectSasAdministratorRecord(self, request):
-    RequestPost('https://%s/admin/injectdata/sas_admin' % self._base_url,
+    RequestPostJson('https://%s/admin/injectdata/sas_admin' % self._base_url,
                 request, self._tls_config)
 
   def TriggerMeasurementReportRegistration(self):
-    RequestPost('https://%s/admin/trigger/meas_report_in_registration_response'
+    RequestPostJson('https://%s/admin/trigger/meas_report_in_registration_response'
                 % self._base_url, None, self._tls_config)
 
   def TriggerMeasurementReportHeartbeat(self):
-    RequestPost('https://%s/admin/trigger/meas_report_in_heartbeat_response' %
-                self._base_url, None, self._tls_config)
+    RequestPostEmpty('https://%s/admin/trigger/meas_report_in_heartbeat_response' %
+                self._base_url, self._tls_config)
 
   def InjectEscSensorDataRecord(self, request):
-    RequestPost('https://%s/admin/injectdata/esc_sensor' % self._base_url,
+    RequestPostJson('https://%s/admin/injectdata/esc_sensor' % self._base_url,
                 request, self._tls_config)
 
   def TriggerPpaCreation(self, request):
-    return RequestPost('https://%s/admin/trigger/create_ppa' % self._base_url,
+    return RequestPostJson('https://%s/admin/trigger/create_ppa' % self._base_url,
                        request, self._tls_config)
 
   def TriggerDailyActivitiesImmediately(self):
-    RequestPost('https://%s/admin/trigger/daily_activities_immediately' %
-                self._base_url, None, self._tls_config)
+    RequestPostEmpty('https://%s/admin/trigger/daily_activities_immediately' %
+                self._base_url, self._tls_config)
 
   def TriggerEnableScheduledDailyActivities(self):
-    RequestPost('https://%s/admin/trigger/enable_scheduled_daily_activities' %
-                self._base_url, None, self._tls_config)
+    RequestPostEmpty('https://%s/admin/trigger/enable_scheduled_daily_activities' %
+                self._base_url, self._tls_config)
 
   def QueryPropagationAndAntennaModel(self, request):
-    return RequestPost('https://%s/admin/query/propagation_and_antenna_model' %
+    return RequestPostJson('https://%s/admin/query/propagation_and_antenna_model' %
                        self._base_url, request, self._tls_config)
 
   def TriggerEnableNtiaExclusionZones(self):
-    _RequestPost('https://%s/admin/trigger/enable_ntia_15_517' %
-                 self._base_url, None, self._tls_config)
+    RequestPostEmpty('https://%s/admin/trigger/enable_ntia_15_517' %
+                 self._base_url, self._tls_config)
     pass
 
   def GetDailyActivitiesStatus(self):
-    return RequestPost(
-        'https://%s/admin/get_daily_activities_status' % self._base_url, None,
+    return RequestGetEmpty(
+        'https://%s/admin/get_daily_activities_status' % self._base_url,
         self._tls_config)
 
   def InjectCpiUser(self, request):
-    RequestPost('https://%s/admin/injectdata/cpi_user' % self._base_url,
+    RequestPostJson('https://%s/admin/injectdata/cpi_user' % self._base_url,
                 request, self._tls_config)
 
   def TriggerLoadDpas(self):
-    RequestPost('https://%s/admin/trigger/load_dpas' % self._base_url, None,
+    RequestPostEmpty('https://%s/admin/trigger/load_dpas' % self._base_url,
                 self._tls_config)
 
   def TriggerBulkDpaActivation(self, request):
-    RequestPost('https://%s/admin/trigger/bulk_dpa_activation' % self._base_url,
+    RequestPostJson('https://%s/admin/trigger/bulk_dpa_activation' % self._base_url,
                 request, self._tls_config)
 
   def TriggerDpaActivation(self, request):
-    RequestPost('https://%s/admin/trigger/dpa_activation' % self._base_url,
+    RequestPostJson('https://%s/admin/trigger/dpa_activation' % self._base_url,
                 request, self._tls_config)
 
   def TriggerDpaDeactivation(self, request):
-    RequestPost('https://%s/admin/trigger/dpa_deactivation' % self._base_url,
+    RequestPostJson('https://%s/admin/trigger/dpa_deactivation' % self._base_url,
                 request, self._tls_config)
 
   def TriggerEscDisconnect(self):
-    RequestPost('https://%s/admin/trigger/disconnect_esc' % self._base_url,
-                request, self._tls_config)
+    RequestPostEmpty('https://%s/admin/trigger/disconnect_esc' % self._base_url,
+                self._tls_config)
 
   def TriggerFullActivityDump(self):
-    RequestPost(
+    RequestPostEmpty(
         'https://%s/admin/trigger/create_full_activity_dump' % self._base_url,
-        None, self._tls_config)
+        self._tls_config)
 
   def _GetDefaultAdminSSLCertPath(self):
     return os.path.join('certs', 'admin_client.cert')
@@ -284,10 +285,10 @@ class SasAdminImpl(sas_interface.SasAdminInterface):
     return os.path.join('certs', 'admin_client.key')
 
   def InjectPeerSas(self, request):
-    RequestPost('https://%s/admin/injectdata/peer_sas' % self._base_url,
+    RequestPostJson('https://%s/admin/injectdata/peer_sas' % self._base_url,
                 request, self._tls_config)
 
   def GetPpaCreationStatus(self):
-    return RequestPost(
-      'https://%s/admin/get_ppa_status' % self._base_url, None,
+    return RequestGetEmpty(
+      'https://%s/admin/get_ppa_status' % self._base_url,
       self._tls_config)


### PR DESCRIPTION
For POST and GET requests, the header always contains the media type of JSON for all requests: 'content-type: json/application'. However, some GET and POST requests do not send any media resources with the request. A web server taking requests that get media resources when they are not part of the API could fail with HTTP 415, Unsupported Media Type.

This PR creates methods that separate PostJson and PostEmpty, GetJson and GetEmpty, so the content types can be explicitly called.