### PR TITLE
fix the getRandomLatLongInPolygon call input parameter issue

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
@@ -56,7 +56,7 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
       open(os.path.join('testcases', 'testdata', 'device_c.json')))
     # Moving device_3 to a location inside GWPZ zone
     device_3['installationParam']['latitude'], \
-    device_3['installationParam']['longitude'] = getRandomLatLongInPolygon(gwpz_record_1['zone'])
+    device_3['installationParam']['longitude'] = getRandomLatLongInPolygon(gwpz_record_1)
 
     device_4 = json.load(
       open(os.path.join('testcases', 'testdata', 'device_d.json')))
@@ -189,7 +189,7 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
       open(os.path.join('testcases', 'testdata', 'device_c.json')))
     # Moving device_3 to a location inside GWPZ zone
     device_3['installationParam']['latitude'], \
-    device_3['installationParam']['longitude'] = getRandomLatLongInPolygon(gwpz_record_1['zone'])
+    device_3['installationParam']['longitude'] = getRandomLatLongInPolygon(gwpz_record_1)
 
     device_4 = json.load(
       open(os.path.join('testcases', 'testdata', 'device_d.json')))
@@ -377,13 +377,13 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
       open(os.path.join('testcases', 'testdata', 'device_a.json')))
     # Moving device_1 to a location inside GWPZ zone
     device_1['installationParam']['latitude'], \
-    device_1['installationParam']['longitude'] = getRandomLatLongInPolygon(gwpz_record_1['zone'])
+    device_1['installationParam']['longitude'] = getRandomLatLongInPolygon(gwpz_record_1)
 
     device_2 = json.load(
       open(os.path.join('testcases', 'testdata', 'device_b.json')))
     # Moving device_2 to a location inside GWPZ zone
     device_2['installationParam']['latitude'], \
-    device_2['installationParam']['longitude'] = getRandomLatLongInPolygon(gwpz_record_1['zone'])
+    device_2['installationParam']['longitude'] = getRandomLatLongInPolygon(gwpz_record_1)
 
     # Load Grant requests
     grant_request_1 = json.load(


### PR DESCRIPTION
fix the getRandomLatLongInPolygon call input parameter issue. The getRandomLatLongInPolygon shall take a higher level of object above "zone" element.