### PR TITLE
Small speedup:  GeodesicSampling routine.

### DIFF
--- a/src/data/resample_uscabdry.py
+++ b/src/data/resample_uscabdry.py
@@ -75,11 +75,11 @@ def ResampleUsCanadaBorderLineString(ls, step_m):
         # departing less than 70m from the 49degree north latitude
         lats = np.interp(range(num_points), [0, num_points-1], [vertex0[1], vertex1[1]])
         lons = np.interp(range(num_points), [0, num_points-1], [vertex0[0], vertex1[0]])
-        points = zip(lats, lons)
       else:
-        points = vincenty.GeodesicSampling(
+        lats, lons = vincenty.GeodesicSampling(
             vertex0[1], vertex0[0], vertex1[1], vertex1[0], num_points)
 
+      points = zip(lats, lons)
       out_vertices.extend([(point[1], point[0]) for point in points[:-1]])
 
   out_vertices.append(vertex1)  # add the last vertex

--- a/src/harness/reference_models/geo/terrain.py
+++ b/src/harness/reference_models/geo/terrain.py
@@ -294,10 +294,9 @@ class TerrainDriver:
       num_points = 2
 
     resolution = dist / float(num_points-1)
-    points = vincenty.GeodesicSampling(lat1, lon1, lat2, lon2, num_points)
+    lats, lons = vincenty.GeodesicSampling(lat1, lon1, lat2, lon2, num_points)
     elev = [num_points-1, resolution]
-    lat, lon = zip(*points)
-    elev.extend(self.GetTerrainElevation(lat, lon, do_interp))
+    elev.extend(self.GetTerrainElevation(lats, lons, do_interp))
     return elev
 
   def ComputeNormalizedHaat(self, lat, lon):

--- a/src/harness/reference_models/geo/vincenty.py
+++ b/src/harness/reference_models/geo/vincenty.py
@@ -323,15 +323,13 @@ def GeodesicSampling(lat1, lon1, lat2, lon2, num_points):
     num_points : number of points to use (must be >=2)
 
   Returns:
-    A list of points along the geodesic, each point being a tuple (lat, lng).
-      The two input locations are first and last points.
+    A tuple (lats, longs) of ndarray vector defining points along the
+    geodesic. The two input locations are first and last points.
   """
-  points = [(lat1, lon1)]
-  lat, lon = lat1, lon1
-  dist, bearing, _ = GeodesicDistanceBearing(lat, lon, lat2, lon2)
+  dist, bearing, _ = GeodesicDistanceBearing(lat1, lon1, lat2, lon2)
   step_km = dist / (float(num_points-1))
-  distances = step_km * np.arange(1, num_points-1)
-  lats, longs, _ = GeodesicPoints(lat, lon, distances, bearing)
-  points.extend(zip(lats, longs))
-  points.append((lat2, lon2))
-  return points
+  distances = step_km * np.arange(0, num_points)
+  lats, lons, _ = GeodesicPoints(lat1, lon1, distances, bearing)
+  lats[0], lons[0] = lat1, lon1
+  lats[-1], lons[-1] = lat2, lon2
+  return lats, lons

--- a/src/harness/reference_models/geo/vincenty_test.py
+++ b/src/harness/reference_models/geo/vincenty_test.py
@@ -106,19 +106,18 @@ class TestVincenty(unittest.TestCase):
     lat11, lng11 = 44.0, -121.0
 
     # Compare with dual iterative implementation (well used initially)
-    pts11 = vincenty.GeodesicSampling(lat0, lng0, lat11, lng11, 1500)
+    lats11, lons11 = vincenty.GeodesicSampling(lat0, lng0, lat11, lng11, 1500)
+    pts11 = zip(lats11, lons11)
     pts11it = geodesic_iterative(lat0, lng0, lat11, lng11, 1500)
     diff = np.array(pts11) - np.array(pts11it)
     self.assertLess(np.max(np.abs(diff)), 1e-10)
 
     # Special case North south, longitude constant. lat delta constant
-    pts10 = vincenty.GeodesicSampling(lat0, lng0, lat10, lng10, 51)
-    lon = np.array([pt[1] for pt in pts10])
-    lon_offs = lon - lng0
+    lats10, lons10 = vincenty.GeodesicSampling(lat0, lng0, lat10, lng10, 51)
+    lon_offs = lons10 - lng0
     self.assertEqual(np.max(np.abs(lon_offs)), 0)
 
-    lat = np.array([pt[0] for pt in pts10])
-    lat_diffs = lat[1:] - lat[:-1]
+    lat_diffs = lats10[1:] - lats10[:-1]
     self.assertAlmostEqual(np.max(lat_diffs), -0.02, 5)
     self.assertAlmostEqual(np.min(lat_diffs), -0.02, 5)
 


### PR DESCRIPTION
This routine was returning data as a list of (lat,lon) points,
by zipping from the numpy vectors. However the main consumer routine (`TerrainProfile()`)
works directly in vectors so as to do the reverse unpacking, and reconvert to numpy vectors.

All this is inefficient and lead to a 10% speed loss on original code using about 3ms per ITM calc (and 20% on the code optimized for using 1.7ms per ITM calc), as I found out in line profiling. By returning directly the numpy vectors, we avoid a useless packing/unpacking operation.

Because this optimization is so simple, I propose it.