### PR TITLE
Update openssl config of SAS cert

### DIFF
--- a/cert/openssl.cnf
+++ b/cert/openssl.cnf
@@ -319,7 +319,7 @@ policyIdentifier = 2.16.840.1.114412.2.1
 subjectKeyIdentifier = hash
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, cRLSign
-extendedKeyUsage = serverAuth
+extendedKeyUsage = serverAuth,clientAuth
 certificatePolicies=@cps,ROLE_SAS,FRN
 crlDistributionPoints=@crl_section
 [ cps ]
@@ -333,7 +333,7 @@ subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, cRLSign
-extendedKeyUsage = serverAuth
+extendedKeyUsage = serverAuth,clientAuth
 certificatePolicies=@cps,ROLE_SAS,FRN
 crlDistributionPoints=@crl_section
 [ cps ]
@@ -342,29 +342,6 @@ policyIdentifier = 2.16.840.1.114412.2.1
  CPS.1="https://www.digicert.com/CPS"
 
 ####################################################################
-[ sas_client_mode_req ]
-
-subjectKeyIdentifier = hash
-basicConstraints = CA:FALSE
-keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
-extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_SAS,FRN
-crlDistributionPoints=@crl_section
-
-[ cps ]
-
-policyIdentifier = 2.16.840.1.114412.2.1
-CPS.1="https://www.digicert.com/CPS"
-
-[ sas_client_mode_req_sign ]
-
-subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
-basicConstraints = CA:FALSE
-keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
-extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_SAS,FRN
-crlDistributionPoints=@crl_section
 
 [ cps ]
 
@@ -378,7 +355,7 @@ subjectKeyIdentifier = hash
 authorityKeyIdentifier = keyid:always,issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
-extendedKeyUsage = clientAuth
+extendedKeyUsage = serverAuth, clientAuth
 certificatePolicies=@cps,ROLE_SAS,ZONE
 ####################################################################
 [ oper_req ]

--- a/src/harness/certs/generate_fake_certs.sh
+++ b/src/harness/certs/generate_fake_certs.sh
@@ -119,21 +119,21 @@ openssl ca -cert sas-ecc_ca.cert -keyfile private/sas-ecc_ca.key -in server-ecc.
 # Generate sas server certificate/key.
 echo -e "\n\nGenerate 'sas server' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
-    -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
+    -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out sas.csr -keyout sas.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=localhost"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas.csr \
     -out sas.cert -outdir ./root \
-    -policy policy_anything -extensions sas_client_mode_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 openssl req -new -newkey rsa:2048 -nodes \
-    -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
+    -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out sas_1.csr -keyout sas_1.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate 001/CN=localhost"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas_1.csr \
     -out sas_1.cert -outdir ./root \
-    -policy policy_anything -extensions sas_client_mode_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Generate normal operation device certificate/key.
@@ -245,7 +245,7 @@ openssl ca -cert non_cbrs_root_signed_cbsd_ca.cert -keyfile private/non_cbrs_roo
 echo -e "\n\nGenerate wrong type certificate/key"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in server.csr \
     -out device_wrong_type.cert -outdir ./root \
-    -policy policy_anything -extensions sas_client_mode_req_sign   -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign   -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Certificate for test case WINNF.FT.S.SCS.11
@@ -281,12 +281,12 @@ openssl ca -revoke domain_proxy_blacklisted.cert -keyfile private/proxy_ca.key -
 # Certificate for test case WINNF.FT.S.SSS.11
 echo -e "\n\nGenerate blacklisted sas certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
-    -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
+    -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out sas_blacklisted.csr -keyout sas_blacklisted.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=localhost"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas_blacklisted.csr \
     -out sas_blacklisted.cert -outdir ./root \
-    -policy policy_anything -extensions sas_client_mode_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Revoke the sas_blacklisted.cert for WINNF.FT.S.SSS.11
@@ -383,7 +383,7 @@ openssl ca -cert non_cbrs_root_signed_oper_ca.cert -keyfile private/non_cbrs_roo
 echo -e "\n\nGenerate wrong type certificate/key"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in server.csr \
     -out domain_proxy_wrong_type.cert -outdir ./root \
-    -policy policy_anything -extensions sas_client_mode_req_sign   -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign   -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Certificate for test case WINNF.FT.S.SDS.12 - Expired certificate presented during registration
@@ -407,12 +407,12 @@ openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key -in domain_proxy.cs
 # Generate certificates for test case WINNF.FT.S.SSS.6 - Unrecognized root of trust certificate presented during registration
 echo -e "\n\nGenerate 'unrecognized_sas' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
-    -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
+    -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out unrecognized_sas.csr -keyout unrecognized_sas.key \
     -subj "/C=US/O=Generic Certification Organization/OU=www.example.org/CN=Unrecognized SAS Provider"
 openssl ca -cert unrecognized_root_ca.cert -keyfile private/unrecognized_root_ca.key -in unrecognized_sas.csr \
     -out unrecognized_sas.cert -outdir ./root \
-    -policy policy_anything -extensions sas_client_mode_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Certificates for test case WINN.FT.S.SSS.7 - corrupted certificate, based on sas.cert
@@ -442,12 +442,12 @@ openssl ca -cert non_cbrs_root_ca.cert -keyfile private/non_cbrs_root_ca.key -in
 # Generate a SAS certificate signed by an intermediate SAS CA which is signed by a non-CBRS root CA
 echo -e "\n\nGenerate sas certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
-    -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
+    -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out non_cbrs_signed_sas.csr -keyout non_cbrs_signed_sas.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=non-cbrs.example.org"
 openssl ca -cert non_cbrs_root_signed_sas_ca.cert -keyfile private/non_cbrs_root_signed_sas_ca.key -in non_cbrs_signed_sas.csr \
     -out non_cbrs_signed_sas.cert -outdir ./root \
-    -policy policy_anything -extensions sas_client_mode_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Certificate for test case WINNF.FT.S.SSS.10 - Certificate of wrong type presented by SAS Test Harness 
@@ -461,12 +461,12 @@ openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in device_a.csr \
 # Certificate for test case WINNF.FT.S.SSS.12 - Expired certificate presented by SAS Test Harness
 echo -e "\n\nGenerate 'sas_expired' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
-    -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
+    -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out sas_expired.csr -keyout sas_expired.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=expired.example.org"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas_expired.csr \
     -out sas_expired.cert -outdir ./root \
-    -policy policy_anything -extensions sas_client_mode_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -startdate 20150214120000Z -enddate 20160214120000Z -md sha384
 
 # Certificate for test case WINNF.FT.S.SSS.15 -Certificate with inapplicable fields presented by SAS Test Harness
@@ -543,12 +543,12 @@ openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in revoked_sas_ca.cs
 # Generate sas server certificate/key.
 echo -e "\n\nGenerate 'sas server' certificate/key signed by revoked_sas_ca"
 openssl req -new -newkey rsa:2048 -nodes \
-    -reqexts sas_client_mode_req -config ../../../cert/openssl.cnf \
+    -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out sas_cert_from_revoked_ca.csr -keyout sas_cert_from_revoked_ca.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=localhost - Revoked"
 openssl ca -cert revoked_sas_ca.cert -keyfile private/revoked_sas_ca.key -in sas_cert_from_revoked_ca.csr \
     -out sas_cert_from_revoked_ca.cert -outdir ./root \
-    -policy policy_anything -extensions sas_client_mode_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Revoke the SAS CA Certificate.


### PR DESCRIPTION
Update openssl config of SAS cert to use only one config with both server auth and client auth

## [jni2000] Note: Add the following context from Takashi's comment email to explain the background of this modification

> Hi, Reda, and all
Thanks Reda, I have studied some more. 

>BTW
 I don’t know if there is a way to generate a certificate with both(server and client auth), I tried that before and I couldn’t make it work on windows :/
Yes I’m also thinking the same idea(below Option-2 solution). 
We haven’t try this, but if it can be done, that’s more easier to implement. 
I think the current MCP code can be used with small/no changes. 
We may need to change the openssl.conf (and generate_fake_certs.sh)

Below is thought in our team what is the problem and possible approach. 

 (SAS-TH) ::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::::: (SAS-UUT)
  Client ............................................................................ Server
(ClientCert_ut)    ------ RequestFAD_ut -------->(ServerCert_ut)
for client auth    <----- ResponseFAD_ut ------- for server auth
  Server ........................................................................... Client
(ServerCert_th)  <----- RequestFAD_th -------- (ClientCert_th)
for server auth  ------- ResponseFAD_th-------> for client auth

Observation-1
certs/server.cert is generated for the purpose of serverAuth. We can confirm it by doing below. 

$ openssl x509 -text -in certs/server.cert
 
             X509v3 Key Usage: critical
                 Digital Signature, CRL Sign
             X509v3 Extended Key Usage:
                 TLS Web Server Authentication

This comes from settings in openssl.conf  (& certs/generate_fake_certs.sh, -regexts) 
   in certs/generate_fake_certs.sh, “sas_req” is set in “–regexts” field. 
   in openssl.conf,       extendedKeyUsage = serverAuth  is set in [ sas_req ] 

Observation-2
  SAS-TH uses the certs/server.cert certificates as ClientCert_ut during  Request FAD_ut.
  i.e. Current code : ServerCert_th = ClientCert_ut = certs/server.cert

From these two observations, 
SAS-TH is using certs/server.cert whose extendedKeyUsage=serverAuth for the purpose of clientAuth. 

Problem 
According to the TLS rule, extendedkeyUsage field is mandatory. We should not violate the usage written in the certificate file. 
SAS-TH is violating the TLS rule of the usage of the certificate. 
--I found some of the server implementation can pass this, however, it is not permitted to use it in this way as a manner. 

Possible solution for SAS-TH to use the correct ClientCert_ut file during  Request FAD_ut. 
Option-1  
   SAS-TH will use the certs/sas.cert certificates as ClientCert_ut. 
Option-2  
   Add clientAuth in the extendedKeyUsage field when generating certs/server.cert. 
   It is permitted to have both serverAuth and clientAuth in the extendedKeyUsage field in the certificate certs/servrer.cert.  
Then SAS-TH can use the same file as ClientCert_ut and ServerCert_th. 



generate_fake_certs.sh 
  98 # Generate fake server certificate/key.$
  99 echo -e "\n\nGenerate 'server' certificate/key"$
100 openssl req -new -newkey rsa:2048 -nodes \$
101 -reqexts sas_req -config ../../../cert/openssl.cnf \$
102 -out server.csr -keyout server.key \$
103 -subj "//C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=localhost"$
104 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in server.csr \$
105 -out server.cert -outdir ./root \$
106 -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \$
107 -batch -notext -create_serial -utf8 -days 1185 -md sha384$
 

openssl.conf
[ sas_req ] (openssl.conf  line317)  (server.cert generation is reffering here) 
subjectKeyIdentifier = hash
basicConstraints = CA:FALSE
keyUsage = critical, digitalSignature, cRLSign
extendedKeyUsage = serverAuth 
certificatePolicies=@cps,ROLE_SAS,FRN
crlDistributionPoints=@crl_section

[ sas_client_mode_req ] (openssl.conf  line345)  (FYI, reference for sas.cert generation)
subjectKeyIdentifier = hash
basicConstraints = CA:FALSE
keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
extendedKeyUsage = clientAuth
certificatePolicies=@cps,ROLE_SAS,FRN
crlDistributionPoints=@crl_section

Best Regards,
Takashi 

