### PR TITLE
Clean code by introducing new functions in util.py

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,10 @@ support for advanced functools such as OrderedDict and lru_cache memoization.
 This Python library can be installed with <code>pip</code>. It provides
 information on running processes and system (RAM,..).
 
+* portpicker (https://pypi.org/project/portpicker)
+
+This Python library can be installed with <code>pip</code>. It allows to
+find unused network ports on a host.
 
 For all these Python packages, a good way to test their installation is to
 run the Python interpreter and then issue an <code>import xyz</code> command,

--- a/src/harness/README.md
+++ b/src/harness/README.md
@@ -14,6 +14,7 @@ This folder contains code and testcases for SAS certification test as defined in
 *   mock (https://pypi.python.org/pypi/mock)
 *   validators (https://pypi.python.org/pypi/validators)
 *   pytz (https://pypi.org/project/pytz)
+*   portpicker (https://pypi.org/project/portpicker)
 
 ## Code location
 

--- a/src/harness/sas_test_harness.py
+++ b/src/harness/sas_test_harness.py
@@ -81,7 +81,7 @@ class SasTestHarnessServer(threading.Thread):
     self.base_url = host_name + ':' + str(port)
     #BaseURL format should be https: // < hostname >: < port > / versionX.Y
     self.http_server_url = 'https://' + host_name + ':' + str(port) + '/' + self.sas_version
-    self.dump_path = self.__generateTempDirectory()
+    self.dump_path = self.generateTempDirectory()
     self.cert_file = cert_file if cert_file is not None else DEFAULT_CERT_FILE
     self.key_file = key_file if key_file is not None else DEFAULT_KEY_FILE
     self.ca_cert_file = ca_cert_file if ca_cert_file is not None else DEFAULT_CA_CERT
@@ -105,7 +105,7 @@ class SasTestHarnessServer(threading.Thread):
   def __del__(self):
     self.cleanDumpFiles()
 
-  def __generateTempDirectory(self):
+  def generateTempDirectory(self):
     """ This method will generate a random directory using the current timestamp.
 
     The relative path of the directory is

--- a/src/harness/security_testcase.py
+++ b/src/harness/security_testcase.py
@@ -69,13 +69,6 @@ class SecurityTestCase(sas_testcase.SasTestCase):
     """Resets the SAS UUT to its initial state."""
     self._sas_admin.Reset()
 
-  def getCertFilename(self, cert_name):
-    """Returns the absolute path of the file corresponding to the given |cert_name|.
-    """
-    harness_dir = os.path.dirname(
-                  os.path.abspath(inspect.getfile(inspect.currentframe())))
-    return os.path.join(harness_dir, 'certs', cert_name)
-
   def assertTlsHandshakeSucceed(self, base_url, ciphers, client_cert, client_key):
     """Checks that the TLS handshake succeed with the given parameters.
 

--- a/src/harness/testcases/WINNF_FT_S_EPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_EPR_testcase.py
@@ -19,7 +19,8 @@ import sas_testcase
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords, \
     generatePpaRecords
 from util import winnforum_testcase, configurable_testcase, writeConfig, \
-  loadConfig, makePpaAndPalRecordsConsistent
+  loadConfig, makePpaAndPalRecordsConsistent, getFqdnLocalhost, getUnusedPort, \
+  getCertFilename
 from testcases.WINNF_FT_S_MCP_testcase import McpXprCommonTestcase
 
 
@@ -144,7 +145,7 @@ class EscProtectionTestcase(McpXprCommonTestcase):
         'cbsdRecords': [{
             'registrationRequest': device_4,
             'grantRequest': grant_request_4,
-            'conditionalRegistrationData': conditionals_device_4,  
+            'conditionalRegistrationData': conditionals_device_4,
             'clientCert': sas.GetDefaultDomainProxySSLCertPath(),
             'clientKey': sas.GetDefaultDomainProxySSLKeyPath()
         }],
@@ -159,12 +160,12 @@ class EscProtectionTestcase(McpXprCommonTestcase):
         'iterationData': [iteration_config],
         'sasTestHarnessConfigs': [],
         'domainProxyConfigs': [{
-            'cert': os.path.join('certs', 'domain_proxy.cert'),
-            'key': os.path.join('certs', 'domain_proxy.key')
-         }, {
-            'cert': os.path.join('certs', 'domain_proxy_1.cert'),
-            'key': os.path.join('certs', 'domain_proxy_1.key')
-         }]
+            'cert': getCertFilename('domain_proxy.cert'),
+            'key': getCertFilename('domain_proxy.key')
+        }, {
+            'cert': getCertFilename('domain_proxy_1.cert'),
+            'key': getCertFilename('domain_proxy_1.key')
+        }]
     }
     writeConfig(filename, config)
 
@@ -274,7 +275,7 @@ class EscProtectionTestcase(McpXprCommonTestcase):
         'registrationRequests': [device_1, device_2],
         'grantRequests': [grant_request_1, grant_request_2],
         'conditionalRegistrationData': [conditionals_device_2]
-            
+
     }
     cbsd_records_domain_proxy_1 = {
         'registrationRequests': [device_3],
@@ -327,20 +328,20 @@ class EscProtectionTestcase(McpXprCommonTestcase):
     # SAS Test Harnesses configuration
     sas_test_harness_0_config = {
         'sasTestHarnessName': 'SAS-TH-1',
-        'hostName': 'localhost',
-        'port': 9001,
-        'serverCert': os.path.join('certs', 'sas.cert'),
-        'serverKey': os.path.join('certs', 'sas.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('sas.cert'),
+        'serverKey': getCertFilename('sas.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
-        'hostName': 'localhost',
-        'port': 9002,
-        'serverCert': os.path.join('certs', 'sas_1.cert'),
-        'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('sas_1.cert'),
+        'serverKey': getCertFilename('sas_1.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_sas_test_harness_1
     }
 
@@ -364,15 +365,16 @@ class EscProtectionTestcase(McpXprCommonTestcase):
     # Create the actual config.
     config = {
         'iterationData': [iteration_config],
-        'sasTestHarnessConfigs': [sas_test_harness_0_config,
-                                  sas_test_harness_1_config],
+        'sasTestHarnessConfigs': [
+            sas_test_harness_0_config, sas_test_harness_1_config
+        ],
         'domainProxyConfigs': [{
-             'cert': os.path.join('certs', 'domain_proxy.cert'),
-             'key': os.path.join('certs', 'domain_proxy.key')
+            'cert': getCertFilename('domain_proxy.cert'),
+            'key': getCertFilename('domain_proxy.key')
         }, {
-            'cert': os.path.join('certs', 'domain_proxy_1.cert'),
-            'key': os.path.join('certs', 'domain_proxy_1.key')}
-        ]
+            'cert': getCertFilename('domain_proxy_1.cert'),
+            'key': getCertFilename('domain_proxy_1.key')
+        }]
     }
     writeConfig(filename, config)
 

--- a/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
@@ -24,9 +24,10 @@ from reference_models.geo import vincenty, utils
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords, \
     generateCbsdReferenceId, generatePpaRecords
 
-from util import configurable_testcase, writeConfig, loadConfig \
-  , getCertificateFingerprint, getRandomLatLongInPolygon, makePpaAndPalRecordsConsistent \
-  , compareDictWithUnorderedLists, winnforum_testcase, areTwoPpasEqual
+from util import configurable_testcase, writeConfig, loadConfig, \
+  getCertificateFingerprint, getRandomLatLongInPolygon, makePpaAndPalRecordsConsistent, \
+  compareDictWithUnorderedLists, winnforum_testcase, areTwoPpasEqual, \
+  getFqdnLocalhost, getUnusedPort, getCertFilename
 import logging
 
 class FullActivityDumpTestcase(sas_testcase.SasTestCase):
@@ -247,19 +248,19 @@ class FullActivityDumpTestcase(sas_testcase.SasTestCase):
       # SAS test harness configuration
       sas_test_harness_0_config = {
           'sasTestHarnessName': 'SAS-TH-2',
-          'hostName': 'localhost',
-          'port': 9002,
-          'serverCert': os.path.join('certs', 'sas.cert'),
-          'serverKey': os.path.join('certs', 'sas.key'),
+          'hostName': getFqdnLocalhost(),
+          'port': getUnusedPort(),
+          'serverCert': getCertFilename('sas.cert'),
+          'serverKey': getCertFilename('sas.key'),
           'caCert': "certs/ca.cert"
       }
       sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
-        'hostName': 'localhost',
-        'port': 9003,
-        'serverCert': os.path.join('certs', 'sas_1.cert'),
-        'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('sas_1.cert'),
+        'serverKey': getCertFilename('sas_1.key'),
+        'caCert': getCertFilename('ca.cert')
       }
       config = {
         'registrationRequests': devices,
@@ -621,8 +622,8 @@ class FullActivityDumpTestcase(sas_testcase.SasTestCase):
     # SAS test harness configuration
     sas_harness_config = {
         'sasTestHarnessName': 'SAS-TH-1',
-        'hostName': 'localhost',
-        'port': 9001,
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
         'serverCert': "certs/server.cert",
         'serverKey': "certs/server.key",
         'caCert': "certs/ca.cert"

--- a/src/harness/testcases/WINNF_FT_S_FDB_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FDB_testcase.py
@@ -22,7 +22,8 @@ from database import DatabaseServer
 from datetime import date, datetime, time, timedelta
 from pytz import timezone
 from time import sleep, strftime, gmtime
-from util import configurable_testcase, writeConfig, loadConfig, addCbsdIdsToRequests
+from util import configurable_testcase, writeConfig, loadConfig, \
+  addCbsdIdsToRequests, getFqdnLocalhost, getUnusedPort,getCertFilename
 
 # Time zone in which CPAS is scheduled
 CPAS_TIME_ZONE = 'US/Pacific'
@@ -56,8 +57,8 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
 
     # Exclusion zone database test harness configuration
     exclusion_zone_database_config = {
-        'hostName': 'localhost',
-        'port': 8000,
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
         'fileUrl': '/db_sync',
         'filePath': os.path.join('testcases', 'testdata', 'fdb_1', 'FDB_1_ground_based_exclusion_zones.kml'),
         'modifiedFilePath': os.path.join('testcases', 'testdata', 'fdb_1', 'modified_FDB_1_ground_based_exclusion_zones.kml')
@@ -289,8 +290,8 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
 
     # DPA database test harness configuration
     dpa_database_config = {
-        'hostName': 'localhost',
-        'port': 8000,
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
         'fileUrl': '/db_sync',
         'filePath': os.path.join('testcases', 'testdata', 'fdb_2', 'FDB_2_Portal_DPAs.kml'),
         'modifiedFilePath': os.path.join('testcases', 'testdata', 'fdb_2', 'modified_FDB_2_Portal_DPAs.kml')
@@ -604,8 +605,8 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
     }
 
     fss_database_config = {
-        'hostName': 'localhost',
-        'port': 8003,
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
         'fileUrl': '/rest/fss/v1/allsitedata',
         'filePath': os.path.join('testcases', 'testdata', 'fdb_3', 'FDB_3_default_allsitedata')
     }
@@ -691,8 +692,8 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
 
     # FSS database test harness configuration
     fss_database_config = {
-        'hostName': 'localhost',
-        'port': 8000,
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
         'fileUrl': '/db_sync',
         'filePath': os.path.join('testcases', 'testdata', 'fdb_4', 'FDB_4_default_allsitedata.json'),
         'modifiedFilePath': os.path.join('testcases', 'testdata', 'fdb_4', 'modified_FDB_4_default_allsitedata.json')
@@ -917,8 +918,8 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
     # FSS database test harness configuration
     # The database File FDB_5_default_allsitedata.json has FSS sites information.
     fss_database_config = {
-        'hostName': 'localhost',
-        'port': 8000,
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
         'fileUrl': '/db_sync',
         'filePath': os.path.join('testcases', 'testdata', 'fdb_5', 'FDB_5_default_allsitedata.json')
     }
@@ -928,8 +929,8 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
     # WAKEENEY,KS with Unique System Identifier as 959499
     # NEW YORK, NY with Unique System Identifier as 954597
     gwbl_database_config = {
-        'hostName': 'localhost',
-        'port': 8001,
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
         'fileUrl': '/db_sync',
         'filePath': os.path.join('testcases', 'testdata', 'fdb_5', 'l_micro.zip')
     }
@@ -1082,8 +1083,8 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
     # FSS database test harness configuration.
     # The database File FDB_6_default_allsitedata.json has FSS sites information.
     fss_database_config = {
-        'hostName': 'localhost',
-        'port': 8000,
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
         'fileUrl': '/db_sync',
         'filePath': os.path.join('testcases', 'testdata', 'fdb_6', 'FDB_6_default_allsitedata.json')
     }
@@ -1096,8 +1097,8 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
     # The GWBL database file modified_l_micro.zip has updated locations for the above
     # mentioned GWBLs (GWBLs are moved further than 150 km from the FSS sites).
     gwbl_database_config = {
-        'hostName': 'localhost',
-        'port': 8001,
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
         'fileUrl': '/db_sync',
         'filePath': os.path.join('testcases', 'testdata', 'fdb_6', 'l_micro.zip'),
         'modifiedFilePath': os.path.join('testcases', 'testdata', 'fdb_6', 'modified_l_micro.zip')
@@ -1303,8 +1304,8 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
 
     # FSS database test harness configuration
     fss_database_config = {
-        'hostName': 'localhost',
-        'port': 8000,
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
         'fileUrl': '/db_sync',
         'filePath': os.path.join('testcases', 'testdata',  'fdb_8', 'FDB_8_default_allsitedata.json')
     }

--- a/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
@@ -19,7 +19,7 @@ import sas
 import sas_testcase
 from sas_test_harness import generateCbsdRecords
 from util import winnforum_testcase, writeConfig, loadConfig, configurable_testcase,\
- addCbsdIdsToRequests
+ addCbsdIdsToRequests, getFqdnLocalhost, getUnusedPort, getCertFilename
 from testcases.WINNF_FT_S_MCP_testcase import McpXprCommonTestcase
 
 
@@ -200,20 +200,20 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     # SAS Test Harnesses configuration
     sas_test_harness_0_config = {
         'sasTestHarnessName': 'SAS-TH-1',
-        'hostName': 'localhost',
-        'port': 9001,
-        'serverCert': os.path.join('certs', 'sas.cert'),
-        'serverKey': os.path.join('certs', 'sas.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('sas.cert'),
+        'serverKey': getCertFilename('sas.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_iteration_0_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
-        'hostName': 'localhost',
-        'port': 9002,
-        'serverCert': os.path.join('certs', 'sas_1.cert'),
-        'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort() ,
+        'serverCert': getCertFilename('sas_1.cert'),
+        'serverKey': getCertFilename('sas_1.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_iteration_0_sas_test_harness_1
     }
 
@@ -235,10 +235,10 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     config = {
         'iterationData': [iteration0_config],
         'sasTestHarnessConfigs': [sas_test_harness_0_config, sas_test_harness_1_config],
-        'domainProxyConfigs': [{'cert': os.path.join('certs', 'domain_proxy.cert'),
-                                'key': os.path.join('certs', 'domain_proxy.key')},
-                               {'cert': os.path.join('certs', 'domain_proxy_1.cert'),
-                                'key': os.path.join('certs', 'domain_proxy_1.key')}]
+        'domainProxyConfigs': [{'cert': getCertFilename('domain_proxy.cert'),
+                                'key': getCertFilename('domain_proxy.key')},
+                               {'cert': getCertFilename('domain_proxy_1.cert'),
+                                'key': getCertFilename('domain_proxy_1.key')}]
     }
     writeConfig(filename, config)
 
@@ -454,20 +454,20 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     # SAS Test Harnesses configuration
     sas_test_harness_0_config = {
         'sasTestHarnessName': 'SAS-TH-1',
-        'hostName': 'localhost',
-        'port': 9001,
-        'serverCert': os.path.join('certs', 'sas.cert'),
-        'serverKey': os.path.join('certs', 'sas.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('sas.cert'),
+        'serverKey': getCertFilename('sas.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
-        'hostName': 'localhost',
-        'port': 9002,
-        'serverCert': os.path.join('certs', 'sas_1.cert'),
-        'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('sas_1.cert'),
+        'serverKey': getCertFilename('sas_1.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_sas_test_harness_1
     }
 
@@ -492,10 +492,10 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'sasTestHarnessConfigs': [sas_test_harness_0_config,
                                   sas_test_harness_1_config],
         'domainProxyConfigs': [
-            {'cert': os.path.join('certs', 'domain_proxy.cert'),
-             'key': os.path.join('certs', 'domain_proxy.key')},
-            {'cert': os.path.join('certs', 'domain_proxy_1.cert'),
-             'key': os.path.join('certs', 'domain_proxy_1.key')}
+            {'cert': getCertFilename('domain_proxy.cert'),
+             'key': getCertFilename('domain_proxy.key')},
+            {'cert': getCertFilename('domain_proxy_1.cert'),
+             'key': getCertFilename('domain_proxy_1.key')}
         ]
     }
     writeConfig(filename, config)
@@ -653,20 +653,20 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     # SAS Test Harnesses configuration
     sas_test_harness_0_config = {
         'sasTestHarnessName': 'SAS-TH-1',
-        'hostName': 'localhost',
-        'port': 9001,
-        'serverCert': os.path.join('certs', 'sas.cert'),
-        'serverKey': os.path.join('certs', 'sas.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('sas.cert'),
+        'serverKey': getCertFilename('sas.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_iteration_0_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
-        'hostName': 'localhost',
-        'port': 9002,
-        'serverCert': os.path.join('certs', 'sas_1.cert'),
-        'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('sas_1.cert'),
+        'serverKey': getCertFilename('sas_1.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_iteration_0_sas_test_harness_1
     }
 
@@ -688,10 +688,10 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     config = {
         'iterationData': [iteration0_config],
         'sasTestHarnessConfigs': [sas_test_harness_0_config, sas_test_harness_1_config],
-        'domainProxyConfigs': [{'cert': os.path.join('certs', 'domain_proxy.cert'),
-                                'key': os.path.join('certs', 'domain_proxy.key')},
-                               {'cert': os.path.join('certs', 'domain_proxy_1.cert'),
-                                'key': os.path.join('certs', 'domain_proxy_1.key')}]
+        'domainProxyConfigs': [{'cert': getCertFilename('domain_proxy.cert'),
+                                'key': getCertFilename('domain_proxy.key')},
+                               {'cert': getCertFilename('domain_proxy_1.cert'),
+                                'key': getCertFilename('domain_proxy_1.key')}]
     }
     writeConfig(filename, config)
 
@@ -861,20 +861,20 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     # SAS Test Harnesses configuration
     sas_test_harness_0_config = {
         'sasTestHarnessName': 'SAS-TH-1',
-        'hostName': 'localhost',
-        'port': 9001,
-        'serverCert': os.path.join('certs', 'sas.cert'),
-        'serverKey': os.path.join('certs', 'sas.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('sas.cert'),
+        'serverKey': getCertFilename('sas.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
-        'hostName': 'localhost',
-        'port': 9002,
-        'serverCert': os.path.join('certs', 'sas_1.cert'),
-        'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('sas_1.cert'),
+        'serverKey': getCertFilename('sas_1.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_sas_test_harness_1
     }
 
@@ -885,8 +885,8 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
             {'registrationRequest': device_4,
              'grantRequest': grant_request_4,
              'conditionalRegistrationData': conditionals_device_4,
-             'clientCert': os.path.join('certs', 'client.cert'),
-             'clientKey': os.path.join('certs', 'client.key')}],
+             'clientCert': getCertFilename('client.cert'),
+             'clientKey': getCertFilename('client.key')}],
         'protectedEntities': protected_entities,
         'dpaActivationList': [],
         'dpaDeactivationList': [],
@@ -900,10 +900,10 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
         'sasTestHarnessConfigs': [sas_test_harness_0_config,
                                   sas_test_harness_1_config],
         'domainProxyConfigs': [
-            {'cert': os.path.join('certs', 'domain_proxy.cert'),
-             'key': os.path.join('certs', 'domain_proxy.key')},
-            {'cert': os.path.join('certs', 'domain_proxy_1.cert'),
-             'key': os.path.join('certs', 'domain_proxy_1.key')}
+            {'cert': getCertFilename('domain_proxy.cert'),
+             'key': getCertFilename('domain_proxy.key')},
+            {'cert': getCertFilename('domain_proxy_1.cert'),
+             'key': getCertFilename('domain_proxy_1.key')}
         ]
     }
     writeConfig(filename, config)

--- a/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
@@ -19,7 +19,8 @@ import sas_testcase
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords, \
     generatePpaRecords
 from util import addCbsdIdsToRequests, winnforum_testcase, configurable_testcase, writeConfig, \
-  loadConfig, getRandomLatLongInPolygon, makePpaAndPalRecordsConsistent
+  loadConfig, getRandomLatLongInPolygon, makePpaAndPalRecordsConsistent, \
+  getFqdnLocalhost, getUnusedPort, getCertFilename
 from testcases.WINNF_FT_S_MCP_testcase import McpXprCommonTestcase
 
 
@@ -144,11 +145,11 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
         'iterationData': [iteration_config],
         'sasTestHarnessConfigs': [],
         'domainProxyConfigs': [{
-            'cert': os.path.join('certs', 'domain_proxy.cert'),
-            'key': os.path.join('certs', 'domain_proxy.key')
+            'cert': getCertFilename('domain_proxy.cert'),
+            'key': getCertFilename('domain_proxy.key')
         }, {
-            'cert': os.path.join('certs', 'domain_proxy_1.cert'),
-            'key': os.path.join('certs', 'domain_proxy_1.key')
+            'cert': getCertFilename('domain_proxy_1.cert'),
+            'key': getCertFilename('domain_proxy_1.key')
         }]
     }
     writeConfig(filename, config)
@@ -303,20 +304,20 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
     # SAS Test Harnesses configuration
     sas_test_harness_0_config = {
         'sasTestHarnessName': 'SAS-TH-1',
-        'hostName': 'localhost',
-        'port': 9001,
-        'serverCert': os.path.join('certs', 'sas.cert'),
-        'serverKey': os.path.join('certs', 'sas.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('sas.cert'),
+        'serverKey': getCertFilename('sas.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
-        'hostName': 'localhost',
-        'port': 9002,
-        'serverCert': os.path.join('certs', 'sas_1.cert'),
-        'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('sas_1.cert'),
+        'serverKey': getCertFilename('sas_1.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_sas_test_harness_1
     }
 
@@ -343,11 +344,11 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
         'sasTestHarnessConfigs': [sas_test_harness_0_config,
                                   sas_test_harness_1_config],
         'domainProxyConfigs': [{
-             'cert': os.path.join('certs', 'domain_proxy.cert'),
-             'key': os.path.join('certs', 'domain_proxy.key')
+             'cert': getCertFilename('domain_proxy.cert'),
+             'key': getCertFilename('domain_proxy.key')
         }, {
-             'cert': os.path.join('certs', 'domain_proxy_1.cert'),
-             'key': os.path.join('certs', 'domain_proxy_1.key')}]
+             'cert': getCertFilename('domain_proxy_1.cert'),
+             'key': getCertFilename('domain_proxy_1.key')}]
     }
     writeConfig(filename, config)
 

--- a/src/harness/testcases/WINNF_FT_S_GRA_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_GRA_testcase.py
@@ -51,7 +51,8 @@ import sas_testcase
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords
 from util import winnforum_testcase, getRandomLatLongInPolygon, \
   makePpaAndPalRecordsConsistent, configurable_testcase, writeConfig, \
-  loadConfig, getCertificateFingerprint, addCbsdIdsToRequests, getRandomLatLongInPolygon
+  loadConfig, getCertificateFingerprint, addCbsdIdsToRequests, \
+  getRandomLatLongInPolygon, getFqdnLocalhost, getUnusedPort, getCertFilename
 
 class GrantTestcase(sas_testcase.SasTestCase):
 
@@ -234,8 +235,8 @@ class GrantTestcase(sas_testcase.SasTestCase):
      SAS rejects the request by sending responseCode 103
     """
     # Load device_a [cert|key]
-    device_a_cert = os.path.join('certs', 'device_a.cert')
-    device_a_key = os.path.join('certs', 'device_a.key')
+    device_a_cert = getCertFilename('device_a.cert')
+    device_a_key = getCertFilename('device_a.key')
 
     # Register the first device with certificates
     device_a = json.load(
@@ -251,8 +252,8 @@ class GrantTestcase(sas_testcase.SasTestCase):
     del request, response
 
     # Load device_c [cert|key]
-    device_c_cert = os.path.join('certs', 'device_c.cert')
-    device_c_key = os.path.join('certs', 'device_c.key')
+    device_c_cert = getCertFilename('device_c.cert')
+    device_c_key = getCertFilename('device_c.key')
 
     # Register the second device with certificates
     device_c = json.load(
@@ -317,11 +318,11 @@ class GrantTestcase(sas_testcase.SasTestCase):
 
     sas_harness_config = {
         'sasTestHarnessName': 'SAS-Test-Harness-1',
-        'hostName': 'localhost',
-        'port': 9001,
-        'serverCert': os.path.join('certs', 'server.cert'),
-        'serverKey': os.path.join('certs', 'server.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('server.cert'),
+        'serverKey': getCertFilename('server.key'),
+        'caCert': getCertFilename('ca.cert')
     }
     sas_harness_dump_records = {
         'cbsdRecords': generateCbsdRecords([device_c1], [[grant_g1]])
@@ -435,11 +436,11 @@ class GrantTestcase(sas_testcase.SasTestCase):
         'highFrequency'] = 3655000000
     sas_harness_config = {
         'sasTestHarnessName': 'SAS-TestHarness-1',
-        'hostName': 'localhost',
-        'port': 9001,
-        'serverCert': os.path.join('certs', 'server.cert'),
-        'serverKey': os.path.join('certs', 'server.key'),
-        'caCert': os.path.join('certs', 'ca.cert')
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('server.cert'),
+        'serverKey': getCertFilename('server.key'),
+        'caCert': getCertFilename('ca.cert')
     }
     sas_harness_dump_records = {
         'cbsdRecords': generateCbsdRecords([device_c1],

--- a/src/harness/testcases/WINNF_FT_S_GRA_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_GRA_testcase.py
@@ -320,8 +320,8 @@ class GrantTestcase(sas_testcase.SasTestCase):
         'sasTestHarnessName': 'SAS-Test-Harness-1',
         'hostName': getFqdnLocalhost(),
         'port': getUnusedPort(),
-        'serverCert': getCertFilename('server.cert'),
-        'serverKey': getCertFilename('server.key'),
+        'serverCert': getCertFilename('sas.cert'),
+        'serverKey': getCertFilename('sas.key'),
         'caCert': getCertFilename('ca.cert')
     }
     sas_harness_dump_records = {
@@ -438,8 +438,8 @@ class GrantTestcase(sas_testcase.SasTestCase):
         'sasTestHarnessName': 'SAS-TestHarness-1',
         'hostName': getFqdnLocalhost(),
         'port': getUnusedPort(),
-        'serverCert': getCertFilename('server.cert'),
-        'serverKey': getCertFilename('server.key'),
+        'serverCert': getCertFilename('sas.cert'),
+        'serverKey': getCertFilename('sas.key'),
         'caCert': getCertFilename('ca.cert')
     }
     sas_harness_dump_records = {

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -102,8 +102,8 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         'sasTestHarnessName': 'SAS-Test-Harness-1',
         'hostName': getFqdnLocalhost(),
         'port': getUnusedPort(),
-        'serverCert': getCertFilename('server.cert'),
-        'serverKey': getCertFilename('server.key'),
+        'serverCert': getCertFilename('sas.cert'),
+        'serverKey': getCertFilename('sas.key'),
         'caCert': getCertFilename('ca.cert'),
         'fullActivityDumpRecords': [
             generateCbsdRecords([device_a], [[grant_a]])
@@ -281,8 +281,8 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         'sasTestHarnessName': 'SAS-Test-Harness-1',
         'hostName': getFqdnLocalhost(),
         'port': getUnusedPort(),
-        'serverCert': getCertFilename('server.cert'),
-        'serverKey': getCertFilename('server.key'),
+        'serverCert': getCertFilename('sas.cert'),
+        'serverKey': getCertFilename('sas.key'),
         'caCert': getCertFilename('ca.cert'),
         'fullActivityDumpRecords': [
             generateCbsdRecords([device_a], [[grant_a]])
@@ -742,8 +742,8 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         'sasTestHarnessName': 'SAS-Test-Harness-1',
         'hostName': getFqdnLocalhost(),
         'port': getUnusedPort(),
-        'serverCert': getCertFilename('server.cert'),
-        'serverKey': getCertFilename('server.key'),
+        'serverCert': getCertFilename('sas.cert'),
+        'serverKey': getCertFilename('sas.key'),
         'caCert': getCertFilename('ca.cert'),
         'fullActivityDumpRecords': [
             generateCbsdRecords([device_a], [[grant_a]])

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -19,7 +19,9 @@ import sas
 import sas_testcase
 import time
 
-from util import buildDpaActivationMessage, configurable_testcase, writeConfig, loadConfig, getCertificateFingerprint
+from util import buildDpaActivationMessage, configurable_testcase, writeConfig, \
+  loadConfig, getCertificateFingerprint, getFqdnLocalhost, getUnusedPort, \
+  getCertFilename
 from test_harness_objects import DomainProxy
 from full_activity_dump_helper import getFullActivityDumpSasTestHarness, getFullActivityDumpSasUut
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords
@@ -97,18 +99,12 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         open(os.path.join('testcases', 'testdata', 'grant_0.json')))
 
     sas_test_harness_config = {
-        'sasTestHarnessName':
-            'SAS-Test-Harness-1',
-        'hostName':
-            'localhost',
-        'port':
-            9001,
-        'serverCert':
-            os.path.join('certs', 'server.cert'),
-        'serverKey':
-            os.path.join('certs', 'server.key'),
-        'caCert':
-            os.path.join('certs', 'ca.cert'),
+        'sasTestHarnessName': 'SAS-Test-Harness-1',
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('server.cert'),
+        'serverKey': getCertFilename('server.key'),
+        'caCert': getCertFilename('ca.cert'),
         'fullActivityDumpRecords': [
             generateCbsdRecords([device_a], [[grant_a]])
         ]
@@ -282,18 +278,12 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         open(os.path.join('testcases', 'testdata', 'grant_0.json')))
 
     sas_test_harness_config = {
-        'sasTestHarnessName':
-            'SAS-Test-Harness-1',
-        'hostName':
-            'localhost',
-        'port':
-            9002,
-        'serverCert':
-            os.path.join('certs', 'server.cert'),
-        'serverKey':
-            os.path.join('certs', 'server.key'),
-        'caCert':
-            os.path.join('certs', 'ca.cert'),
+        'sasTestHarnessName': 'SAS-Test-Harness-1',
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('server.cert'),
+        'serverKey': getCertFilename('server.key'),
+        'caCert': getCertFilename('ca.cert'),
         'fullActivityDumpRecords': [
             generateCbsdRecords([device_a], [[grant_a]])
         ]
@@ -340,8 +330,8 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         'registrationRequests': [device_b],
         'grantRequests': [grant_b],
         'conditionalRegistrationData': [conditionals_b],
-        'cert': os.path.join('certs', 'domain_proxy.cert'),
-        'key': os.path.join('certs', 'domain_proxy.key')
+        'cert': getCertFilename('domain_proxy.cert'),
+        'key': getCertFilename('domain_proxy.key')
     }
 
     config = {
@@ -645,8 +635,8 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         'registrationRequests': [device_a],
         'grantRequests': [grant_a],
         'conditionalRegistrationData': [conditionals_a],
-        'sslCert': os.path.join('certs', 'domain_proxy.cert'),
-        'sslKey': os.path.join('certs', 'domain_proxy.key')
+        'sslCert': getCertFilename('domain_proxy.cert'),
+        'sslKey': getCertFilename('domain_proxy.key')
     }
 
     config = {
@@ -749,18 +739,12 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         open(os.path.join('testcases', 'testdata', 'grant_0.json')))
 
     sas_test_harness_config = {
-        'sasTestHarnessName':
-            'SAS-Test-Harness-1',
-        'hostName':
-            'localhost',
-        'port':
-            9006,
-        'serverCert':
-            os.path.join('certs', 'server.cert'),
-        'serverKey':
-            os.path.join('certs', 'server.key'),
-        'caCert':
-            os.path.join('certs', 'ca.cert'),
+        'sasTestHarnessName': 'SAS-Test-Harness-1',
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('server.cert'),
+        'serverKey': getCertFilename('server.key'),
+        'caCert': getCertFilename('ca.cert'),
         'fullActivityDumpRecords': [
             generateCbsdRecords([device_a], [[grant_a]])
         ]
@@ -776,8 +760,8 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         'registrationRequests': [device_b],
         'grantRequests': [grant_b],
         'conditionalRegistrationData': [conditionals_b],
-        'cert': os.path.join('certs', 'domain_proxy.cert'),
-        'key': os.path.join('certs', 'domain_proxy.key')
+        'cert': getCertFilename('domain_proxy.cert'),
+        'key': getCertFilename('domain_proxy.key')
     }
 
     config = {

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -966,8 +966,8 @@ class MultiConstraintProtectionTestcase(McpXprCommonTestcase):
         'sasTestHarnessName': 'SAS-TH-1',
         'hostName': getFqdnLocalhost(),
         'port': getUnusedPort(),
-        'serverCert': getCertFilename('server.cert'),
-        'serverKey': getCertFilename('server.key'),
+        'serverCert': getCertFilename('sas.cert'),
+        'serverKey': getCertFilename('sas.key'),
         'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_iteration_0_sas_test_harness_0
     }
@@ -975,8 +975,8 @@ class MultiConstraintProtectionTestcase(McpXprCommonTestcase):
         'sasTestHarnessName': 'SAS-TH-2',
         'hostName': getFqdnLocalhost(),
         'port': getUnusedPort(),
-        'serverCert': getCertFilename('server.cert'),
-        'serverKey': getCertFilename('server.key'),
+        'serverCert': getCertFilename('sas_1.cert'),
+        'serverKey': getCertFilename('sas_1.key'),
         'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_iteration_0_sas_test_harness_1
     }

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -26,7 +26,8 @@ from full_activity_dump import FullActivityDump
 from full_activity_dump_helper import getFullActivityDumpSasTestHarness, getFullActivityDumpSasUut
 import common_strings
 from util import winnforum_testcase, configurable_testcase, getCertificateFingerprint, writeConfig, \
-        loadConfig, makePpaAndPalRecordsConsistent
+        loadConfig, makePpaAndPalRecordsConsistent, getFqdnLocalhost, \
+        getUnusedPort, getCertFilename
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords, \
         generatePpaRecords, generateCbsdReferenceId
 from reference_models.dpa import dpa_mgr
@@ -963,20 +964,20 @@ class MultiConstraintProtectionTestcase(McpXprCommonTestcase):
     # SAS Test Harnesses configuration
     sas_test_harness_0_config = {
         'sasTestHarnessName': 'SAS-TH-1',
-        'hostName': 'localhost',
-        'port': 9001,
-        'serverCert': os.path.join('certs', 'server.cert'),
-        'serverKey': os.path.join('certs', 'server.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('server.cert'),
+        'serverKey': getCertFilename('server.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_iteration_0_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
-        'hostName': 'localhost',
-        'port': 9002,
-        'serverCert': os.path.join('certs', 'server.cert'),
-        'serverKey': os.path.join('certs', 'server.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('server.cert'),
+        'serverKey': getCertFilename('server.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_iteration_0_sas_test_harness_1
     }
 
@@ -1011,10 +1012,10 @@ class MultiConstraintProtectionTestcase(McpXprCommonTestcase):
     config = {
         'iterationData': [iteration0_config, iteration1_config],
         'sasTestHarnessConfigs': [sas_test_harness_0_config, sas_test_harness_1_config],
-        'domainProxyConfigs': [{'cert': os.path.join('certs', 'domain_proxy.cert'),
-                                'key': os.path.join('certs', 'domain_proxy.key')},
-                               {'cert': os.path.join('certs', 'domain_proxy_1.cert'),
-                                'key': os.path.join('certs', 'domain_proxy_1.key')}],
+        'domainProxyConfigs': [{'cert': getCertFilename('domain_proxy.cert'),
+                                'key': getCertFilename('domain_proxy.key')},
+                               {'cert': getCertFilename('domain_proxy_1.cert'),
+                                'key': getCertFilename('domain_proxy_1.key')}],
         'dpas': dpa_generic
     }
     writeConfig(filename, config)

--- a/src/harness/testcases/WINNF_FT_S_PCR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_PCR_testcase.py
@@ -24,7 +24,7 @@ from reference_models.ppa import ppa
 from reference_models.geo import drive, utils
 from util import configurable_testcase, loadConfig, \
      makePalRecordsConsistent, writeConfig, getCertificateFingerprint, \
-     makePpaAndPalRecordsConsistent
+     makePpaAndPalRecordsConsistent, getCertFilename
 SAS_TEST_HARNESS_URL = 'https://test.harness.url.not.used/v1.2'
 
 def getSasUutClaimedPpaBoundaryFilePath(config_filename):
@@ -292,8 +292,8 @@ class PpaCreationTestcase(sas_testcase.SasTestCase):
         'registrationRequests': devices,
         'conditionalRegistrationData': conditionals,
         'palRecords': pal_records,
-        'sasTestHarnessCert': os.path.join('certs', 'sas.cert'),
-        'sasTestHarnessKey': os.path.join('certs', 'sas.key')
+        'sasTestHarnessCert': getCertFilename('sas.cert'),
+        'sasTestHarnessKey': getCertFilename('sas.key')
     }
     writeConfig(filename, config)
 
@@ -464,8 +464,8 @@ class PpaCreationTestcase(sas_testcase.SasTestCase):
         'registrationRequests': devices,
         'conditionalRegistrationData': conditionals,
         'palRecords': pal_records,
-        'sasTestHarnessCert': os.path.join('certs', 'sas.cert'),
-        'sasTestHarnessKey': os.path.join('certs', 'sas.key')
+        'sasTestHarnessCert': getCertFilename('sas.cert'),
+        'sasTestHarnessKey': getCertFilename('sas.key')
     }
     writeConfig(filename, config)
 

--- a/src/harness/testcases/WINNF_FT_S_PPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_PPR_testcase.py
@@ -19,7 +19,8 @@ import sas_testcase
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords, \
     generatePpaRecords
 from util import winnforum_testcase, configurable_testcase, writeConfig, \
-  loadConfig, getRandomLatLongInPolygon, makePpaAndPalRecordsConsistent
+  loadConfig, getRandomLatLongInPolygon, makePpaAndPalRecordsConsistent, \
+  getFqdnLocalhost, getUnusedPort, getCertFilename
 from testcases.WINNF_FT_S_MCP_testcase import McpXprCommonTestcase
 
 class PpaProtectionTestcase(McpXprCommonTestcase):
@@ -157,11 +158,11 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
         'iterationData': [iteration_config],
         'sasTestHarnessConfigs': [],
         'domainProxyConfigs': [{
-            'cert': os.path.join('certs', 'domain_proxy.cert'),
-            'key': os.path.join('certs', 'domain_proxy.key')
+            'cert': getCertFilename('domain_proxy.cert'),
+            'key': getCertFilename('domain_proxy.key')
         }, {
-            'cert': os.path.join('certs', 'domain_proxy_1.cert'),
-            'key': os.path.join('certs', 'domain_proxy_1.key')
+            'cert': getCertFilename('domain_proxy_1.cert'),
+            'key': getCertFilename('domain_proxy_1.key')
         }]
     }
     writeConfig(filename, config)
@@ -330,20 +331,20 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
     # SAS Test Harnesses configuration
     sas_test_harness_0_config = {
         'sasTestHarnessName': 'SAS-TH-1',
-        'hostName': 'localhost',
-        'port': 9001,
-        'serverCert': os.path.join('certs', 'sas.cert'),
-        'serverKey': os.path.join('certs', 'sas.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('sas.cert'),
+        'serverKey': getCertFilename('sas.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_sas_test_harness_0
     }
     sas_test_harness_1_config = {
         'sasTestHarnessName': 'SAS-TH-2',
-        'hostName': 'localhost',
-        'port': 9002,
-        'serverCert': os.path.join('certs', 'sas_1.cert'),
-        'serverKey': os.path.join('certs', 'sas_1.key'),
-        'caCert': os.path.join('certs', 'ca.cert'),
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
+        'serverCert': getCertFilename('sas_1.cert'),
+        'serverKey': getCertFilename('sas_1.key'),
+        'caCert': getCertFilename('ca.cert'),
         'initialFad': dump_records_sas_test_harness_1
     }
 
@@ -370,11 +371,11 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
         'sasTestHarnessConfigs': [sas_test_harness_0_config,
                                   sas_test_harness_1_config],
         'domainProxyConfigs': [{
-             'cert': os.path.join('certs', 'domain_proxy.cert'),
-             'key': os.path.join('certs', 'domain_proxy.key')
+             'cert': getCertFilename('domain_proxy.cert'),
+             'key': getCertFilename('domain_proxy.key')
         }, {
-            'cert': os.path.join('certs', 'domain_proxy_1.cert'),
-            'key': os.path.join('certs', 'domain_proxy_1.key')}
+            'cert': getCertFilename('domain_proxy_1.cert'),
+            'key': getCertFilename('domain_proxy_1.key')}
         ]
     }
     writeConfig(filename, config)

--- a/src/harness/testcases/WINNF_FT_S_SCS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SCS_testcase.py
@@ -19,7 +19,7 @@ import security_testcase
 import time
 from OpenSSL import SSL
 from util import winnforum_testcase, configurable_testcase,\
-  writeConfig, loadConfig
+  writeConfig, loadConfig, getCertFilename
 
 
 class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
@@ -33,8 +33,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     Checks that a CBSD registration with this configuration succeed.
     """
     self.doCbsdTestCipher('AES128-GCM-SHA256',
-                          self.getCertFilename("device_a.cert"),
-                          self.getCertFilename("device_a.key"))
+                          getCertFilename("device_a.cert"),
+                          getCertFilename("device_a.key"))
 
   @winnforum_testcase
   def test_WINNF_FT_S_SCS_2(self):
@@ -44,8 +44,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     Checks that a CBSD registration with this configuration succeed.
     """
     self.doCbsdTestCipher('AES256-GCM-SHA384',
-                          self.getCertFilename("device_a.cert"),
-                          self.getCertFilename("device_a.key"))
+                          getCertFilename("device_a.cert"),
+                          getCertFilename("device_a.key"))
 
   @winnforum_testcase
   def test_WINNF_FT_S_SCS_3(self):
@@ -56,8 +56,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     Note that the test require a SAS UUT
     """
     self.doCbsdTestCipher('ECDHE-ECDSA-AES128-GCM-SHA256',
-                          self.getCertFilename("device_a.cert"),
-                          self.getCertFilename("device_a.key"))
+                          getCertFilename("device_a.cert"),
+                          getCertFilename("device_a.key"))
 
   @winnforum_testcase
   def test_WINNF_FT_S_SCS_4(self):
@@ -67,8 +67,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     Checks that a CBSD registration with this configuration succeed.
     """
     self.doCbsdTestCipher('ECDHE-ECDSA-AES256-GCM-SHA384',
-                          self.getCertFilename("device_a.cert"),
-                          self.getCertFilename("device_a.key"))
+                          getCertFilename("device_a.cert"),
+                          getCertFilename("device_a.key"))
 
   @winnforum_testcase
   def test_WINNF_FT_S_SCS_5(self):
@@ -78,16 +78,16 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     Checks that a CBSD registration with this configuration succeed.
     """
     self.doCbsdTestCipher('ECDHE-RSA-AES128-GCM-SHA256',
-                          self.getCertFilename("device_a.cert"),
-                          self.getCertFilename("device_a.key"))
+                          getCertFilename("device_a.cert"),
+                          getCertFilename("device_a.key"))
 
   def generate_SCS_6_default_config(self, filename):
     """Generates the WinnForum configuration for SCS_6"""
     # Create the actual config for client cert/key path
 
     config = {
-      'clientCert': self.getCertFilename("unrecognized_device.cert"),
-      'clientKey': self.getCertFilename("unrecognized_device.key")
+      'clientCert': getCertFilename("unrecognized_device.cert"),
+      'clientKey': getCertFilename("unrecognized_device.key")
     }
     writeConfig(filename, config)
 
@@ -106,8 +106,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for client cert/key path
 
     config = {
-      'clientCert': self.getCertFilename("device_corrupted.cert"),
-      'clientKey': self.getCertFilename("device_corrupted.key")
+      'clientCert': getCertFilename("device_corrupted.cert"),
+      'clientKey': getCertFilename("device_corrupted.key")
     }
     writeConfig(filename, config)
 
@@ -126,8 +126,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for client cert/key path
 
     config = {
-      'clientCert': self.getCertFilename("device_self_signed.cert"),
-      'clientKey': self.getCertFilename("device_a.key")
+      'clientCert': getCertFilename("device_self_signed.cert"),
+      'clientKey': getCertFilename("device_a.key")
     }
     writeConfig(filename, config)
 
@@ -146,8 +146,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for client cert/key path
 
     config = {
-      'clientCert': self.getCertFilename("non_cbrs_signed_device.cert"),
-      'clientKey': self.getCertFilename("non_cbrs_signed_device.key")
+      'clientCert': getCertFilename("non_cbrs_signed_device.cert"),
+      'clientKey': getCertFilename("non_cbrs_signed_device.key")
     }
     writeConfig(filename, config)
 
@@ -166,8 +166,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for client cert/key path
 
     config = {
-      'clientCert': self.getCertFilename("device_wrong_type.cert"),
-      'clientKey': self.getCertFilename("server.key")
+      'clientCert': getCertFilename("device_wrong_type.cert"),
+      'clientKey': getCertFilename("server.key")
 
     }
     writeConfig(filename, config)
@@ -200,8 +200,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the configuration for blacklisted client cert/key path
 
     config = {
-        'clientCert': self.getCertFilename("device_blacklisted.cert"),
-        'clientKey': self.getCertFilename("device_blacklisted.key")
+        'clientCert': getCertFilename("device_blacklisted.cert"),
+        'clientKey': getCertFilename("device_blacklisted.key")
     }
     writeConfig(filename, config)
 
@@ -225,8 +225,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for client cert/key path
     
     config = { 
-        'clientCert': self.getCertFilename("device_expired.cert"),
-        'clientKey': self.getCertFilename("device_expired.key")
+        'clientCert': getCertFilename("device_expired.cert"),
+        'clientKey': getCertFilename("device_expired.key")
     }
     writeConfig(filename, config)
   
@@ -248,8 +248,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     """
     self.assertTlsHandshakeFailureOrHttp403(
         ssl_method=SSL.TLSv1_1_METHOD,
-        client_cert=self.getCertFilename('device_a.cert'),
-        client_key=self.getCertFilename('device_a.key'))
+        client_cert=getCertFilename('device_a.cert'),
+        client_key=getCertFilename('device_a.key'))
 
   @winnforum_testcase
   def test_WINNF_FT_S_SCS_14(self):
@@ -259,16 +259,16 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     """
     self.assertTlsHandshakeFailureOrHttp403(
         ciphers='ECDHE-RSA-AES256-GCM-SHA384',
-        client_cert=self.getCertFilename('device_a.cert'),
-        client_key=self.getCertFilename('device_a.key'))
+        client_cert=getCertFilename('device_a.cert'),
+        client_key=getCertFilename('device_a.key'))
 
   def generate_SCS_15_default_config(self, filename):
     """ Generates the WinnForum configuration for SCS.15 """
     # Create the actual config for client cert/key path
     
     config = {
-        'clientCert': self.getCertFilename("device_inapplicable.cert"),
-        'clientKey': self.getCertFilename("device_a.key")
+        'clientCert': getCertFilename("device_inapplicable.cert"),
+        'clientKey': getCertFilename("device_a.key")
     }
     writeConfig(filename, config)
 
@@ -303,8 +303,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the configuration for client cert/key path.
 
     config = {
-        'clientCert': self.getCertFilename("device_cert_from_revoked_ca.cert"),
-        'clientKey': self.getCertFilename("device_cert_from_revoked_ca.key")
+        'clientCert': getCertFilename("device_cert_from_revoked_ca.cert"),
+        'clientKey': getCertFilename("device_cert_from_revoked_ca.key")
     }
     writeConfig(filename, config)
 
@@ -338,8 +338,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     self.createShortLivedCertificate("CBSD", device_cert_name, cert_duration_minutes)
 
     # Get the absolute path of the short lived certificate created.
-    device_cert = self.getCertFilename(device_cert_name + ".cert")
-    device_key = self.getCertFilename(device_cert_name + ".key")
+    device_cert = getCertFilename(device_cert_name + ".cert")
+    device_key = getCertFilename(device_cert_name + ".key")
 
     # Successful TLS Handshake
     self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'],
@@ -385,8 +385,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     self.createShortLivedCertificate("CBSD", device_cert_name, cert_duration_minutes)
 
     # Get the absolute path of the short lived certificate created.
-    device_cert = self.getCertFilename(device_cert_name + ".cert")
-    device_key = self.getCertFilename(device_cert_name + ".key")
+    device_cert = getCertFilename(device_cert_name + ".cert")
+    device_key = getCertFilename(device_cert_name + ".key")
 
     # Successful TLS Handshake
     self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'], device_cert,
@@ -435,8 +435,8 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     self.createShortLivedCertificate("CBSD", device_cert_name, cert_duration_minutes)
 
     # Get the absolute path of the short lived certificate created.
-    device_cert = self.getCertFilename(device_cert_name + ".cert")
-    device_key = self.getCertFilename(device_cert_name + ".key")
+    device_cert = getCertFilename(device_cert_name + ".cert")
+    device_key = getCertFilename(device_cert_name + ".key")
 
     # Successful TLS Handshake.
     self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'],

--- a/src/harness/testcases/WINNF_FT_S_SDS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SDS_testcase.py
@@ -18,11 +18,11 @@ import os
 import time
 from OpenSSL import SSL
 from util import winnforum_testcase, configurable_testcase, \
-  writeConfig, loadConfig
+  writeConfig, loadConfig, getCertFilename
 
 
-DOMAIN_PROXY_CERT = os.path.join('certs', 'domain_proxy.cert')
-DOMAIN_PROXY_KEY = os.path.join('certs', 'domain_proxy.key')
+DOMAIN_PROXY_CERT = getCertFilename('domain_proxy.cert')
+DOMAIN_PROXY_KEY = getCertFilename('domain_proxy.key')
 
 
 class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
@@ -86,8 +86,8 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for domain proxy cert/key path
 
     config = {
-      'domainProxyCert': self.getCertFilename("unrecognized_domain_proxy.cert"),
-      'domainProxyKey': self.getCertFilename("unrecognized_domain_proxy.key")
+      'domainProxyCert': getCertFilename("unrecognized_domain_proxy.cert"),
+      'domainProxyKey': getCertFilename("unrecognized_domain_proxy.key")
     }
     writeConfig(filename, config)
 
@@ -106,8 +106,8 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for domain proxy cert/key path
 
     config = {
-      'domainProxyCert': self.getCertFilename("domain_proxy_corrupted.cert"),
-      'domainProxyKey': self.getCertFilename("domain_proxy_corrupted.key")
+      'domainProxyCert': getCertFilename("domain_proxy_corrupted.cert"),
+      'domainProxyKey': getCertFilename("domain_proxy_corrupted.key")
     }
     writeConfig(filename, config)
 
@@ -126,8 +126,8 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for domain proxy cert/key path
 
     config = {
-      'domainProxyCert': self.getCertFilename("domain_proxy_self_signed.cert"),
-      'domainProxyKey': self.getCertFilename("domain_proxy.key")
+      'domainProxyCert': getCertFilename("domain_proxy_self_signed.cert"),
+      'domainProxyKey': getCertFilename("domain_proxy.key")
     }
     writeConfig(filename, config)
 
@@ -146,8 +146,8 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for domain proxy cert/key path
 
     config = {
-      'domainProxyCert': self.getCertFilename("non_cbrs_signed_domain_proxy.cert"),
-      'domainProxyKey': self.getCertFilename("non_cbrs_signed_domain_proxy.key")
+      'domainProxyCert': getCertFilename("non_cbrs_signed_domain_proxy.cert"),
+      'domainProxyKey': getCertFilename("non_cbrs_signed_domain_proxy.key")
     }
     writeConfig(filename, config)
 
@@ -166,8 +166,8 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for domain proxy cert/key path
 
     config = {
-      'domainProxyCert': self.getCertFilename("domain_proxy_wrong_type.cert"),
-      'domainProxyKey': self.getCertFilename("server.key")
+      'domainProxyCert': getCertFilename("domain_proxy_wrong_type.cert"),
+      'domainProxyKey': getCertFilename("server.key")
 
     }
     writeConfig(filename, config)
@@ -200,8 +200,8 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     # Create the configuration for blacklisted domain proxy cert/key path.
 
     config = {
-        'domainProxyCert': self.getCertFilename("domain_proxy_blacklisted.cert"),
-        'domainProxyKey': self.getCertFilename("domain_proxy_blacklisted.key")
+        'domainProxyCert': getCertFilename("domain_proxy_blacklisted.cert"),
+        'domainProxyKey': getCertFilename("domain_proxy_blacklisted.key")
     }
     writeConfig(filename, config)
 
@@ -226,8 +226,8 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for domain proxy cert/key path
 
     config = {
-        'domainProxyCert': self.getCertFilename("domain_proxy_expired.cert"),
-        'domainProxyKey': self.getCertFilename("domain_proxy_expired.key")
+        'domainProxyCert': getCertFilename("domain_proxy_expired.cert"),
+        'domainProxyKey': getCertFilename("domain_proxy_expired.key")
     }
     writeConfig(filename, config)
 
@@ -262,8 +262,8 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for domain proxy cert/key path
 
     config = {
-        'domainProxyCert': self.getCertFilename("domain_proxy_inapplicable.cert"),
-        'domainProxyKey': self.getCertFilename("domain_proxy.key")
+        'domainProxyCert': getCertFilename("domain_proxy_inapplicable.cert"),
+        'domainProxyKey': getCertFilename("domain_proxy.key")
     }
     writeConfig(filename, config)
 
@@ -298,8 +298,8 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     # Create the configuration for domain proxy cert/key path.
 
     config = {
-        'domainProxyCert': self.getCertFilename("domain_proxy_cert_from_revoked_ca.cert"),
-        'domainProxyKey': self.getCertFilename("domain_proxy_cert_from_revoked_ca.key")
+        'domainProxyCert': getCertFilename("domain_proxy_cert_from_revoked_ca.cert"),
+        'domainProxyKey': getCertFilename("domain_proxy_cert_from_revoked_ca.key")
     }
     writeConfig(filename, config)
 
@@ -334,8 +334,8 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     self.createShortLivedCertificate("DomainProxy", device_cert_name, cert_duration_minutes)
 
     # Get the absolute path of short lived certificate.
-    domain_proxy_cert = self.getCertFilename(device_cert_name + ".cert")
-    domain_proxy_key = self.getCertFilename(device_cert_name + ".key")
+    domain_proxy_cert = getCertFilename(device_cert_name + ".cert")
+    domain_proxy_key = getCertFilename(device_cert_name + ".key")
 
     # Successful TLS Handshake.
     self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'],
@@ -380,8 +380,8 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     self.createShortLivedCertificate("DomainProxy", device_cert_name, cert_duration_minutes)
 
     # Get the absoulte path of short lived certificate.
-    domain_proxy_cert = self.getCertFilename(device_cert_name + ".cert")
-    domain_proxy_key = self.getCertFilename(device_cert_name + ".key")
+    domain_proxy_cert = getCertFilename(device_cert_name + ".cert")
+    domain_proxy_key = getCertFilename(device_cert_name + ".key")
 
     # Successful TLS Handshake.
     self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'], domain_proxy_cert,
@@ -429,8 +429,8 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     self.createShortLivedCertificate("DomainProxy", device_cert_name, cert_duration_minutes)
 
     # Get the absolute path of short lived certificate created.
-    domain_proxy_cert = self.getCertFilename(device_cert_name + ".cert")
-    domain_proxy_key = self.getCertFilename(device_cert_name + ".key")
+    domain_proxy_cert = getCertFilename(device_cert_name + ".cert")
+    domain_proxy_key = getCertFilename(device_cert_name + ".key")
 
     # Successful TLS Handshake.
     self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'],domain_proxy_cert,

--- a/src/harness/testcases/WINNF_FT_S_SIQ_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SIQ_testcase.py
@@ -18,8 +18,9 @@ import os
 import sas
 import sas_testcase
 import logging
-from util import winnforum_testcase, writeConfig,loadConfig, configurable_testcase ,getRandomLatLongInPolygon, \
-  makePpaAndPalRecordsConsistent,filterChannelsByFrequencyRange, addCbsdIdsToRequests
+from util import winnforum_testcase, writeConfig,loadConfig, configurable_testcase, \
+  getRandomLatLongInPolygon, makePpaAndPalRecordsConsistent,filterChannelsByFrequencyRange, \
+  addCbsdIdsToRequests, getCertFilename
 import time
 
 class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
@@ -413,8 +414,8 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
     SAS rejects the request by sending responseCode = 103 or 105 
     """
     # Load device_a [cert|key]
-    device_a_cert = os.path.join('certs', 'device_a.cert')
-    device_a_key = os.path.join('certs', 'device_a.key')
+    device_a_cert = getCertFilename('device_a.cert')
+    device_a_key = getCertFilename('device_a.key')
 
     # Register the first device with certificates
     device_a = json.load(
@@ -430,8 +431,8 @@ class SpectrumInquiryTestcase(sas_testcase.SasTestCase):
     del request, response
 
     # Load device_c [cert|key]
-    device_c_cert = os.path.join('certs', 'device_c.cert')
-    device_c_key = os.path.join('certs', 'device_c.key')
+    device_c_cert = getCertFilename('device_c.cert')
+    device_c_key = getCertFilename('device_c.key')
 
     # Register the second device with certificates
     device_c = json.load(

--- a/src/harness/testcases/WINNF_FT_S_SSS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SSS_testcase.py
@@ -19,12 +19,12 @@ from OpenSSL.crypto import load_certificate, FILETYPE_PEM
 
 from request_handler import HTTPError
 import security_testcase
-from util import winnforum_testcase, configurable_testcase, writeConfig, loadConfig,\
-getCertificateFingerprint
+from util import winnforum_testcase, configurable_testcase, writeConfig, \
+  loadConfig, getCertificateFingerprint, getCertFilename
 from request_handler import HTTPError
 
-SAS_CERT = os.path.join('certs', 'sas.cert')
-SAS_KEY = os.path.join('certs', 'sas.key')
+SAS_CERT = getCertFilename('sas.cert')
+SAS_KEY = getCertFilename('sas.key')
 SAS_TEST_HARNESS_URL = 'https://fake.sas.url.not.used/v1.2'
 
 class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
@@ -90,8 +90,8 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for SAS cert/key path
 
     config = {
-        'sasCert': self.getCertFilename("unrecognized_sas.cert"),
-        'sasKey': self.getCertFilename("unrecognized_sas.key")
+        'sasCert': getCertFilename("unrecognized_sas.cert"),
+        'sasKey': getCertFilename("unrecognized_sas.key")
     }
     writeConfig(filename, config)
 
@@ -116,8 +116,8 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for SAS cert/key path
 
     config = {
-        'sasCert': self.getCertFilename("sas_corrupted.cert"),
-        'sasKey': self.getCertFilename("sas_corrupted.key")
+        'sasCert': getCertFilename("sas_corrupted.cert"),
+        'sasKey': getCertFilename("sas_corrupted.key")
     }
     writeConfig(filename, config)
 
@@ -141,8 +141,8 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for SAS cert/key path
 
     config = {
-        'sasCert': self.getCertFilename("sas_self_signed.cert"),
-        'sasKey': self.getCertFilename("sas.key")
+        'sasCert': getCertFilename("sas_self_signed.cert"),
+        'sasKey': getCertFilename("sas.key")
     }
     writeConfig(filename, config)
 
@@ -166,8 +166,8 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for SAS cert/key path
 
     config = {
-        'sasCert': self.getCertFilename("non_cbrs_signed_sas.cert"),
-        'sasKey': self.getCertFilename("non_cbrs_signed_sas.key")
+        'sasCert': getCertFilename("non_cbrs_signed_sas.cert"),
+        'sasKey': getCertFilename("non_cbrs_signed_sas.key")
     }
     writeConfig(filename, config)
 
@@ -191,8 +191,8 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for SAS cert/key path 
 
     config = {
-        'sasCert': self.getCertFilename("sas_wrong_type.cert"),
-        'sasKey': self.getCertFilename("device_a.key")
+        'sasCert': getCertFilename("sas_wrong_type.cert"),
+        'sasKey': getCertFilename("device_a.key")
     }
     writeConfig(filename, config)
 
@@ -229,8 +229,8 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the configuration for blacklisted SAS cert/key path.
 
     config = {
-        'sasCert': self.getCertFilename("sas_blacklisted.cert"),
-        'sasKey': self.getCertFilename("sas_blacklisted.key")
+        'sasCert': getCertFilename("sas_blacklisted.cert"),
+        'sasKey': getCertFilename("sas_blacklisted.key")
     }
     writeConfig(filename, config)
 
@@ -263,8 +263,8 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for SAS cert/key path
 
     config = {
-        'sasCert': self.getCertFilename("sas_expired.cert"),
-        'sasKey': self.getCertFilename("sas_expired.key")
+        'sasCert': getCertFilename("sas_expired.cert"),
+        'sasKey': getCertFilename("sas_expired.key")
     }
     writeConfig(filename, config)
 
@@ -288,8 +288,8 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for SAS cert/key path
 
     config = {
-        'sasCert': self.getCertFilename("sas.cert"),
-        'sasKey': self.getCertFilename("sas.key")
+        'sasCert': getCertFilename("sas.cert"),
+        'sasKey': getCertFilename("sas.key")
     }
     writeConfig(filename, config)
 
@@ -318,8 +318,8 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for SAS cert/key path
 
     config = {
-        'sasCert': self.getCertFilename("sas.cert"),
-        'sasKey': self.getCertFilename("sas.key")
+        'sasCert': getCertFilename("sas.cert"),
+        'sasKey': getCertFilename("sas.key")
     }
     writeConfig(filename, config)
 
@@ -348,8 +348,8 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for SAS cert/key path
 
     config = {
-        'sasCert': self.getCertFilename("sas_inapplicable.cert"),
-        'sasKey': self.getCertFilename("sas.key")
+        'sasCert': getCertFilename("sas_inapplicable.cert"),
+        'sasKey': getCertFilename("sas.key")
     }
     writeConfig(filename, config)
 
@@ -382,8 +382,8 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the configuration for SAS cert/key path.
 
     config = {
-        'sasCert': self.getCertFilename("sas_cert_from_revoked_ca.cert"),
-        'sasKey': self.getCertFilename("sas_cert_from_revoked_ca.key")
+        'sasCert': getCertFilename("sas_cert_from_revoked_ca.cert"),
+        'sasKey': getCertFilename("sas_cert_from_revoked_ca.key")
     }
     writeConfig(filename, config)
 
@@ -408,8 +408,8 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     # Create the actual config for SAS cert/key path
 
     config = {
-        'sasCert': self.getCertFilename("sas.cert"),
-        'sasKey': self.getCertFilename("sas.key")
+        'sasCert': getCertFilename("sas.cert"),
+        'sasKey': getCertFilename("sas.key")
     }
     writeConfig(filename, config)
 
@@ -430,11 +430,15 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
   def generate_SSS_18_default_config(self, filename):
     """ Generates the WinnForum configuration for SSS.18 """
     # Create the actual config for SAS cert/key path
-    
-    valid_cert_key_pair = {'cert' :self.getCertFilename("sas.cert"),
-                           'key' :self.getCertFilename("sas.key")}
-    invalid_cert_key_pair = {'cert' :self.getCertFilename("sas_expired.cert"),
-                             'key' :self.getCertFilename("sas_expired.key")}
+
+    valid_cert_key_pair = {
+        'cert': getCertFilename('sas.cert'),
+        'key': getCertFilename('sas.key')
+    }
+    invalid_cert_key_pair = {
+        'cert': getCertFilename('sas_expired.cert'),
+        'key': getCertFilename('sas_expired.key')
+    }
 
     config = {
         'validCertKeyPair': valid_cert_key_pair,

--- a/src/harness/testcases/WINNF_FT_S_WDB_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_WDB_testcase.py
@@ -20,7 +20,9 @@ import sas
 import sas_testcase
 from database import DatabaseServer
 from util import configurable_testcase, writeConfig, loadConfig,\
-    convertRequestToRequestWithCpiSignature, makePalRecordsConsistent, generateCpiRsaKeys, ensureFileDirectoryExists
+  convertRequestToRequestWithCpiSignature, makePalRecordsConsistent, \
+  generateCpiRsaKeys, ensureFileDirectoryExists, getFqdnLocalhost, \
+  getUnusedPort, getCertFilename
 
 
 class WinnforumDatabaseUpdateTestcase(sas_testcase.SasTestCase):
@@ -105,8 +107,8 @@ class WinnforumDatabaseUpdateTestcase(sas_testcase.SasTestCase):
       file_handle.write(json.dumps(pal_db_contents,indent=2))
 
     pal_database_config = {
-        'hostName': 'localhost',
-        'port': 8003,
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
         'fileUrl': '/rest/pal/v1/pal_db.json/pal_db.json',
         'filePath': pal_db_relative_file_path
     }
@@ -220,8 +222,8 @@ class WinnforumDatabaseUpdateTestcase(sas_testcase.SasTestCase):
       file_handle.write(cpi_public_key_device_d)
 
     cpi_database_config = {
-        'hostName': 'localhost',
-        'port': 8003,
+        'hostName': getFqdnLocalhost(),
+        'port': getUnusedPort(),
         'cpis': [{
             'cpiId': cpi_id_b,
             'status': 'ACTIVE',

--- a/src/harness/util.py
+++ b/src/harness/util.py
@@ -26,6 +26,7 @@ import time
 import random
 import uuid
 import jwt
+import portpicker
 from OpenSSL.crypto import load_certificate, FILETYPE_PEM
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
@@ -518,3 +519,21 @@ def ensureFileDirectoryExists(file_path):
   dir_name = os.path.dirname(file_path)
   if not os.path.exists(dir_name):
     os.makedirs(dir_name)
+
+def getCertFilename(cert_name):
+  """Returns the file path corresponding to the given |cert_name|.
+  """
+  return os.path.join('certs', cert_name)
+
+def getFqdnLocalhost():
+  """Returns the fully qualified name of the host running the testcase.
+  To be used when starting peer SAS webserver or other database webserver.
+  """
+  return os.environ.get('HOSTNAME', 'localhost')
+
+def getUnusedPort():
+  """Returns an unused TCP port on the local host.
+  To be used when starting peer SAS webserver or other database webserver.
+  """
+  return portpicker.pick_unused_port()
+


### PR DESCRIPTION
Clean code by introducing new function in util.py and use them whenever:
- getCertFilename(): moved from security_testcase,
- getFqdnLocalhost(): return the $HOSTNAME, allowing to run the tests on another computer than the SAS UUT
- getUnusedPort(): get rid of hardcoded port