### PR TITLE
fix SIQ.3 C2 and C4 checking

### DIFF
--- a/src/harness/sas_testcase.py
+++ b/src/harness/sas_testcase.py
@@ -298,10 +298,10 @@ class SasTestCase(unittest.TestCase):
         reverse=False)
     for index, channel in enumerate(channels):
       if index == 0:
-        self.assertLessEqual(channel['frequencyRange']['lowFrequency'],
+        self.assertGreaterEqual(channel['frequencyRange']['lowFrequency'],
                          frequency_range['lowFrequency'])
       else:
-        self.assertLessEqual(
+        self.assertGreaterEqual(
             channel['frequencyRange']['lowFrequency'],
             channels[index - 1]['frequencyRange']['highFrequency'])
 

--- a/src/harness/sas_testcase.py
+++ b/src/harness/sas_testcase.py
@@ -282,14 +282,21 @@ class SasTestCase(unittest.TestCase):
     self.assertEqual(channels[0]['frequencyRange']['highFrequency'],
                      frequency_range['highFrequency'])
 
-  def assertChannelsWithinFrequencyRange(self, channels, frequency_range):
-    """Checks if the frequency range of all channels are within 
-       a given frequency range.
+  def assertChannelsOverlapFrequencyRange(self, channels, frequency_range,
+                                          constrain_low=False, constrain_high=False):
+    """Checks if the frequency range of all channels overlap
+       the given frequency range.
 
     Args:
       channels: A list of dictionaries containing frequencyRange,
         which is a dictionary containing lowFrequency and highFrequency.
       frequency_range: A dictionary containing lowFrequency and highFrequency.
+      constrain_low: boolean indicating if the low edge frequency of the channel
+        at the lowest frequency end need to be constrained on the low frequency
+        of the frequency range.
+      constrain_high: boolean indicating if the high edge frequency of the channel
+        at the highest frequency end need to be constrained on the high frequency
+        of the frequency range.
     """
     channels.sort(
         key=
@@ -298,8 +305,12 @@ class SasTestCase(unittest.TestCase):
         reverse=False)
     for index, channel in enumerate(channels):
       if index == 0:
-        self.assertGreaterEqual(channel['frequencyRange']['lowFrequency'],
-                         frequency_range['lowFrequency'])
+        if constrain_low:
+          self.assertEqual(channel['frequencyRange']['lowFrequency'],
+                           frequency_range['lowFrequency'])
+        else:
+          self.assertGreaterEqual(channel['frequencyRange']['lowFrequency'],
+                                  frequency_range['lowFrequency'])
       else:
         self.assertGreaterEqual(
             channel['frequencyRange']['lowFrequency'],
@@ -307,8 +318,12 @@ class SasTestCase(unittest.TestCase):
 
     channels.sort(
         key=lambda ch: (ch['frequencyRange']['highFrequency']), reverse=True)
-    self.assertLessEqual(channels[0]['frequencyRange']['highFrequency'],
-                     frequency_range['highFrequency'])
+    if constrain_high:
+      self.assertEqual(channels[0]['frequencyRange']['highFrequency'],
+                       frequency_range['highFrequency'])
+    else:
+      self.assertLessEqual(channels[0]['frequencyRange']['highFrequency'],
+                           frequency_range['highFrequency'])
 
   def assertChannelIncludedInFrequencyRanges(self, channel, frequency_ranges):
     """Checks if the channel lies within the list of frequency ranges.

--- a/src/harness/sas_testcase.py
+++ b/src/harness/sas_testcase.py
@@ -282,6 +282,34 @@ class SasTestCase(unittest.TestCase):
     self.assertEqual(channels[0]['frequencyRange']['highFrequency'],
                      frequency_range['highFrequency'])
 
+  def assertChannelsWithinFrequencyRange(self, channels, frequency_range):
+    """Checks if the frequency range of all channels is within 
+       a given input frequency range.
+
+    Args:
+      channels: A list of dictionaries containing frequencyRange,
+        which is a dictionary containing lowFrequency and highFrequency.
+      frequency_range: A dictionary containing lowFrequency and highFrequency.
+    """
+    channels.sort(
+        key=
+        lambda ch: (ch['frequencyRange']['lowFrequency'],
+                    ch['frequencyRange']['highFrequency']),
+        reverse=False)
+    for index, channel in enumerate(channels):
+      if index == 0:
+        self.assertLessEqual(channel['frequencyRange']['lowFrequency'],
+                         frequency_range['lowFrequency'])
+      else:
+        self.assertLessEqual(
+            channel['frequencyRange']['lowFrequency'],
+            channels[index - 1]['frequencyRange']['highFrequency'])
+
+    channels.sort(
+        key=lambda ch: (ch['frequencyRange']['highFrequency']), reverse=True)
+    self.assertLessEqual(channels[0]['frequencyRange']['highFrequency'],
+                     frequency_range['highFrequency'])
+
   def assertChannelIncludedInFrequencyRanges(self, channel, frequency_ranges):
     """Checks if the channel lies within the list of frequency ranges.
 

--- a/src/harness/sas_testcase.py
+++ b/src/harness/sas_testcase.py
@@ -309,10 +309,10 @@ class SasTestCase(unittest.TestCase):
           self.assertEqual(channel['frequencyRange']['lowFrequency'],
                            frequency_range['lowFrequency'])
         else:
-          self.assertGreaterEqual(channel['frequencyRange']['lowFrequency'],
-                                  frequency_range['lowFrequency'])
+          self.assertLessEqual(channel['frequencyRange']['lowFrequency'],
+                               frequency_range['lowFrequency'])
       else:
-        self.assertGreaterEqual(
+        self.assertLessEqual(
             channel['frequencyRange']['lowFrequency'],
             channels[index - 1]['frequencyRange']['highFrequency'])
 
@@ -322,8 +322,8 @@ class SasTestCase(unittest.TestCase):
       self.assertEqual(channels[0]['frequencyRange']['highFrequency'],
                        frequency_range['highFrequency'])
     else:
-      self.assertLessEqual(channels[0]['frequencyRange']['highFrequency'],
-                           frequency_range['highFrequency'])
+      self.assertGreaterEqual(channels[0]['frequencyRange']['highFrequency'],
+                              frequency_range['highFrequency'])
 
   def assertChannelIncludedInFrequencyRanges(self, channel, frequency_ranges):
     """Checks if the channel lies within the list of frequency ranges.

--- a/src/harness/sas_testcase.py
+++ b/src/harness/sas_testcase.py
@@ -304,6 +304,8 @@ class SasTestCase(unittest.TestCase):
                     ch['frequencyRange']['highFrequency']),
         reverse=False)
     for index, channel in enumerate(channels):
+      self.assertGreater(channel['frequencyRange']['highFrequency'],
+                         frequency_range['lowFrequency'])
       if index == 0:
         if constrain_low:
           self.assertEqual(channel['frequencyRange']['lowFrequency'],
@@ -316,6 +318,9 @@ class SasTestCase(unittest.TestCase):
             channel['frequencyRange']['lowFrequency'],
             channels[index - 1]['frequencyRange']['highFrequency'])
 
+    for index, channel in enumerate(channels):
+      self.assertLess(channel['frequencyRange']['lowFrequency'],
+                      frequency_range['highFrequency'])
     channels.sort(
         key=lambda ch: (ch['frequencyRange']['highFrequency']), reverse=True)
     if constrain_high:

--- a/src/harness/sas_testcase.py
+++ b/src/harness/sas_testcase.py
@@ -283,8 +283,8 @@ class SasTestCase(unittest.TestCase):
                      frequency_range['highFrequency'])
 
   def assertChannelsWithinFrequencyRange(self, channels, frequency_range):
-    """Checks if the frequency range of all channels is within 
-       a given input frequency range.
+    """Checks if the frequency range of all channels are within 
+       a given frequency range.
 
     Args:
       channels: A list of dictionaries containing frequencyRange,

--- a/src/harness/sas_testcase.py
+++ b/src/harness/sas_testcase.py
@@ -291,12 +291,12 @@ class SasTestCase(unittest.TestCase):
       channels: A list of dictionaries containing frequencyRange,
         which is a dictionary containing lowFrequency and highFrequency.
       frequency_range: A dictionary containing lowFrequency and highFrequency.
-      constrain_low: boolean indicating if the low edge frequency of the channel
-        at the lowest frequency end need to be constrained on the low frequency
-        of the frequency range.
-      constrain_high: boolean indicating if the high edge frequency of the channel
-        at the highest frequency end need to be constrained on the high frequency
-        of the frequency range.
+      constrain_low: A Boolean flag indicating if the lower frequency edge of the
+        channel with the lowest frequency segment need to be constrained to be 
+        equal to the lower frequency edge of the frequency range.
+      constrain_high: A Boolean flag indicating if the upper frequency edge of the
+        channel with the highest frequency segment need to be constrained to be 
+        equal to the upper frequency edge of the frequency range.
     """
     channels.sort(
         key=

--- a/src/harness/testcases/WINNF_FT_S_SIQ_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SIQ_testcase.py
@@ -93,14 +93,9 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
 
     # Inject GWBL station operating at range 3650 - 3700 MHz within 150 km of
     # FSS (approx. 100 km from FSS location set above).
-    gwbl_data = json.load(
+    gwbl = json.load(
         open(os.path.join('testcases', 'testdata', 'gwbl_record_0.json')))
-    self._sas_admin.InjectWisp(gwbl_data)
-    gwbl = gwbl_data['record']
-    gwbl_low_frequency = gwbl['deploymentParam'][0]['operationParam'][
-      'operationFrequencyRange']['lowFrequency']
-    gwbl_high_frequency  = gwbl['deploymentParam'][0]['operationParam'][
-      'operationFrequencyRange']['highFrequency']
+    self._sas_admin.InjectWisp(gwbl)
 
     # Load PAL/PPA data, operating channel 3620 - 3630 MHz.
     pal_record = json.load(
@@ -215,7 +210,7 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
     }
     freq_range_all_but_fss_gwbl = {
         'lowFrequency': 3550000000,
-        'highFrequency': gwbl_low_frequency,
+        'highFrequency': 3650000000,
     }
     freq_range_all = {
         'lowFrequency': 3550000000,

--- a/src/harness/testcases/WINNF_FT_S_SIQ_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SIQ_testcase.py
@@ -208,10 +208,6 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
         'lowFrequency': 3650000000,
         'highFrequency': 3700000000,
     }
-    freq_range_all_but_fss_gwbl = {
-        'lowFrequency': 3550000000,
-        'highFrequency': 3650000000,
-    }
     freq_range_all = {
         'lowFrequency': 3550000000,
         'highFrequency': 3700000000,
@@ -247,11 +243,15 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
             for channel in channels_pal[0]))
 
     # Checks for cbsd 2 (index 1)
-    self.assertChannelsWithinFrequencyRange(all_channels[1], freq_range_all)
+    self.assertChannelsOverlapFrequencyRange(channels_low[1], freq_range_low, True, False)
+    self.assertChannelsOverlapFrequencyRange(channels_high[1], freq_range_high, False, False)
+    for channel in channels[1]:
+      self.assertLessEqual(channel['frequencyRange']['highFrequency'],
+                           freq_range_all['highFrequency'])
     self.assertTrue(
         all(channel['channelType'] == 'GAA' and
             channel['ruleApplied'] == 'FCC_PART_96'
-            for channel in channels_low[1] + channels_high[1]))
+            for channel in all_channels[1]))
     self.assertFalse(
         any(channel['channelType'] == 'PAL' for channel in all_channels[1]))
 
@@ -270,7 +270,8 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
     self.assertEqual(len(channels_excluded[2]), 0)
 
     # Checks for cbsd 4 (index 3)
-    self.assertChannelsWithinFrequencyRange(all_channels[3], freq_range_all_but_fss_gwbl)
+    self.assertChannelsOverlapFrequencyRange(channels_low[3], freq_range_low, True, False)
+    self.assertChannelsOverlapFrequencyRange(channels_high[3], freq_range_high, False, True)
     self.assertTrue(
         all(channel['channelType'] == 'GAA' and
             channel['ruleApplied'] == 'FCC_PART_96'

--- a/src/harness/testcases/WINNF_FT_S_SIQ_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SIQ_testcase.py
@@ -231,7 +231,12 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
 
     # Checks for cbsd 1 (index 0)
     self.assertChannelsContainFrequencyRange(channels_low[0], freq_range_low)
-    self.assertChannelsContainFrequencyRange(channels_high[0], freq_range_high)
+    constrain_low = True
+    constrain_high = False
+    self.assertChannelsOverlapFrequencyRange(channels_high[0], freq_range_high, constrain_low, constrain_high)
+    for channel in all_channels[0]:
+      self.assertLessEqual(channel['frequencyRange']['highFrequency'],
+                           3700000000)
     self.assertTrue(
         all(channel['channelType'] == 'GAA' and
             channel['ruleApplied'] == 'FCC_PART_96'
@@ -243,11 +248,14 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
             for channel in channels_pal[0]))
 
     # Checks for cbsd 2 (index 1)
-    self.assertChannelsOverlapFrequencyRange(channels_low[1], freq_range_low, True, False)
-    self.assertChannelsOverlapFrequencyRange(channels_high[1], freq_range_high, False, False)
-    for channel in channels[1]:
+    constrain_low = True
+    constrain_high = False
+    self.assertChannelsOverlapFrequencyRange(channels_low[1], freq_range_low, constrain_low, constrain_high)
+    constrain_low = False
+    self.assertChannelsOverlapFrequencyRange(channels_high[1], freq_range_high, constrain_low, constrain_high)
+    for channel in all_channels[1]:
       self.assertLessEqual(channel['frequencyRange']['highFrequency'],
-                           freq_range_all['highFrequency'])
+                           3700000000)
     self.assertTrue(
         all(channel['channelType'] == 'GAA' and
             channel['ruleApplied'] == 'FCC_PART_96'
@@ -270,8 +278,12 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
     self.assertEqual(len(channels_excluded[2]), 0)
 
     # Checks for cbsd 4 (index 3)
-    self.assertChannelsOverlapFrequencyRange(channels_low[3], freq_range_low, True, False)
-    self.assertChannelsOverlapFrequencyRange(channels_high[3], freq_range_high, False, True)
+    constrain_low = True
+    constrain_high = False
+    self.assertChannelsOverlapFrequencyRange(channels_low[3], freq_range_low, constrain_low, constrain_high)
+    constrain_low = False
+    constrain_high = True	
+    self.assertChannelsOverlapFrequencyRange(channels_high[3], freq_range_high, constrain_low, constrain_high)
     self.assertTrue(
         all(channel['channelType'] == 'GAA' and
             channel['ruleApplied'] == 'FCC_PART_96'

--- a/src/harness/testcases/WINNF_FT_S_SIQ_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SIQ_testcase.py
@@ -93,9 +93,14 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
 
     # Inject GWBL station operating at range 3650 - 3700 MHz within 150 km of
     # FSS (approx. 100 km from FSS location set above).
-    gwbl = json.load(
+    gwbl_data = json.load(
         open(os.path.join('testcases', 'testdata', 'gwbl_record_0.json')))
-    self._sas_admin.InjectWisp(gwbl)
+    self._sas_admin.InjectWisp(gwbl_data)
+    gwbl = gwbl_data['record']
+    gwbl_low_frequency = gwbl['deploymentParam'][0]['operationParam'][
+      'operationFrequencyRange']['lowFrequency']
+    gwbl_high_frequency  = gwbl['deploymentParam'][0]['operationParam'][
+      'operationFrequencyRange']['highFrequency']
 
     # Load PAL/PPA data, operating channel 3620 - 3630 MHz.
     pal_record = json.load(
@@ -208,6 +213,14 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
         'lowFrequency': 3650000000,
         'highFrequency': 3700000000,
     }
+    freq_range_all_but_fss_gwbl = {
+        'lowFrequency': 3550000000,
+        'highFrequency': gwbl_low_frequency,
+    }
+    freq_range_all = {
+        'lowFrequency': 3550000000,
+        'highFrequency': 3700000000,
+    }
     all_channels = []
     channels_low = []
     channels_high = []
@@ -239,8 +252,7 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
             for channel in channels_pal[0]))
 
     # Checks for cbsd 2 (index 1)
-    self.assertChannelsContainFrequencyRange(channels_low[1], freq_range_low)
-    self.assertChannelsContainFrequencyRange(channels_high[1], freq_range_high)
+    self.assertChannelsContainFrequencyRange(all_channels[1], freq_range_all)
     self.assertTrue(
         all(channel['channelType'] == 'GAA' and
             channel['ruleApplied'] == 'FCC_PART_96'
@@ -263,8 +275,7 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
     self.assertEqual(len(channels_excluded[2]), 0)
 
     # Checks for cbsd 4 (index 3)
-    self.assertChannelsContainFrequencyRange(channels_low[3], freq_range_low)
-    self.assertChannelsContainFrequencyRange(channels_high[3], freq_range_high)
+    self.assertChannelsContainFrequencyRange(all_channels[3], freq_range_all_but_fss_gwbl)
     self.assertTrue(
         all(channel['channelType'] == 'GAA' and
             channel['ruleApplied'] == 'FCC_PART_96'

--- a/src/harness/testcases/WINNF_FT_S_SIQ_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SIQ_testcase.py
@@ -208,10 +208,6 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
         'lowFrequency': 3650000000,
         'highFrequency': 3700000000,
     }
-    freq_range_all = {
-        'lowFrequency': 3550000000,
-        'highFrequency': 3700000000,
-    }
     all_channels = []
     channels_low = []
     channels_high = []
@@ -231,9 +227,7 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
 
     # Checks for cbsd 1 (index 0)
     self.assertChannelsContainFrequencyRange(channels_low[0], freq_range_low)
-    constrain_low = True
-    constrain_high = False
-    self.assertChannelsOverlapFrequencyRange(channels_high[0], freq_range_high, constrain_low, constrain_high)
+    self.assertChannelsOverlapFrequencyRange(channels_high[0], freq_range_high, constrain_low=True, constrain_high=False)
     for channel in all_channels[0]:
       self.assertLessEqual(channel['frequencyRange']['highFrequency'],
                            3700000000)
@@ -248,11 +242,8 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
             for channel in channels_pal[0]))
 
     # Checks for cbsd 2 (index 1)
-    constrain_low = True
-    constrain_high = False
-    self.assertChannelsOverlapFrequencyRange(channels_low[1], freq_range_low, constrain_low, constrain_high)
-    constrain_low = False
-    self.assertChannelsOverlapFrequencyRange(channels_high[1], freq_range_high, constrain_low, constrain_high)
+    self.assertChannelsOverlapFrequencyRange(channels_low[1], freq_range_low, constrain_low=True, constrain_high=False)
+    self.assertChannelsOverlapFrequencyRange(channels_high[1], freq_range_high, constrain_low=False, constrain_high=False)
     for channel in all_channels[1]:
       self.assertLessEqual(channel['frequencyRange']['highFrequency'],
                            3700000000)
@@ -278,12 +269,8 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
     self.assertEqual(len(channels_excluded[2]), 0)
 
     # Checks for cbsd 4 (index 3)
-    constrain_low = True
-    constrain_high = False
-    self.assertChannelsOverlapFrequencyRange(channels_low[3], freq_range_low, constrain_low, constrain_high)
-    constrain_low = False
-    constrain_high = True	
-    self.assertChannelsOverlapFrequencyRange(channels_high[3], freq_range_high, constrain_low, constrain_high)
+    self.assertChannelsOverlapFrequencyRange(channels_low[3], freq_range_low, constrain_low=True, constrain_high=False)
+    self.assertChannelsOverlapFrequencyRange(channels_high[3], freq_range_high, constrain_low=False, constrain_high=True)
     self.assertTrue(
         all(channel['channelType'] == 'GAA' and
             channel['ruleApplied'] == 'FCC_PART_96'

--- a/src/harness/testcases/WINNF_FT_S_SIQ_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SIQ_testcase.py
@@ -247,7 +247,7 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
             for channel in channels_pal[0]))
 
     # Checks for cbsd 2 (index 1)
-    self.assertChannelsContainFrequencyRange(all_channels[1], freq_range_all)
+    self.assertChannelsWithinFrequencyRange(all_channels[1], freq_range_all)
     self.assertTrue(
         all(channel['channelType'] == 'GAA' and
             channel['ruleApplied'] == 'FCC_PART_96'
@@ -270,7 +270,7 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
     self.assertEqual(len(channels_excluded[2]), 0)
 
     # Checks for cbsd 4 (index 3)
-    self.assertChannelsContainFrequencyRange(all_channels[3], freq_range_all_but_fss_gwbl)
+    self.assertChannelsWithinFrequencyRange(all_channels[3], freq_range_all_but_fss_gwbl)
     self.assertTrue(
         all(channel['channelType'] == 'GAA' and
             channel['ruleApplied'] == 'FCC_PART_96'

--- a/src/harness/testcases/helper_unit_testcase.py
+++ b/src/harness/testcases/helper_unit_testcase.py
@@ -101,7 +101,7 @@ class assertChannelsOverlapFrequencyRange(sas_testcase.SasTestCase):
                     {'frequencyRange': {'lowFrequency': 3630, 'highFrequency': 3650}},
                     {'frequencyRange': {'lowFrequency': 3650, 'highFrequency': 3700}}]
 
-        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3660}
         self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=True, constrain_high=False)
 
     def test_shouldSucceedWhenConflictChannelWithEqualMinConstrainLow(self):

--- a/src/harness/testcases/helper_unit_testcase.py
+++ b/src/harness/testcases/helper_unit_testcase.py
@@ -78,6 +78,242 @@ class AssertChannelsContainFrequencyRangeTest(sas_testcase.SasTestCase):
       with self.assertRaises(AssertionError):
           self.assertChannelsContainFrequencyRange(channels, frequency_range)
 
+# ===============================================================================
+# this class unit tests assertChannelsOverlapFrequencyRange method with different
+# possible combinations for simplifying the tests we use frequencies in MHz units
+# ===============================================================================
+class assertChannelsOverlapFrequencyRange(sas_testcase.SasTestCase):
+
+    def setUp(self):
+        pass
+
+    # test cases for testing constraint_low=True
+
+    def test_shouldSucceedWhenSingleChannelCoversAllConstrainLow(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3700}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3650}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=True, constrain_high=False)
+
+    def test_shouldSucceedWhenMultipleChannelsCoverAllConstrainLow(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3620}},
+                    {'frequencyRange': {'lowFrequency': 3620, 'highFrequency': 3630}},
+                    {'frequencyRange': {'lowFrequency': 3630, 'highFrequency': 3650}},
+                    {'frequencyRange': {'lowFrequency': 3650, 'highFrequency': 3700}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=True, constrain_high=False)
+
+    def test_shouldSucceedWhenConflictChannelWithEqualMinConstrainLow(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3555, 'highFrequency': 3570}},
+                    {'frequencyRange': {'lowFrequency': 3555, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3560, 'highFrequency': 3575}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=True, constrain_high=False)
+
+    def test_shouldSucceedWhenOneChannelContainsAnotherConstrainLow(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3565}},
+                    {'frequencyRange': {'lowFrequency': 3565, 'highFrequency': 3580}},
+                    {'frequencyRange': {'lowFrequency': 3570, 'highFrequency': 3575}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3580}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=True, constrain_high=False)
+
+    def test_shouldSucceedWhenOneChannelContainsAnotherConstrainLow2(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3565}},
+                    {'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3565, 'highFrequency': 3580}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3580}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=True, constrain_high=False)
+
+    def test_shouldSucceedWhenConflictChannelConstrainLow(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3565, 'highFrequency': 3575}},
+                    {'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3565}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=True, constrain_high=False)
+
+    def test_shouldSucceedWhenMultiSequencialChannelConstrainLow(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3560, 'highFrequency': 3565}},
+                    {'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3565, 'highFrequency': 3580}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3580}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=True, constrain_high=False)
+
+    def test_shouldSuccessWhenChannelHigherThanRangeConstrainLow(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3560, 'highFrequency': 3570}},
+                    {'frequencyRange': {'lowFrequency': 3570, 'highFrequency': 3580}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=True, constrain_high=False)
+
+    def test_shouldFailWhenChannelLowerThanRangeConstrainLow(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3545, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3560, 'highFrequency': 3570}},
+                    {'frequencyRange': {'lowFrequency': 3570, 'highFrequency': 3575}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        with self.assertRaises(AssertionError):
+            self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=True, constrain_high=False)
+
+    def test_shouldFailWhenChannelOutOfLowRangeConstrainLow(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3450, 'highFrequency': 3460}},
+                    {'frequencyRange': {'lowFrequency': 3570, 'highFrequency': 3575}},
+                    {'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3565}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        with self.assertRaises(AssertionError):
+            self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=True, constrain_high=False)
+
+    def test_shouldFailWhenChannelOutOfHighRangeConstrainLow(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3570, 'highFrequency': 3575}},
+                    {'frequencyRange': {'lowFrequency': 3590, 'highFrequency': 3600}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        with self.assertRaises(AssertionError):
+            self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=True, constrain_high=False)
+
+    # Test cases for testing constraint_high=True
+
+    def test_shouldSucceedWhenSingleChannelCoversAllConstrainHigh(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3650}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3650}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=False, constrain_high=True)
+
+    def test_shouldSucceedWhenMultipleChannelsCoverAllConstrainHigh(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3620}},
+                    {'frequencyRange': {'lowFrequency': 3620, 'highFrequency': 3630}},
+                    {'frequencyRange': {'lowFrequency': 3630, 'highFrequency': 3650}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3650}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, cconstrain_low=False, constrain_high=True)
+
+    def test_shouldSucceedWhenConflictChannelWithEqualMinConstrainHigh(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3555, 'highFrequency': 3570}},
+                    {'frequencyRange': {'lowFrequency': 3555, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3560, 'highFrequency': 3575}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, cconstrain_low=False, constrain_high=True)
+
+    def test_shouldSucceedWhenOneChannelContainsAnotherConstrainHigh(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3565}},
+                    {'frequencyRange': {'lowFrequency': 3565, 'highFrequency': 3580}},
+                    {'frequencyRange': {'lowFrequency': 3570, 'highFrequency': 3575}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3580}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=False, constrain_high=True)
+
+    def test_shouldSucceedWhenOneChannelContainsAnotherConstrainHigh2(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3565}},
+                    {'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3565, 'highFrequency': 3580}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3580}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=False, constrain_high=True)
+
+    def test_shouldSucceedWhenConflictChannelConstrainHigh(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3565, 'highFrequency': 3575}},
+                    {'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3565}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=False, constrain_high=True)
+
+    def test_shouldSucceedWhenMultiSequencialChannelConstrainHigh(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3560, 'highFrequency': 3565}},
+                    {'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3565, 'highFrequency': 3580}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3580}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=False, constrain_high=True)
+
+    def test_shouldSuccessWhenChannelLowerThanRangeConstrainHigh(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3570}},
+                    {'frequencyRange': {'lowFrequency': 3570, 'highFrequency': 3580}}]
+
+        frequency_range = {'lowFrequency': 3560, 'highFrequency': 3580}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=False, constrain_high=True)
+
+    def test_shouldFailWhenChannelHigherThanRangeConstrainHigh(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3560, 'highFrequency': 3570}},
+                    {'frequencyRange': {'lowFrequency': 3570, 'highFrequency': 3580}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        with self.assertRaises(AssertionError):
+            self.assertChannelsOverlapFrequencyRange(channels, frequency_range, cconstrain_low=False, constrain_high=True)
+
+    def test_shouldFailWhenChannelOutOfLowRangeConstrainHigh(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3450, 'highFrequency': 3460}},
+                    {'frequencyRange': {'lowFrequency': 3570, 'highFrequency': 3575}},
+                    {'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3565}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        with self.assertRaises(AssertionError):
+            self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=False, constrain_high=True)
+
+    def test_shouldFailWhenChannelOutOfHighRangeConstrainHigh(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3550, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3570, 'highFrequency': 3575}},
+                    {'frequencyRange': {'lowFrequency': 3590, 'highFrequency': 3600}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        with self.assertRaises(AssertionError):
+            self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=False, constrain_high=True)
+
+    # Test cases for testing constraint_high=False and constraint_high=False
+
+    def test_shouldSucceedWhenSingleChannelCoversAllConstrainNeither(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3540, 'highFrequency': 3700}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3650}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=False, constrain_high=False)
+
+    def test_shouldSucceedWhenMultipleChannelsCoverAllConstrainNeither(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3540, 'highFrequency': 3620}},
+                    {'frequencyRange': {'lowFrequency': 3620, 'highFrequency': 3630}},
+                    {'frequencyRange': {'lowFrequency': 3630, 'highFrequency': 3700}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3650}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, cconstrain_low=False, constrain_high=False)
+
+    def test_shouldSucceedWhenConflictChannelWithEqualMinConstrainNeither(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3540, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3555, 'highFrequency': 3570}},
+                    {'frequencyRange': {'lowFrequency': 3555, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3560, 'highFrequency': 3595}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, cconstrain_low=False, constrain_high=False)
+
+    # Test cases for testing constraint_high=True and constraint_high=True
+
+    def test_shouldFailWhenChannelOutOfRangeConstrainHigh(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3540, 'highFrequency': 3560}},
+                    {'frequencyRange': {'lowFrequency': 3560, 'highFrequency': 3570}},
+                    {'frequencyRange': {'lowFrequency': 3570, 'highFrequency': 3580}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        with self.assertRaises(AssertionError):
+            self.assertChannelsOverlapFrequencyRange(channels, frequency_range, cconstrain_low=True, constrain_high=True)
+
+    def test_shouldFailWhenChannelOutOfRangeConstrainHigh2(self):
+        channels = [{'frequencyRange': {'lowFrequency': 3540, 'highFrequency': 3580}}]
+
+        frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
+        with self.assertRaises(AssertionError):
+            self.assertChannelsOverlapFrequencyRange(channels, frequency_range, cconstrain_low=True, constrain_high=True)
+
 # Test the Compare Dict function in util which is used in FAD.1 test to compare PPA record and Esc records in dump file with injected object
 class AssertPpaComparison(sas_testcase.SasTestCase):
     

--- a/src/harness/testcases/helper_unit_testcase.py
+++ b/src/harness/testcases/helper_unit_testcase.py
@@ -271,7 +271,7 @@ class assertChannelsOverlapFrequencyRange(sas_testcase.SasTestCase):
         with self.assertRaises(AssertionError):
             self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=False, constrain_high=True)
 
-    # Test cases for testing constraint_high=False and constraint_high=False
+    # Test cases for testing constraint_low=False and constraint_high=False
 
     def test_shouldSucceedWhenSingleChannelCoversAllConstrainNeither(self):
         channels = [{'frequencyRange': {'lowFrequency': 3540, 'highFrequency': 3700}}]
@@ -296,7 +296,7 @@ class assertChannelsOverlapFrequencyRange(sas_testcase.SasTestCase):
         frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
         self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=False, constrain_high=False)
 
-    # Test cases for testing constraint_high=True and constraint_high=True
+    # Test cases for testing constraint_low=True and constraint_high=True
 
     def test_shouldFailWhenChannelOutOfRangeConstrainHigh(self):
         channels = [{'frequencyRange': {'lowFrequency': 3540, 'highFrequency': 3560}},

--- a/src/harness/testcases/helper_unit_testcase.py
+++ b/src/harness/testcases/helper_unit_testcase.py
@@ -285,7 +285,7 @@ class assertChannelsOverlapFrequencyRange(sas_testcase.SasTestCase):
                     {'frequencyRange': {'lowFrequency': 3630, 'highFrequency': 3700}}]
 
         frequency_range = {'lowFrequency': 3550, 'highFrequency': 3650}
-        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, cconstrain_low=False, constrain_high=False)
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=False, constrain_high=False)
 
     def test_shouldSucceedWhenConflictChannelWithEqualMinConstrainNeither(self):
         channels = [{'frequencyRange': {'lowFrequency': 3540, 'highFrequency': 3560}},
@@ -294,7 +294,7 @@ class assertChannelsOverlapFrequencyRange(sas_testcase.SasTestCase):
                     {'frequencyRange': {'lowFrequency': 3560, 'highFrequency': 3595}}]
 
         frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
-        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, cconstrain_low=False, constrain_high=False)
+        self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=False, constrain_high=False)
 
     # Test cases for testing constraint_high=True and constraint_high=True
 
@@ -305,14 +305,14 @@ class assertChannelsOverlapFrequencyRange(sas_testcase.SasTestCase):
 
         frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
         with self.assertRaises(AssertionError):
-            self.assertChannelsOverlapFrequencyRange(channels, frequency_range, cconstrain_low=True, constrain_high=True)
+            self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=True, constrain_high=True)
 
     def test_shouldFailWhenChannelOutOfRangeConstrainHigh2(self):
         channels = [{'frequencyRange': {'lowFrequency': 3540, 'highFrequency': 3580}}]
 
         frequency_range = {'lowFrequency': 3550, 'highFrequency': 3575}
         with self.assertRaises(AssertionError):
-            self.assertChannelsOverlapFrequencyRange(channels, frequency_range, cconstrain_low=True, constrain_high=True)
+            self.assertChannelsOverlapFrequencyRange(channels, frequency_range, constrain_low=True, constrain_high=True)
 
 # Test the Compare Dict function in util which is used in FAD.1 test to compare PPA record and Esc records in dump file with injected object
 class AssertPpaComparison(sas_testcase.SasTestCase):


### PR DESCRIPTION
This is fox fixing issue #639. Basically 
1. for C2, since CBSD C2 is out of every single protected entities and thus the full frequency range from 3550-3700 shall be available to be responded in spectrum inquiry response.
2. for C4, CBSD C4 is only in range of the FSS site with a GWBL, so we only need to exclude the GWBL-FSS frequency range and thus frequency range 3550-3650 shall be available to be responded in spectrum inquiry response.

The original codes will fail the tests when SAS respond single frequency range of 3550-3700 and 3550-3650 respectively.

Please review.