### PR TITLE
fix run time error: list indices must be integers not str

### DIFF
--- a/src/harness/reference_models/pre_iap_filtering/pre_iap_filtering.py
+++ b/src/harness/reference_models/pre_iap_filtering/pre_iap_filtering.py
@@ -43,10 +43,9 @@ def preIapReferenceModel(protected_entities, sas_uut_fad, sas_test_harness_fads)
 
   # Invoke PPA, EXZ, GWPZ, and FSS+GWBL purge list reference models
   # Initialize expected keys in protected_entities to empty array if type does not exist
-  protected_entity_types = ['gwblRecords', 'fssRecords', 'ppaRecords', 'palRecords', 'gwpzRecords']
-  for protected_entity_type in protected_entity_types:
-    if protected_entity_type not in protected_entities:
-      protected_entities[protected_entity_type] = []
+  for key in ['gwblRecords', 'fssRecords', 'ppaRecords', 'palRecords', 'gwpzRecords']:
+    if key not in protected_entities:
+      protected_entities[key] = []
 
   list_of_fss_neighboring_gwbl = pre_iap_util.getFssNeighboringGwbl(
       protected_entities['gwblRecords'],

--- a/src/harness/reference_models/pre_iap_filtering/pre_iap_filtering.py
+++ b/src/harness/reference_models/pre_iap_filtering/pre_iap_filtering.py
@@ -42,15 +42,16 @@ def preIapReferenceModel(protected_entities, sas_uut_fad, sas_test_harness_fads)
                                                                       sas_test_harness_fads)
 
   # Invoke PPA, EXZ, GWPZ, and FSS+GWBL purge list reference models
-  list_of_fss_neighboring_gwbl = pre_iap_util.getFssNeighboringGwbl(
-      protected_entities['gwblRecords'],
-      protected_entities['fssRecords'])
-  zone_purge.zonePurgeReferenceModel(sas_uut_fad,
-                                     sas_test_harness_fads,
-                                     protected_entities['ppaRecords'],
-                                     protected_entities['palRecords'],
-                                     protected_entities['gwpzRecords'],
-                                     list_of_fss_neighboring_gwbl)
+  if 'gwblRecords' in protected_entities and 'fssRecords' in protected_entities:
+    list_of_fss_neighboring_gwbl = pre_iap_util.getFssNeighboringGwbl(
+        protected_entities['gwblRecords'],
+        protected_entities['fssRecords'])
+    zone_purge.zonePurgeReferenceModel(sas_uut_fad,
+                                       sas_test_harness_fads,
+                                       protected_entities['ppaRecords'],
+                                       protected_entities['palRecords'],
+                                       protected_entities['gwpzRecords'],
+                                       list_of_fss_neighboring_gwbl)
 
   # Invoke FSS purge list reference model
   if 'fssRecords' in protected_entities:

--- a/src/harness/reference_models/pre_iap_filtering/pre_iap_filtering.py
+++ b/src/harness/reference_models/pre_iap_filtering/pre_iap_filtering.py
@@ -42,18 +42,21 @@ def preIapReferenceModel(protected_entities, sas_uut_fad, sas_test_harness_fads)
                                                                       sas_test_harness_fads)
 
   # Invoke PPA, EXZ, GWPZ, and FSS+GWBL purge list reference models
-  if 'gwblRecords' in protected_entities and 'fssRecords' in protected_entities:
-    list_of_fss_neighboring_gwbl = pre_iap_util.getFssNeighboringGwbl(
-        protected_entities['gwblRecords'],
-        protected_entities['fssRecords'])
-  if 'ppaRecords' in protected_entities and 'palRecords' in protected_entities and \
-      'gwpzRecords' in protected_entities:
-    zone_purge.zonePurgeReferenceModel(sas_uut_fad,
-                                       sas_test_harness_fads,
-                                       protected_entities['ppaRecords'],
-                                       protected_entities['palRecords'],
-                                       protected_entities['gwpzRecords'],
-                                       list_of_fss_neighboring_gwbl)
+  # Initialize expected keys in protected_entities to empty array if type does not exist
+  protected_entity_types = ['gwblRecords', 'fssRecords', 'ppaRecords', 'palRecords', 'gwpzRecords']
+  for protected_entity_type in protected_entity_types:
+    if protected_entity_type not in protected_entities:
+      protected_entities[protected_entity_type] = []
+
+  list_of_fss_neighboring_gwbl = pre_iap_util.getFssNeighboringGwbl(
+      protected_entities['gwblRecords'],
+      protected_entities['fssRecords'])
+  zone_purge.zonePurgeReferenceModel(sas_uut_fad,
+                                     sas_test_harness_fads,
+                                     protected_entities['ppaRecords'],
+                                     protected_entities['palRecords'],
+                                     protected_entities['gwpzRecords'],
+                                     list_of_fss_neighboring_gwbl)
 
   # Invoke FSS purge list reference model
   if 'fssRecords' in protected_entities:

--- a/src/harness/reference_models/pre_iap_filtering/pre_iap_filtering.py
+++ b/src/harness/reference_models/pre_iap_filtering/pre_iap_filtering.py
@@ -46,6 +46,8 @@ def preIapReferenceModel(protected_entities, sas_uut_fad, sas_test_harness_fads)
     list_of_fss_neighboring_gwbl = pre_iap_util.getFssNeighboringGwbl(
         protected_entities['gwblRecords'],
         protected_entities['fssRecords'])
+  if 'ppaRecords' in protected_entities and 'palRecords' in protected_entities and \
+      'gwpzRecords' in protected_entities:
     zone_purge.zonePurgeReferenceModel(sas_uut_fad,
                                        sas_test_harness_fads,
                                        protected_entities['ppaRecords'],


### PR DESCRIPTION
This commit fixes run time error : “list indices must be integers, not str”

Noticed that ‘gwblRecords’ are not present in protected_entities and we are invoking pre-iap filtering with the same, so ensure 'gwblRecords' and 'fssRecords' are available.