### PR TITLE
Transform all assert into proper exception raising

### DIFF
--- a/src/harness/reference_models/iap/iap.py
+++ b/src/harness/reference_models/iap/iap.py
@@ -523,7 +523,8 @@ def performIapForFssCochannel(fss_record, sas_uut_fad_object, sas_th_fad_objects
   fss_low_freq, fss_high_freq = fss_freq_range
 
   # Get channels for co-channel CBSDs
-  assert fss_high_freq >= interf.CBRS_HIGH_FREQ_HZ, 'FSS high frequency should not be less than CBRS high frequency(Hz)'
+  if fss_high_freq < interf.CBRS_HIGH_FREQ_HZ:
+    raise ValueError('FSS high frequency should not be less than CBRS high frequency(Hz)')
   protection_channels = interf.getProtectedChannels(fss_low_freq, interf.CBRS_HIGH_FREQ_HZ)
 
   asas_interference = interf.getInterferenceObject()

--- a/src/harness/reference_models/interference/interference.py
+++ b/src/harness/reference_models/interference/interference.py
@@ -190,7 +190,8 @@ def getProtectedChannels(low_freq_hz, high_freq_hz):
     An array of protected channel frequency range tuple
     (low_freq_hz,high_freq_hz).
   """
-  assert low_freq_hz < high_freq_hz, 'Low frequency is greater than high frequency'
+  if low_freq_hz >= high_freq_hz:
+    raise ValueError('Low frequency is greater than high frequency')
   channels = np.arange( max(low_freq_hz, 3550*MHZ), min(high_freq_hz, 3700*MHZ), 5*MHZ)
 
   return [(low, high) for low, high in zip(channels, channels+5*MHZ)]

--- a/src/harness/sas_test_harness.py
+++ b/src/harness/sas_test_harness.py
@@ -395,8 +395,8 @@ def generateCbsdRecords(registration_requests, grant_requests_list):
 
       # Auto-generating GrantData 'id' field.
       grant_data['id'] = 'SAMPLE_ID_{:05}'.format(random.randrange(1, 10 ** 5))
-
-      assert grant_request.has_key('operationParam'), 'operationParam does not exist in GrantRequest'
+      if not grant_request.has_key('operationParam'):
+        raise ValueError('operationParam does not exist in GrantRequest')
       grant_data['operationParam'] = grant_request['operationParam']
 
       # requestedOperationParam is a required field in SAS-SAS exchange in Release 1.

--- a/src/harness/test_harness_objects.py
+++ b/src/harness/test_harness_objects.py
@@ -73,7 +73,8 @@ class Cbsd(object):
       grant_ids: list of grant ids.
       grant_requests:A list of dictionary containing the grant request parameters.
     """
-    assert len(grant_requests) == len(grant_ids)
+    if len(grant_requests) != len(grant_ids):
+      raise ValueError('Cbsd builder: invalid grant_ids number')
     self.cbsd_id = cbsd_id
     self.grant_objects = {}
     for grant_id, grant_request in zip(grant_ids, grant_requests):

--- a/src/harness/util.py
+++ b/src/harness/util.py
@@ -52,9 +52,9 @@ def _log_testcase_header(name, doc):
 def winnforum_testcase(testcase):
   """Decorator for common features (e.g. logging) for WinnForum test cases."""
   def decorated_testcase(*args, **kwargs):
-    assert testcase, ('Avoid using @winnforum_testcase with '
-                      '@configurable_testcase')
-
+    if not testcase:
+      raise ValueError('Avoid using @winnforum_testcase with '
+                       '@configurable_testcase')
     _log_testcase_header(testcase.__name__, testcase.__doc__)
     testcase(*args, **kwargs)
 
@@ -354,7 +354,8 @@ def addIdsToRequests(ids, requests, id_field_name):
   """
   for index, req in enumerate(requests):
     if id_field_name not in req:
-      assert len(ids) == len(requests)  # Not valid otherwise
+      if len(ids) != len(requests):
+        raise ValueError('Bad number of requests')
       req[id_field_name] = ids[index]
     elif req[id_field_name] == 'REMOVE':
       del req[id_field_name]


### PR DESCRIPTION
'assert ' is an utility in debug environment. 
It will be a no-op when running in any kind of 'optimized' environment (python -O ..),
so it is not safe to rely on assert for input validity checking.

