### PR TITLE
Fix MCP.1 and other tests with 'initialFad'

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_EPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_EPR_testcase.py
@@ -332,7 +332,7 @@ class EscProtectionTestcase(McpXprCommonTestcase):
         'serverCert': os.path.join('certs', 'sas.cert'),
         'serverKey': os.path.join('certs', 'sas.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_sas_test_harness_0]
+        'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
@@ -341,7 +341,7 @@ class EscProtectionTestcase(McpXprCommonTestcase):
         'serverCert': os.path.join('certs', 'sas_1.cert'),
         'serverKey': os.path.join('certs', 'sas_1.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_sas_test_harness_1]
+        'initialFad': dump_records_sas_test_harness_1
     }
 
     iteration_config = {
@@ -350,7 +350,7 @@ class EscProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': [{
             'registrationRequest': device_4,
             'grantRequest': grant_request_4,
-            'conditionalRegistrationData': conditionals_device_4,  
+            'conditionalRegistrationData': conditionals_device_4,
             'clientCert': sas.GetDefaultDomainProxySSLCertPath(),
             'clientKey': sas.GetDefaultDomainProxySSLKeyPath()
         }],

--- a/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
@@ -205,7 +205,7 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'serverCert': os.path.join('certs', 'sas.cert'),
         'serverKey': os.path.join('certs', 'sas.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_iteration_0_sas_test_harness_0]
+        'initialFad': dump_records_iteration_0_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
@@ -214,7 +214,7 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'serverCert': os.path.join('certs', 'sas_1.cert'),
         'serverKey': os.path.join('certs', 'sas_1.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_iteration_0_sas_test_harness_1]
+        'initialFad': dump_records_iteration_0_sas_test_harness_1
     }
 
     # Create the actual config.
@@ -223,7 +223,6 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': [{
             'registrationRequest': device_6,
             'grantRequest': grant_request_6,
-            'conditionalRegistrationData': {},
             'clientCert': sas.GetDefaultDomainProxySSLCertPath(),
             'clientKey': sas.GetDefaultDomainProxySSLKeyPath()
         }],
@@ -460,7 +459,7 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'serverCert': os.path.join('certs', 'sas.cert'),
         'serverKey': os.path.join('certs', 'sas.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_sas_test_harness_0]
+        'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
@@ -469,7 +468,7 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'serverCert': os.path.join('certs', 'sas_1.cert'),
         'serverKey': os.path.join('certs', 'sas_1.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_sas_test_harness_1]
+        'initialFad': dump_records_sas_test_harness_1
     }
 
     iteration_config = {
@@ -478,7 +477,6 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': [
             {'registrationRequest': device_5,
              'grantRequest': grant_request_5,
-             'conditionalRegistrationData': {},
              'clientCert': sas.GetDefaultDomainProxySSLCertPath(),
              'clientKey': sas.GetDefaultDomainProxySSLKeyPath()}],
         'protectedEntities': protected_entities,
@@ -660,7 +658,7 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'serverCert': os.path.join('certs', 'sas.cert'),
         'serverKey': os.path.join('certs', 'sas.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_iteration_0_sas_test_harness_0]
+        'initialFad': dump_records_iteration_0_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
@@ -669,7 +667,7 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'serverCert': os.path.join('certs', 'sas_1.cert'),
         'serverKey': os.path.join('certs', 'sas_1.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_iteration_0_sas_test_harness_1]
+        'initialFad': dump_records_iteration_0_sas_test_harness_1
     }
 
     # Create the actual config.
@@ -678,7 +676,6 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': [{
             'registrationRequest': device_3,
             'grantRequest': grant_request_3,
-            'conditionalRegistrationData': {},
             'clientCert': sas.GetDefaultDomainProxySSLCertPath(),
             'clientKey': sas.GetDefaultDomainProxySSLKeyPath()
         }],
@@ -869,7 +866,7 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'serverCert': os.path.join('certs', 'sas.cert'),
         'serverKey': os.path.join('certs', 'sas.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_sas_test_harness_0]
+        'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
@@ -878,7 +875,7 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'serverCert': os.path.join('certs', 'sas_1.cert'),
         'serverKey': os.path.join('certs', 'sas_1.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_sas_test_harness_1]
+        'initialFad': dump_records_sas_test_harness_1
     }
 
     iteration_config = {

--- a/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
@@ -308,7 +308,7 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
         'serverCert': os.path.join('certs', 'sas.cert'),
         'serverKey': os.path.join('certs', 'sas.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_sas_test_harness_0]
+        'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
@@ -317,7 +317,7 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
         'serverCert': os.path.join('certs', 'sas_1.cert'),
         'serverKey': os.path.join('certs', 'sas_1.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_sas_test_harness_1]
+        'initialFad': dump_records_sas_test_harness_1
     }
 
     iteration_config = {

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -87,10 +87,10 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
             cbsd_record, {
                 'registrationRequest': dict,
                 'grantRequest': dict,
-                'conditionalRegistrationData': dict,
                 'clientCert': basestring,
                 'clientKey': basestring
-            })
+            },
+            {'conditionalRegistrationData': dict})
 
       self.assertValidConfig(
           iteration_data['protectedEntities'],
@@ -129,7 +129,7 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
               'serverCert': basestring,
               'serverKey': basestring,
               'caCert': basestring,
-              'initialFad': list
+              'initialFad': dict
           })
       checkFadConfiguration(sas_test_harness_config['initialFad'])
 
@@ -498,7 +498,7 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
       for ppa_record in self.protected_entity_records['ppaRecords']:
         pal_records = self.protected_entity_records['palRecords']
         # Call IAP reference model for PPA.
-        logging.info("Calling the IAP reference model for PPA (%s) with PAL records (%s)" % (str(ppa_record), str(pal_records))
+        logging.info("Calling the IAP reference model for PPA (%s) with PAL records (%s)" % (str(ppa_record), str(pal_records)))
         ppa_ap_iap_ref_values = iap.performIapForPpa(
             ppa_record,
             self.sas_uut_fad,
@@ -917,9 +917,6 @@ class MultiConstraintProtectionTestcase(McpXprCommonTestcase):
     sas_test_harness_device_6['fccId'] = "test_fcc_id_l"
     sas_test_harness_device_6['userId'] = "test_user_id_l"
 
-    # Generate Cbsd FAD Records for SAS Test Harness 0, initial data.
-    cbsd_fad_records_iteration_initial_sas_test_harness_0 = generateCbsdRecords([sas_test_harness_device_1], [[grant_request_1]])
-
     # Generate Cbsd FAD Records for SAS Test Harness 0, iteration 0
     cbsd_fad_records_iteration_0_sas_test_harness_0 = generateCbsdRecords([sas_test_harness_device_1], [[grant_request_1]])
 
@@ -934,27 +931,7 @@ class MultiConstraintProtectionTestcase(McpXprCommonTestcase):
     # Generate Cbsd FAD Records for SAS Test Harness 1, iteration 1
     cbsd_fad_records_iteration_1_sas_test_harness_1 = generateCbsdRecords([sas_test_harness_device_6], [[grant_request_5, grant_request_6]])
 
-    # SAS Test Harnesses configuration
-    sas_test_harness_0_config = {
-        'sasTestHarnessName': 'SAS-TH-1',
-        'hostName': 'localhost',
-        'port': 9001,
-        'serverCert': os.path.join('certs', 'server.cert'),
-        'serverKey': os.path.join('certs', 'server.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_iteration_initial_sas_test_harness_0]
-    }
-    sas_test_harness_1_config = {
-        'sasTestHarnessName': 'SAS-TH-2',
-        'hostName': 'localhost',
-        'port': 9002,
-        'serverCert': os.path.join('certs', 'server.cert'),
-        'serverKey': os.path.join('certs', 'server.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_iteration_initial_sas_test_harness_1]
-    }
-
-    # Generate SAS Test Harnesses dump records for multiple iterations
+   # Generate SAS Test Harnesses dump records for multiple iterations
     dump_records_iteration_0_sas_test_harness_0 = {
         'cbsdRecords': cbsd_fad_records_iteration_0_sas_test_harness_0
     }
@@ -966,6 +943,26 @@ class MultiConstraintProtectionTestcase(McpXprCommonTestcase):
     }
     dump_records_iteration_1_sas_test_harness_1 = {
         'cbsdRecords': cbsd_fad_records_iteration_1_sas_test_harness_1
+    }
+
+    # SAS Test Harnesses configuration
+    sas_test_harness_0_config = {
+        'sasTestHarnessName': 'SAS-TH-1',
+        'hostName': 'localhost',
+        'port': 9001,
+        'serverCert': os.path.join('certs', 'server.cert'),
+        'serverKey': os.path.join('certs', 'server.key'),
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_iteration_0_sas_test_harness_0
+    }
+    sas_test_harness_1_config = {
+        'sasTestHarnessName': 'SAS-TH-2',
+        'hostName': 'localhost',
+        'port': 9002,
+        'serverCert': os.path.join('certs', 'server.cert'),
+        'serverKey': os.path.join('certs', 'server.key'),
+        'caCert': os.path.join('certs', 'ca.cert'),
+        'initialFad': dump_records_iteration_0_sas_test_harness_1
     }
 
     # Create the actual config.

--- a/src/harness/testcases/WINNF_FT_S_PPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_PPR_testcase.py
@@ -335,7 +335,7 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
         'serverCert': os.path.join('certs', 'sas.cert'),
         'serverKey': os.path.join('certs', 'sas.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_sas_test_harness_0]
+        'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
@@ -344,7 +344,7 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
         'serverCert': os.path.join('certs', 'sas_1.cert'),
         'serverKey': os.path.join('certs', 'sas_1.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
-        'initialFad': [cbsd_fad_records_sas_test_harness_1]
+        'initialFad': dump_records_sas_test_harness_1
     }
 
     iteration_config = {


### PR DESCRIPTION
- Fix MCP.1 errors
- Fix 'initialFad' in xPR tests
- Make conditionalRegistrationData an optional in cbsdRecords.