### PR TITLE
Fix test_WINNF_FT_S_FAD_1

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
@@ -13,6 +13,7 @@
 #    limitations under the License.
 """ Implementation of FAD test cases """
 
+import copy
 import hashlib
 import json
 import os

--- a/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
@@ -404,7 +404,7 @@ class FullActivityDumpTestcase(sas_testcase.SasTestCase):
       esc_sensor_dump_data = []
       # step 8 and check
       # download dump files and fill corresponding arrays
-      dump_file = {}
+      downloaded_files = {}
       for dump_file in response['files']:
           self.assertContainsRequiredFields("ActivityDumpFile.schema.json",
                                               dump_file)
@@ -412,7 +412,10 @@ class FullActivityDumpTestcase(sas_testcase.SasTestCase):
           if dump_file['recordType'] != 'coordination':
               downloaded_file = self._sas.DownloadFile(dump_file['url'],\
                 sas_th_config['serverCert'], sas_th_config['serverKey'])
-              dump_file[dump_file['url']] =  downloaded_file
+              # The downloaded_file is being modified in the assertions below,
+              # and hence we need a deep copy to verify that dump files are the
+              # same when requested by different SASs.
+              downloaded_files[dump_file['url']] = copy.deepcopy(downloaded_file)
           if dump_file['recordType'] ==  'cbsd':
               cbsd_dump_data.extend(downloaded_file['recordData'])
           elif dump_file['recordType'] ==  'esc_sensor':
@@ -476,7 +479,7 @@ class FullActivityDumpTestcase(sas_testcase.SasTestCase):
           if dump_file['recordType'] != 'coordination':
               downloaded_file = self._sas.DownloadFile(dump_file['url'],\
                 sas_th['serverCert'], sas_th['serverKey'])
-              self.assertDictEqual(dump_file[dump_file['url']], downloaded_file)
+              self.assertDictEqual(downloaded_files[dump_file['url']], downloaded_file)
 
   def generate_FAD_2_default_config(self, filename):
     """Generates the WinnForum configuration for FAD_2"""


### PR DESCRIPTION
The test_WINNF_FT_S_FAD_1 is incorrect when comparing FAD files retrieved by different SAS THs. The issues are as follows:
- Wrong dictionaries are being compared.
- The original FAD files are mutated (keys are being removed), and hence the comparison will never succeed. The fix is to create deep copies of the original FAD files. Alternative would be to add back the keys being removed - this complicates the logic though.