### PR TITLE
Fw pcr.7fix

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_PCR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_PCR_testcase.py
@@ -25,9 +25,7 @@ from reference_models.geo import drive, utils
 from util import configurable_testcase, loadConfig, \
      makePalRecordsConsistent, writeConfig, getCertificateFingerprint, \
      makePpaAndPalRecordsConsistent, getCertFilename
-from request_handler import HTTPError
 import signal
-import time
 
 SAS_TEST_HARNESS_URL = 'https://test.harness.url.not.used/v1.2'
 
@@ -196,12 +194,7 @@ class PpaCreationTestcase(sas_testcase.SasTestCase):
          c. SAS UUT responds with success response rather than failure response.
 
     """
-    try:
-        response = self._sas_admin.TriggerPpaCreation(ppa_creation_request)
-    except HTTPError:
-        # We are done if PPA creation failure is detected during TriggerPpaCreation.
-        return
-
+    response = self._sas_admin.TriggerPpaCreation(ppa_creation_request)
     logging.info('TriggerPpaCreation is in progress')
 
     # Triggers most recent PPA Creation Status immediately and checks for the status
@@ -923,7 +916,10 @@ class PpaCreationTestcase(sas_testcase.SasTestCase):
         open(os.path.join('testcases', 'testdata', 'ppa_record_0.json')))
 
     # Update the user_claimed ppa contour geometry required for overlaps ppa.
-    overlapping_ppa_record['zone'] = overlapping_ppa_contour_geometry
+    overlapping_ppa_record['zone'] = {'type':'FeatureCollection',
+                                      'features': [
+                                          {'geometry': overlapping_ppa_contour_geometry}
+                                      ]}
 
     # Load PCR.1 configuration.
     pcr_1_test_config = loadConfig(pcr_1_test_config_file_path)

--- a/src/harness/testcases/WINNF_FT_S_PCR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_PCR_testcase.py
@@ -925,7 +925,9 @@ class PpaCreationTestcase(sas_testcase.SasTestCase):
     # Update the user_claimed ppa contour geometry required for overlaps ppa.
     overlapping_ppa_record['zone'] = {'type':'FeatureCollection',
                                       'features': [
-                                          {'geometry': overlapping_ppa_contour_geometry}
+                                          {'type': 'Feature', 
+                                           'properties': {}, 
+                                           'geometry': overlapping_ppa_contour_geometry}
                                       ]}
 
     # Load PCR.1 configuration.

--- a/src/harness/testcases/WINNF_FT_S_PCR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_PCR_testcase.py
@@ -25,7 +25,9 @@ from reference_models.geo import drive, utils
 from util import configurable_testcase, loadConfig, \
      makePalRecordsConsistent, writeConfig, getCertificateFingerprint, \
      makePpaAndPalRecordsConsistent, getCertFilename
+from request_handler import HTTPError
 import signal
+import time
 
 SAS_TEST_HARNESS_URL = 'https://test.harness.url.not.used/v1.2'
 
@@ -199,7 +201,6 @@ class PpaCreationTestcase(sas_testcase.SasTestCase):
     except HTTPError:
         # We are done if PPA creation failure is detected during TriggerPpaCreation.
         return
-      
     logging.info('TriggerPpaCreation is in progress')
 
     # Triggers most recent PPA Creation Status immediately and checks for the status

--- a/src/harness/testcases/WINNF_FT_S_PCR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_PCR_testcase.py
@@ -201,6 +201,7 @@ class PpaCreationTestcase(sas_testcase.SasTestCase):
     except HTTPError:
         # We are done if PPA creation failure is detected during TriggerPpaCreation.
         return
+
     logging.info('TriggerPpaCreation is in progress')
 
     # Triggers most recent PPA Creation Status immediately and checks for the status

--- a/src/harness/testcases/WINNF_FT_S_PCR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_PCR_testcase.py
@@ -194,7 +194,12 @@ class PpaCreationTestcase(sas_testcase.SasTestCase):
          c. SAS UUT responds with success response rather than failure response.
 
     """
-    response = self._sas_admin.TriggerPpaCreation(ppa_creation_request)
+    try:
+        response = self._sas_admin.TriggerPpaCreation(ppa_creation_request)
+    except HTTPError:
+        # We are done if PPA creation failure is detected during TriggerPpaCreation.
+        return
+      
     logging.info('TriggerPpaCreation is in progress')
 
     # Triggers most recent PPA Creation Status immediately and checks for the status


### PR DESCRIPTION
In PCR7 a zone is injected into the SUUT

/admin/injectdata/zone :

{"record": {"terminated": false, "name": "PPA Zone 0", "zone": {"type": "Polygon", "coordinates": [[[-100.61355286470628, 39.06028870255636], [-100.6103309414228, 39.05904150644663], [-100.60427196105131, 39.056756972863944], [-100.60425345765879, 39.05674997526318], [

This is not consistent with the zones we inject in other TCs:

/admin/injectdata/zone :

{"record": {"terminated": false, "name": "PPA Zone 0", "zone": {"type": "FeatureCollection", "features": [{"geometry": {"type": "Polygon", "coordinates": [[[-97.23861694335938, 38.865374851611634], [-97.31964111328125, 38.7615795117574], [-97.16995239257811, 38.739088441876866], [-97.16171264648436, 38.86751337001198], [-97.2386

It looks like the zone record in the PCR 7 config was not created properly

The second one is the correct one and what the PCR7 config should look like when it’s fixed