### PR TITLE
Bring testcases and test components up to date with cert naming scheme

### DIFF
--- a/src/harness/database.py
+++ b/src/harness/database.py
@@ -30,6 +30,7 @@ d.setFilesToServe({
 
 import base64
 import logging
+import os
 import ssl
 import threading
 from BaseHTTPServer import HTTPServer
@@ -41,9 +42,9 @@ _USERNAME = 'username'
 _PASSWORD = 'password'
 _AUTHORIZATION_STRING = 'Basic ' + base64.b64encode(_USERNAME+':'+_PASSWORD)
 
-_SSL_CERT = 'certs/server.cert'
-_SSL_KEY = 'certs/server.key'
-_SSL_CA_CERT_FILE = 'certs/ca.cert'
+_SSL_CERT = os.path.join('certs', 'server.cert')
+_SSL_KEY = os.path.join('certs', 'server.key')
+_SSL_CA_CERT_FILE = os.path.join('certs', 'ca.cert')
 
 
 class DatabaseServer(threading.Thread):

--- a/src/harness/fake_sas.py
+++ b/src/harness/fake_sas.py
@@ -62,9 +62,9 @@ import sas_interface
 
 # Fake SAS server configurations.
 PORT = 9000
-CERT_FILE = 'certs/server.cert'
-KEY_FILE = 'certs/server.key'
-CA_CERT = 'certs/ca.cert'
+CERT_FILE = os.path.join('certs', 'sas.cert')
+KEY_FILE = os.path.join('certs', 'sas.key')
+CA_CERT = os.path.join('certs', 'ca.cert')
 CIPHERS = [
     'AES128-GCM-SHA256',              # TLS_RSA_WITH_AES_128_GCM_SHA256
     'AES256-GCM-SHA384',              # TLS_RSA_WITH_AES_256_GCM_SHA384

--- a/src/harness/sas_test_harness.py
+++ b/src/harness/sas_test_harness.py
@@ -35,9 +35,9 @@ from datetime import datetime, timedelta
 from BaseHTTPServer import HTTPServer
 from SimpleHTTPServer import SimpleHTTPRequestHandler
 
-DEFAULT_CERT_FILE = 'certs/server.cert'
-DEFAULT_KEY_FILE = 'certs/server.key'
-DEFAULT_CA_CERT = 'certs/ca.cert'
+DEFAULT_CERT_FILE = os.path.join('certs', 'sas.cert')
+DEFAULT_KEY_FILE = os.path.join('certs', 'sas.key')
+DEFAULT_CA_CERT = os.path.join('certs', 'ca.cert')
 CIPHERS = [
     'AES128-GCM-SHA256',              # TLS_RSA_WITH_AES_128_GCM_SHA256
     'AES256-GCM-SHA384',              # TLS_RSA_WITH_AES_256_GCM_SHA384

--- a/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
@@ -623,9 +623,9 @@ class FullActivityDumpTestcase(sas_testcase.SasTestCase):
         'sasTestHarnessName': 'SAS-TH-1',
         'hostName': 'localhost',
         'port': 9001,
-        'serverCert': "certs/server.cert",
-        'serverKey': "certs/server.key",
-        'caCert': "certs/ca.cert"
+        'serverCert': os.path.join('certs', 'sas.cert'),
+        'serverKey': os.path.join('certs', 'sas.key'),
+        'caCert': os.path.join('certs', 'ca.cert')
     }
     # Generate FAD Records for each record type like cbsd,zone and esc_sensor
     cbsd_fad_records = generateCbsdRecords(cbsd_records, grant_record_list)

--- a/src/harness/testcases/WINNF_FT_S_GRA_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_GRA_testcase.py
@@ -319,8 +319,8 @@ class GrantTestcase(sas_testcase.SasTestCase):
         'sasTestHarnessName': 'SAS-Test-Harness-1',
         'hostName': 'localhost',
         'port': 9001,
-        'serverCert': os.path.join('certs', 'server.cert'),
-        'serverKey': os.path.join('certs', 'server.key'),
+        'serverCert': os.path.join('certs', 'sas.cert'),
+        'serverKey': os.path.join('certs', 'sas.key'),
         'caCert': os.path.join('certs', 'ca.cert')
     }
     sas_harness_dump_records = {
@@ -360,7 +360,7 @@ class GrantTestcase(sas_testcase.SasTestCase):
     grant_g1 = config['grantRequestG1']
     grant_g2 = config['grantRequestG2']
     sas_test_harness_dump_records = [config['sasTestHarnessDumpRecords']['cbsdRecords']]
-    
+
     # Inserting FCC IDs on SUUT before CPAS so SUUT will know about them
     self._sas_admin.InjectFccId({'fccId': device_c1['fccId']})
     self._sas_admin.InjectFccId({'fccId': device_c2['fccId']})
@@ -437,8 +437,8 @@ class GrantTestcase(sas_testcase.SasTestCase):
         'sasTestHarnessName': 'SAS-TestHarness-1',
         'hostName': 'localhost',
         'port': 9001,
-        'serverCert': os.path.join('certs', 'server.cert'),
-        'serverKey': os.path.join('certs', 'server.key'),
+        'serverCert': os.path.join('certs', 'sas.cert'),
+        'serverKey': os.path.join('certs', 'sas.key'),
         'caCert': os.path.join('certs', 'ca.cert')
     }
     sas_harness_dump_records = {

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -104,9 +104,9 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         'port':
             9001,
         'serverCert':
-            os.path.join('certs', 'server.cert'),
+            os.path.join('certs', 'sas.cert'),
         'serverKey':
-            os.path.join('certs', 'server.key'),
+            os.path.join('certs', 'sas.key'),
         'caCert':
             os.path.join('certs', 'ca.cert'),
         'fullActivityDumpRecords': [
@@ -289,9 +289,9 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         'port':
             9002,
         'serverCert':
-            os.path.join('certs', 'server.cert'),
+            os.path.join('certs', 'sas.cert'),
         'serverKey':
-            os.path.join('certs', 'server.key'),
+            os.path.join('certs', 'sas.key'),
         'caCert':
             os.path.join('certs', 'ca.cert'),
         'fullActivityDumpRecords': [
@@ -756,9 +756,9 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         'port':
             9006,
         'serverCert':
-            os.path.join('certs', 'server.cert'),
+            os.path.join('certs', 'sas.cert'),
         'serverKey':
-            os.path.join('certs', 'server.key'),
+            os.path.join('certs', 'sas.key'),
         'caCert':
             os.path.join('certs', 'ca.cert'),
         'fullActivityDumpRecords': [

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -965,8 +965,8 @@ class MultiConstraintProtectionTestcase(McpXprCommonTestcase):
         'sasTestHarnessName': 'SAS-TH-1',
         'hostName': 'localhost',
         'port': 9001,
-        'serverCert': os.path.join('certs', 'server.cert'),
-        'serverKey': os.path.join('certs', 'server.key'),
+        'serverCert': os.path.join('certs', 'sas.cert'),
+        'serverKey': os.path.join('certs', 'sas.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
         'initialFad': dump_records_iteration_0_sas_test_harness_0
     }
@@ -974,8 +974,8 @@ class MultiConstraintProtectionTestcase(McpXprCommonTestcase):
         'sasTestHarnessName': 'SAS-TH-2',
         'hostName': 'localhost',
         'port': 9002,
-        'serverCert': os.path.join('certs', 'server.cert'),
-        'serverKey': os.path.join('certs', 'server.key'),
+        'serverCert': os.path.join('certs', 'sas_1.cert'),
+        'serverKey': os.path.join('certs', 'sas_1.key'),
         'caCert': os.path.join('certs', 'ca.cert'),
         'initialFad': dump_records_iteration_0_sas_test_harness_1
     }


### PR DESCRIPTION
- Updates all default test configs to use sas*.cert (which most tests were already using)
- Updates to use os.path to construct the cert/key paths (for compatibility with different OSes)
- Fixes a bug in the default config for MCP.1 where the same cert is used for both test harnesses