### PR TITLE
PPA Assert Failure  adding ability for SUUT to fail right away  (PCR4 and PCR5)

### DIFF
--- a/src/harness/sas_testcase.py
+++ b/src/harness/sas_testcase.py
@@ -441,7 +441,12 @@ class SasTestCase(unittest.TestCase):
          c. SAS UUT responds with success response rather than failure response.
 
     """
-    response = self._sas_admin.TriggerPpaCreation(ppa_creation_request)
+    try:
+        response = self._sas_admin.TriggerPpaCreation(ppa_creation_request)
+    except HTTPError:
+        # We are done if PPA creation failure is detected during TriggerPpaCreation.
+        return
+
     logging.info('TriggerPpaCreation is in progress')
 
     # Triggers most recent PPA Creation Status immediately and checks for the status

--- a/src/harness/testcases/WINNF_FT_S_PCR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_PCR_testcase.py
@@ -25,7 +25,9 @@ from reference_models.geo import drive, utils
 from util import configurable_testcase, loadConfig, \
      makePalRecordsConsistent, writeConfig, getCertificateFingerprint, \
      makePpaAndPalRecordsConsistent, getCertFilename
+from request_handler import HTTPError
 import signal
+import time
 
 SAS_TEST_HARNESS_URL = 'https://test.harness.url.not.used/v1.2'
 
@@ -194,7 +196,12 @@ class PpaCreationTestcase(sas_testcase.SasTestCase):
          c. SAS UUT responds with success response rather than failure response.
 
     """
-    response = self._sas_admin.TriggerPpaCreation(ppa_creation_request)
+    try:
+        response = self._sas_admin.TriggerPpaCreation(ppa_creation_request)
+    except HTTPError:
+        # We are done if PPA creation failure is detected during TriggerPpaCreation.
+        return
+
     logging.info('TriggerPpaCreation is in progress')
 
     # Triggers most recent PPA Creation Status immediately and checks for the status


### PR DESCRIPTION
Allowing for SUUT to be able to fail directly on AssertPpaCreateFailure (TCs PCR 4 and 5)


Notice that fucntion existed in two places:

sas_testcase.py
PCR.py file

modified both...

seems like one of them could be removed


Also added a missing import on PCR file
