### PR TITLE
Finalize multiprocessing cleanup.

### DIFF
--- a/src/harness/reference_models/ppa/ppa.py
+++ b/src/harness/reference_models/ppa/ppa.py
@@ -13,11 +13,11 @@
 #    limitations under the License.
 
 import logging
-import multiprocessing
 from collections import namedtuple
 
 import numpy as np
 from concurrent import futures
+from reference_models.common import mpool
 from reference_models.antenna import antenna
 from reference_models.geo import drive
 from reference_models.geo import vincenty, nlcd
@@ -134,9 +134,9 @@ def PpaCreationModel(devices, pal_records):
   for pal_rec in pal_records:
     logging.info('Validating pal_rec', pal_rec)
     util.assertContainsRequiredFields("PalRecord.schema.json", pal_rec)
-  pool = futures.ProcessPoolExecutor(multiprocessing.cpu_count())
   # Create Contour for each CBSD
-  device_polygon = list(pool.map(_GetPolygon, devices))
+  pool = mpool.Pool()
+  device_polygon = pool.map(_GetPolygon, devices)
   # Create Union of all the CBSD Contours and Check for hole
   # after Census Tract Clipping
   contour_union = ops.cascaded_union(device_polygon)

--- a/src/harness/test_main.py
+++ b/src/harness/test_main.py
@@ -15,6 +15,9 @@ import logging
 import sys
 import unittest
 
+from reference_models.common import mpool
+
+
 logger = logging.getLogger()
 handler = logging.StreamHandler(sys.stdout)
 handler.setFormatter(
@@ -23,6 +26,17 @@ handler.setFormatter(
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
 
+
 if __name__ == '__main__':
+  # Configure the multiprocessing worker pool.
+  # Your options are:
+  #   0: single process (default if not called)
+  #  -1: use half of the cpus
+  #  -2: use all cpus (minus one)
+  #  a specific number of cpus
+  # Or your own `pool`.
+  mpool.Configure(num_processes=-2)
+
+  # Run the tests
   tests = unittest.TestLoader().discover('testcases', '*_testcase.py')
   unittest.TextTestRunner(verbosity=2).run(tests)


### PR DESCRIPTION
All modules (including PPA) now fully migrated to mpool.
Configuration of mpool on top executable file of the test harness.
Fix dummy mpool to be compatible `multiprocessing.Pool` and not `futures`.
