### PR TITLE
revert src/harness/testcases/testdata/gwpz_record_0.json back

### DIFF
--- a/src/harness/testcases/testdata/gwpz_record_0.json
+++ b/src/harness/testcases/testdata/gwpz_record_0.json
@@ -46,6 +46,6 @@
         ]
       }
     }
-  ]},
-  "landCategory": "RURAL" 
+  ]
+}
 }


### PR DESCRIPTION
revert src/harness/testcases/testdata/gwpz_record_0.json back, no landcategory is needed for injecting into UUT according to the post-merge discussion in PR #617 