### PR TITLE
fix the missing 'initialFad' in TH config of GPR. EPR, FPR and PPR

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_EPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_EPR_testcase.py
@@ -322,6 +322,14 @@ class EscProtectionTestcase(McpXprCommonTestcase):
                                           [[grant_request_2], [grant_request_3]]
     )
 
+    # Generate SAS Test Harnesses dump records
+    dump_records_sas_test_harness_0 = {
+        'cbsdRecords': cbsd_fad_records_sas_test_harness_0
+    }
+    dump_records_sas_test_harness_1 = {
+        'cbsdRecords': cbsd_fad_records_sas_test_harness_1
+    }
+
     # SAS Test Harnesses configuration
     sas_test_harness_0_config = {
         'sasTestHarnessName': 'SAS-TH-1',
@@ -329,7 +337,8 @@ class EscProtectionTestcase(McpXprCommonTestcase):
         'port': 9001,
         'serverCert': os.path.join('certs', 'sas.cert'),
         'serverKey': os.path.join('certs', 'sas.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
@@ -337,15 +346,8 @@ class EscProtectionTestcase(McpXprCommonTestcase):
         'port': 9002,
         'serverCert': os.path.join('certs', 'sas_1.cert'),
         'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
-    }
-
-    # Generate SAS Test Harnesses dump records
-    dump_records_sas_test_harness_0 = {
-        'cbsdRecords': cbsd_fad_records_sas_test_harness_0
-    }
-    dump_records_sas_test_harness_1 = {
-        'cbsdRecords': cbsd_fad_records_sas_test_harness_1
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_sas_test_harness_1
     }
 
     iteration_config = {

--- a/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
@@ -190,24 +190,6 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     # Generate Cbsd FAD Records for SAS Test Harness 1, iteration 0
     cbsd_fad_records_iteration_0_sas_test_harness_1 = generateCbsdRecords([sas_test_harness_device_2],[[grant_request_2]])
 
-    # SAS Test Harnesses configuration
-    sas_test_harness_0_config = {
-        'sasTestHarnessName': 'SAS-TH-1',
-        'hostName': 'localhost',
-        'port': 9001,
-        'serverCert': os.path.join('certs', 'sas.cert'),
-        'serverKey': os.path.join('certs', 'sas.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
-    }
-    sas_test_harness_1_config = {
-        'sasTestHarnessName': 'SAS-TH-2',
-        'hostName': 'localhost',
-        'port': 9002,
-        'serverCert': os.path.join('certs', 'sas_1.cert'),
-        'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
-    }
-
     # Generate SAS Test Harnesses dump records for multiple iterations
     dump_records_iteration_0_sas_test_harness_0 = {
         'cbsdRecords': cbsd_fad_records_iteration_0_sas_test_harness_0
@@ -217,6 +199,25 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': cbsd_fad_records_iteration_0_sas_test_harness_1
     }
 
+    # SAS Test Harnesses configuration
+    sas_test_harness_0_config = {
+        'sasTestHarnessName': 'SAS-TH-1',
+        'hostName': 'localhost',
+        'port': 9001,
+        'serverCert': os.path.join('certs', 'sas.cert'),
+        'serverKey': os.path.join('certs', 'sas.key'),
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_iteration_0_sas_test_harness_0
+    }
+    sas_test_harness_1_config = {
+        'sasTestHarnessName': 'SAS-TH-2',
+        'hostName': 'localhost',
+        'port': 9002,
+        'serverCert': os.path.join('certs', 'sas_1.cert'),
+        'serverKey': os.path.join('certs', 'sas_1.key'),
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_iteration_0_sas_test_harness_1
+    }
 
     # Create the actual config.
     iteration0_config = {
@@ -446,6 +447,14 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         [sas_test_harness_device_2, sas_test_harness_device_3],
         [[grant_request_4], [grant_request_6]])
 
+    # Generate SAS Test Harnesses dump records
+    dump_records_sas_test_harness_0 = {
+        'cbsdRecords': cbsd_fad_records_sas_test_harness_0
+    }
+    dump_records_sas_test_harness_1 = {
+        'cbsdRecords': cbsd_fad_records_sas_test_harness_1
+    }
+
     # SAS Test Harnesses configuration
     sas_test_harness_0_config = {
         'sasTestHarnessName': 'SAS-TH-1',
@@ -453,7 +462,8 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'port': 9001,
         'serverCert': os.path.join('certs', 'sas.cert'),
         'serverKey': os.path.join('certs', 'sas.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
@@ -461,15 +471,8 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'port': 9002,
         'serverCert': os.path.join('certs', 'sas_1.cert'),
         'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
-    }
-
-    # Generate SAS Test Harnesses dump records
-    dump_records_sas_test_harness_0 = {
-        'cbsdRecords': cbsd_fad_records_sas_test_harness_0
-    }
-    dump_records_sas_test_harness_1 = {
-        'cbsdRecords': cbsd_fad_records_sas_test_harness_1
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_sas_test_harness_1
     }
 
     iteration_config = {
@@ -648,24 +651,6 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     # Generate Cbsd FAD Records for SAS Test Harness 1, iteration 0
     cbsd_fad_records_iteration_0_sas_test_harness_1 = generateCbsdRecords([sas_test_harness_device_2],[[grant_request_2]])
 
-    # SAS Test Harnesses configuration
-    sas_test_harness_0_config = {
-        'sasTestHarnessName': 'SAS-TH-1',
-        'hostName': 'localhost',
-        'port': 9001,
-        'serverCert': os.path.join('certs', 'sas.cert'),
-        'serverKey': os.path.join('certs', 'sas.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
-    }
-    sas_test_harness_1_config = {
-        'sasTestHarnessName': 'SAS-TH-2',
-        'hostName': 'localhost',
-        'port': 9002,
-        'serverCert': os.path.join('certs', 'sas_1.cert'),
-        'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
-    }
-
     # Generate SAS Test Harnesses dump records for multiple iterations
     dump_records_iteration_0_sas_test_harness_0 = {
         'cbsdRecords': cbsd_fad_records_iteration_0_sas_test_harness_0
@@ -675,6 +660,25 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': cbsd_fad_records_iteration_0_sas_test_harness_1
     }
 
+    # SAS Test Harnesses configuration
+    sas_test_harness_0_config = {
+        'sasTestHarnessName': 'SAS-TH-1',
+        'hostName': 'localhost',
+        'port': 9001,
+        'serverCert': os.path.join('certs', 'sas.cert'),
+        'serverKey': os.path.join('certs', 'sas.key'),
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_iteration_0_sas_test_harness_0
+    }
+    sas_test_harness_1_config = {
+        'sasTestHarnessName': 'SAS-TH-2',
+        'hostName': 'localhost',
+        'port': 9002,
+        'serverCert': os.path.join('certs', 'sas_1.cert'),
+        'serverKey': os.path.join('certs', 'sas_1.key'),
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_iteration_0_sas_test_harness_1
+    }
 
     # Create the actual config.
     iteration0_config = {
@@ -857,6 +861,14 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         [sas_test_harness_device_2, sas_test_harness_device_3],
         [[grant_request_2], [grant_request_3]])
 
+    # Generate SAS Test Harnesses dump records
+    dump_records_sas_test_harness_0 = {
+        'cbsdRecords': cbsd_fad_records_sas_test_harness_0
+    }
+    dump_records_sas_test_harness_1 = {
+        'cbsdRecords': cbsd_fad_records_sas_test_harness_1
+    }
+
     # SAS Test Harnesses configuration
     sas_test_harness_0_config = {
         'sasTestHarnessName': 'SAS-TH-1',
@@ -864,7 +876,8 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'port': 9001,
         'serverCert': os.path.join('certs', 'sas.cert'),
         'serverKey': os.path.join('certs', 'sas.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
@@ -872,15 +885,8 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'port': 9002,
         'serverCert': os.path.join('certs', 'sas_1.cert'),
         'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
-    }
-
-    # Generate SAS Test Harnesses dump records
-    dump_records_sas_test_harness_0 = {
-        'cbsdRecords': cbsd_fad_records_sas_test_harness_0
-    }
-    dump_records_sas_test_harness_1 = {
-        'cbsdRecords': cbsd_fad_records_sas_test_harness_1
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_sas_test_harness_1
     }
 
     iteration_config = {

--- a/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
@@ -298,6 +298,14 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
                                           [[grant_request_2], [grant_request_3]]
     )
 
+    # Generate SAS Test Harnesses dump records
+    dump_records_sas_test_harness_0 = {
+        'cbsdRecords': cbsd_fad_records_sas_test_harness_0
+    }
+    dump_records_sas_test_harness_1 = {
+        'cbsdRecords': cbsd_fad_records_sas_test_harness_1
+    }
+
     # SAS Test Harnesses configuration
     sas_test_harness_0_config = {
         'sasTestHarnessName': 'SAS-TH-1',
@@ -305,7 +313,8 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
         'port': 9001,
         'serverCert': os.path.join('certs', 'sas.cert'),
         'serverKey': os.path.join('certs', 'sas.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
@@ -313,15 +322,8 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
         'port': 9002,
         'serverCert': os.path.join('certs', 'sas_1.cert'),
         'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
-    }
-
-    # Generate SAS Test Harnesses dump records
-    dump_records_sas_test_harness_0 = {
-        'cbsdRecords': cbsd_fad_records_sas_test_harness_0
-    }
-    dump_records_sas_test_harness_1 = {
-        'cbsdRecords': cbsd_fad_records_sas_test_harness_1
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_sas_test_harness_1
     }
 
     iteration_config = {

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -83,8 +83,7 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
         sas_test_harness_object.start()
 
         # Initialize content of test harness.
-        if 'initialFad' in test_harness:
-          sas_test_harness_object.writeFadRecords(test_harness['initialFad'])
+        sas_test_harness_object.writeFadRecords(test_harness['initialFad'])
 
         # informing SAS UUT about SAS Test Harnesses
         certificate_hash = getCertificateFingerprint(test_harness['serverCert'])

--- a/src/harness/testcases/WINNF_FT_S_PPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_PPR_testcase.py
@@ -325,6 +325,14 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
                                           [[grant_request_2], [grant_request_3]]
     )
 
+    # Generate SAS Test Harnesses dump records
+    dump_records_sas_test_harness_0 = {
+        'cbsdRecords': cbsd_fad_records_sas_test_harness_0
+    }
+    dump_records_sas_test_harness_1 = {
+        'cbsdRecords': cbsd_fad_records_sas_test_harness_1
+    }
+
     # SAS Test Harnesses configuration
     sas_test_harness_0_config = {
         'sasTestHarnessName': 'SAS-TH-1',
@@ -332,7 +340,8 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
         'port': 9001,
         'serverCert': os.path.join('certs', 'sas.cert'),
         'serverKey': os.path.join('certs', 'sas.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
@@ -340,15 +349,8 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
         'port': 9002,
         'serverCert': os.path.join('certs', 'sas_1.cert'),
         'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
-    }
-
-    # Generate SAS Test Harnesses dump records
-    dump_records_sas_test_harness_0 = {
-        'cbsdRecords': cbsd_fad_records_sas_test_harness_0
-    }
-    dump_records_sas_test_harness_1 = {
-        'cbsdRecords': cbsd_fad_records_sas_test_harness_1
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_sas_test_harness_1
     }
 
     iteration_config = {


### PR DESCRIPTION
This PR is for fixing the issue found by Takashi as described below.

Kate, per you analysis, I agree with your fix suggestions except that I do not think we need to remove the "if" on line 86 of MCP but just add the required 'initialFad' to the GPR.2 test_harness config file. Please take a look of the fix and let me know if think otherwise.

> [Kate] Ahh,
 good point! I guess we should remove the "if" on line 86 of MCP (since line 87 is actually required for successful execution if there are any SAS THs) and set the 'initialFad' to be the same as the 'iterationData' FAD in the GPR_2 config (simulating a SAS TH which had CBSDs already loaded at the beginning of the test and no change the next day).
 

> [Takashi] For GPR_2, there are two sas_test_harness_[0,1]_config defined. And there is no 'initialFad' set in the config in line 301~317.
In that case, in step3 of MCP, no initialFad is written. (Fad Records are written IF there is initialFad, however in GPR_2 case, there is no initialFad.)
84         # Initialize content of test harness.
85         if 'initialFad' in test_harness:
86           sas_test_harness_object.writeFadRecords(test_harness['initialFad'])
Next time, writeFadRecords will be done in Step13. Until then, there is no FAD file. There is no empty FAD, either.
The test harness tries to get FAD file in Step 6,7 (before Step 13).
174       # Pull FAD from SAS Test Harnesses and fad objects are created for each SAS Test Harnesses
175       self.test_harness_fads = []
176       for test_harness in self.sas_test_harness_objects:
177         self.test_harness_fads.append(getFullActivityDumpSasTestHarness(
178                                           test_harness.getSasTestHarnessInterface()))
Then it gives error here because of no FAD files.
 