### PR TITLE
fix MCP.1 integration time errors - please read the description first.

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_EPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_EPR_testcase.py
@@ -126,11 +126,13 @@ class EscProtectionTestcase(McpXprCommonTestcase):
     # Registration and grant records
     cbsd_records_domain_proxy_0 = {
         'registrationRequests': [device_1, device_2],
-        'grantRequests': [grant_request_1, grant_request_2]
+        'grantRequests': [grant_request_1, grant_request_2],
+        'conditionalRegistrationData': [conditionals_device_2]
     }
     cbsd_records_domain_proxy_1 = {
         'registrationRequests': [device_3],
-        'grantRequests': [grant_request_3]
+        'grantRequests': [grant_request_3],
+        'conditionalRegistrationData': []
     }
 
     # Protected entity record
@@ -144,6 +146,7 @@ class EscProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': [{
             'registrationRequest': device_4,
             'grantRequest': grant_request_4,
+            'conditionalRegistrationData': conditionals_device_4,  
             'clientCert': sas.GetDefaultDomainProxySSLCertPath(),
             'clientKey': sas.GetDefaultDomainProxySSLKeyPath()
         }],
@@ -275,11 +278,14 @@ class EscProtectionTestcase(McpXprCommonTestcase):
     # Registration and grant records
     cbsd_records_domain_proxy_0 = {
         'registrationRequests': [device_1, device_2],
-        'grantRequests': [grant_request_1, grant_request_2]
+        'grantRequests': [grant_request_1, grant_request_2],
+        'conditionalRegistrationData': [conditionals_device_2]
+            
     }
     cbsd_records_domain_proxy_1 = {
         'registrationRequests': [device_3],
-        'grantRequests': [grant_request_3]
+        'grantRequests': [grant_request_3],
+        'conditionalRegistrationData': []
     }
 
     # Protected entity record
@@ -348,6 +354,7 @@ class EscProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': [{
             'registrationRequest': device_4,
             'grantRequest': grant_request_4,
+            'conditionalRegistrationData': conditionals_device_4,  
             'clientCert': sas.GetDefaultDomainProxySSLCertPath(),
             'clientKey': sas.GetDefaultDomainProxySSLKeyPath()
         }],

--- a/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
@@ -151,11 +151,13 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     # Registration and grant records for multiple iterations
     cbsd_records_iteration_0_domain_proxy_0 = {
         'registrationRequests': [device_1, device_3,device_4],
-        'grantRequests': [grant_request_1, grant_request_3,grant_request_4]
+        'grantRequests': [grant_request_1, grant_request_3,grant_request_4],
+        'conditionalRegistrationData':[conditionals_device_4]
     }
     cbsd_records_iteration_0_domain_proxy_1 = {
         'registrationRequests': [device_5,device_2],
-        'grantRequests': [grant_request_5,grant_request_2]
+        'grantRequests': [grant_request_5,grant_request_2],
+        'conditionalRegistrationData':[conditionals_device_2]
     }
 
     # Protected entities records for multiple iterations
@@ -222,8 +224,8 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': [{
             'registrationRequest': device_6,
             'grantRequest': grant_request_6,
-            'clientCert': os.path.join('certs', 'client.cert'),
-            'clientKey': os.path.join('certs', 'client.key')
+            'clientCert': sas.GetDefaultDomainProxySSLCertPath(),
+            'clientKey': sas.GetDefaultDomainProxySSLKeyPath()
         }],
         'protectedEntities': protected_entities_iteration_0,
         'sasTestHarnessData': [dump_records_iteration_0_sas_test_harness_0, dump_records_iteration_0_sas_test_harness_1]
@@ -404,11 +406,13 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     # DP Registration and grant records
     cbsd_records_domain_proxy_0 = {
         'registrationRequests': [device_1, device_2, device_6],
-        'grantRequests': [grant_request_1, grant_request_2, grant_request_6]
+        'grantRequests': [grant_request_1, grant_request_2, grant_request_6],
+        'conditionalRegistrationData': [conditionals_device_2]
     }
     cbsd_records_domain_proxy_1 = {
         'registrationRequests': [device_3, device_4, device_7],
-        'grantRequests': [grant_request_3, grant_request_4, grant_request_7]
+        'grantRequests': [grant_request_3, grant_request_4, grant_request_7],
+        'conditionalRegistrationData': [conditionals_device_4]
     }
 
     # Protected entity record
@@ -474,8 +478,8 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': [
             {'registrationRequest': device_5,
              'grantRequest': grant_request_5,
-             'clientCert': os.path.join('certs', 'client.cert'),
-             'clientKey': os.path.join('certs', 'client.key')}],
+             'clientCert': sas.GetDefaultDomainProxySSLCertPath(),
+             'clientKey': sas.GetDefaultDomainProxySSLKeyPath()}],
         'protectedEntities': protected_entities,
         'dpaActivationList': [],
         'dpaDeactivationList': [],
@@ -605,11 +609,13 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     # Registration and grant records for multiple iterations
     cbsd_records_iteration_0_domain_proxy_0 = {
         'registrationRequests': [device_1, device_2],
-        'grantRequests': [grant_request_1, grant_request_2]
+        'grantRequests': [grant_request_1, grant_request_2],
+        'conditionalRegistrationData': [conditionals_device_2]
     }
     cbsd_records_iteration_0_domain_proxy_1 = {
         'registrationRequests': [device_4],
-        'grantRequests': [grant_request_4]
+        'grantRequests': [grant_request_4],
+        'conditionalRegistrationData': [conditionals_device_4]
     }
 
     # Protected entities records for multiple iterations
@@ -676,8 +682,8 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': [{
             'registrationRequest': device_3,
             'grantRequest': grant_request_3,
-            'clientCert': os.path.join('certs', 'client.cert'),
-            'clientKey': os.path.join('certs', 'client.key')
+            'clientCert': sas.GetDefaultDomainProxySSLCertPath(),
+            'clientKey': sas.GetDefaultDomainProxySSLKeyPath()
         }],
         'protectedEntities': protected_entities_iteration_0,
         'sasTestHarnessData': [dump_records_iteration_0_sas_test_harness_0, dump_records_iteration_0_sas_test_harness_1]

--- a/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
@@ -111,11 +111,13 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
     # Registration and grant records
     cbsd_records_domain_proxy_0 = {
         'registrationRequests': [device_1, device_2],
-        'grantRequests': [grant_request_1, grant_request_2]
+        'grantRequests': [grant_request_1, grant_request_2],
+        'conditionalRegistrationData': [conditionals_device_2]
     }
     cbsd_records_domain_proxy_1 = {
         'registrationRequests': [device_3],
-        'grantRequests': [grant_request_3]
+        'grantRequests': [grant_request_3],
+        'conditionalRegistrationData': []
     }
 
     # Protected entity record
@@ -129,6 +131,7 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': [{
             'registrationRequest': device_4,
             'grantRequest': grant_request_4,
+            'conditionalRegistrationData': conditionals_device_4,  
             'clientCert': sas.GetDefaultDomainProxySSLCertPath(),
             'clientKey': sas.GetDefaultDomainProxySSLKeyPath()
         }],
@@ -252,11 +255,13 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
     # Registration and grant records
     cbsd_records_domain_proxy_0 = {
         'registrationRequests': [device_1, device_2],
-        'grantRequests': [grant_request_1, grant_request_2]
+        'grantRequests': [grant_request_1, grant_request_2],
+        'conditionalRegistrationData': [conditionals_device_2]
     }
     cbsd_records_domain_proxy_1 = {
         'registrationRequests': [device_3],
-        'grantRequests': [grant_request_3]
+        'grantRequests': [grant_request_3],
+        'conditionalRegistrationData': []
     }
 
     # Protected entity record
@@ -325,6 +330,7 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': [{
             'registrationRequest': device_4,
             'grantRequest': grant_request_4,
+            'conditionalRegistrationData': conditionals_device_4,
             'clientCert': sas.GetDefaultDomainProxySSLCertPath(),
             'clientKey': sas.GetDefaultDomainProxySSLKeyPath()
         }],

--- a/src/harness/testcases/WINNF_FT_S_PPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_PPR_testcase.py
@@ -123,11 +123,13 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
     # Registration and grant records
     cbsd_records_domain_proxy_0 = {
         'registrationRequests': [device_1, device_2],
-        'grantRequests': [grant_request_1, grant_request_2]
+        'grantRequests': [grant_request_1, grant_request_2],
+        'conditionalRegistrationData': [conditionals_device_2] 
     }
     cbsd_records_domain_proxy_1 = {
         'registrationRequests': [device_3],
-        'grantRequests': [grant_request_3]
+        'grantRequests': [grant_request_3],
+        'conditionalRegistrationData': []
     }
 
     # Protected entity record
@@ -142,6 +144,7 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': [{
             'registrationRequest': device_4,
             'grantRequest': grant_request_4,
+            'conditionalRegistrationData': conditionals_device_4, 
             'clientCert': sas.GetDefaultDomainProxySSLCertPath(),
             'clientKey': sas.GetDefaultDomainProxySSLKeyPath()
         }],
@@ -278,11 +281,13 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
     # Registration and grant records
     cbsd_records_domain_proxy_0 = {
         'registrationRequests': [device_1, device_2],
-        'grantRequests': [grant_request_1, grant_request_2]
+        'grantRequests': [grant_request_1, grant_request_2],
+        'conditionalRegistrationData': [conditionals_device_2]
     }
     cbsd_records_domain_proxy_1 = {
         'registrationRequests': [device_3],
-        'grantRequests': [grant_request_3]
+        'grantRequests': [grant_request_3],
+        'conditionalRegistrationData': []
     }
 
     # Protected entity record
@@ -352,6 +357,7 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': [{
             'registrationRequest': device_4,
             'grantRequest': grant_request_4,
+            'conditionalRegistrationData': conditionals_device_4,
             'clientCert': sas.GetDefaultDomainProxySSLCertPath(),
             'clientKey': sas.GetDefaultDomainProxySSLKeyPath()
         }],


### PR DESCRIPTION
Purely intending to help speeding up the MCP.1 integration for meeting today’s goal, Federated wireless worked out some fixes related to the review comments from us on PR #602. We have put the fixes in a sub-branch (MCP.1-fix) which is branched off from your “MCP.1” for not disturbing the ongoing work. If you would like to take these fixes, please review and merge this into "MCP.1" branch after approval. Or otherwise, you can ignore this PR and close it. 

