### PR TITLE
Fix minor bugs in MCP workflow

### DIFF
--- a/src/harness/reference_models/interference/aggregate_interference.py
+++ b/src/harness/reference_models/interference/aggregate_interference.py
@@ -83,6 +83,10 @@ def aggregateInterferenceForPoint(protection_point, channels, grants,
       grants, protection_point, protection_ent_type)
 
   if not grants_inside:
+    # We need one entry per channel, even if they're all zero.
+    for channel in channels:
+      aggr_interference.UpdateAggregateInterferenceInfo(
+          protection_point[1], protection_point[0], 0)
     return
 
   for channel in channels:

--- a/src/harness/sas_testcase.py
+++ b/src/harness/sas_testcase.py
@@ -90,6 +90,8 @@ class SasTestCase(unittest.TestCase):
       A list of cbsd_ids.
     """
 
+    if not registration_request:
+      return []
     for device in registration_request:
       self._sas_admin.InjectFccId({'fccId': device['fccId']})
       self._sas_admin.InjectUserId({'userId': device['userId']})


### PR DESCRIPTION
- Aggregate Interference results will now be populated for points with no grants (resolves issue in MCP interference checking).
- assertRegistered will now not exception if called with an empty list of registration requests (Allows MCP configurations containing iterations with zero CBSDs being added).
- Correct protected area calculation to only consider a point as correct if all frequencies are below the allowed threshold.
- Produce assert error if a protected entity with zero points is used (to help detect bad configs).