### PR TITLE
Fix propagation segmentation fault when Tx & Rx location identical. 

### DIFF
--- a/src/harness/reference_models/interference/interference.py
+++ b/src/harness/reference_models/interference/interference.py
@@ -288,13 +288,8 @@ def computeInterferencePpaGwpzPoint(cbsd_grant, constraint, h_inc_ant,
   Returns:
     The interference contribution (dBm).
   """
-  if (cbsd_grant.latitude == constraint.latitude and
-      cbsd_grant.longitude == constraint.longitude):
-    db_loss = 0
-    incidence_angles = wf_itm._IncidenceAngles(hor_cbsd=0, ver_cbsd=0, hor_rx=0, ver_rx=0)
-  else:
-    # Get the propagation loss and incident angles for area entity
-    db_loss, incidence_angles, _ = wf_hybrid.CalcHybridPropagationLoss(
+  # Get the propagation loss and incident angles for area entity
+  db_loss, incidence_angles, _ = wf_hybrid.CalcHybridPropagationLoss(
                                      cbsd_grant.latitude, cbsd_grant.longitude,
                                      cbsd_grant.height_agl, constraint.latitude,
                                      constraint.longitude, h_inc_ant,
@@ -381,7 +376,6 @@ def computeInterferenceFssCochannel(cbsd_grant, constraint, fss_info, max_eirp):
   Returns:
     The interference contribution(dBm).
   """
-
   # Get the propagation loss and incident angles for FSS entity_type
   db_loss, incidence_angles, _ = wf_itm.CalcItmPropagationLoss(cbsd_grant.latitude,
                                    cbsd_grant.longitude, cbsd_grant.height_agl,

--- a/src/harness/reference_models/propagation/wf_hybrid.py
+++ b/src/harness/reference_models/propagation/wf_hybrid.py
@@ -186,6 +186,13 @@ def CalcHybridPropagationLoss(lat_cbsd, lon_cbsd, height_cbsd,
   Raises:
     Exception if input parameters invalid or out of range.
   """
+  # Case of same points
+  if (lat_cbsd == lat_rx and lon_cbsd == lon_rx):
+    return _PropagResult(
+        db_loss = 0,
+        incidence_angles = _IncidenceAngles(0,0,0,0),
+        internals = {})
+
   # Sanity checks on input parameters
   if freq_mhz < 40 or freq_mhz > 10000:
     raise Exception('Frequency outside range [40MHz - 10GHz].')

--- a/src/harness/reference_models/propagation/wf_hybrid_test.py
+++ b/src/harness/reference_models/propagation/wf_hybrid_test.py
@@ -215,6 +215,11 @@ class TestWfHybrid(unittest.TestCase):
     self.assertEqual(res_bad.db_loss, res_expected.db_loss)
     self.assertEqual(res_bad.incidence_angles, res_expected.incidence_angles)
 
+  def test_same_location(self):
+    result = wf_hybrid.CalcHybridPropagationLoss(45, -80, 10, 45, -80, 10)
+    self.assertEqual(result.db_loss, 0)
+    self.assertTupleEqual(result.incidence_angles, (0, 0, 0, 0))
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/src/harness/reference_models/propagation/wf_hybrid_test.py
+++ b/src/harness/reference_models/propagation/wf_hybrid_test.py
@@ -53,7 +53,7 @@ class TestWfHybrid(unittest.TestCase):
     res = wf_hybrid.CalcHybridPropagationLoss(
         lat1, lng1, height1, lat2, lng2, height2,
         reliability=reliability, freq_mhz=3625.,
-        region='SUBURBAN')
+        region='SUBURBAN', return_internals=True)
     self.assertAlmostEqual(res.db_loss, 79.167, 3)
     self.assertEqual(res.internals['hybrid_opcode'], wf_hybrid.HybridMode.FSL)
 
@@ -64,7 +64,7 @@ class TestWfHybrid(unittest.TestCase):
     res = wf_hybrid.CalcHybridPropagationLoss(
         lat1, lng1, height1, lat2, lng2, height2,
         reliability=reliability, freq_mhz=3625.,
-        region='SUBURBAN')
+        region='SUBURBAN', return_internals=True)
     self.assertEqual(res.db_loss, res.internals['itm_db_loss'])
     self.assertEqual(res.internals['hybrid_opcode'],
                      wf_hybrid.HybridMode.ITM_HIGH_HEIGHT)
@@ -76,7 +76,7 @@ class TestWfHybrid(unittest.TestCase):
     res = wf_hybrid.CalcHybridPropagationLoss(
         lat1, lng1, height1, lat2, lng2, height2,
         reliability=reliability, freq_mhz=3625.,
-        region='RURAL')
+        region='RURAL', return_internals=True)
     self.assertEqual(res.db_loss, res.internals['itm_db_loss'])
     self.assertEqual(res.internals['hybrid_opcode'],
                      wf_hybrid.HybridMode.ITM_RURAL)
@@ -88,7 +88,7 @@ class TestWfHybrid(unittest.TestCase):
     res = wf_hybrid.CalcHybridPropagationLoss(
         lat1, lng1, height1, lat2, lng2, height2,
         reliability=reliability, freq_mhz=3625.,
-        region='URBAN')
+        region='URBAN', return_internals=True)
     self.assertAlmostEqual(res.db_loss, 144.836, 3)
     self.assertEqual(res.internals['hybrid_opcode'],
                      wf_hybrid.HybridMode.EHATA_FSL_INTERP)
@@ -101,7 +101,7 @@ class TestWfHybrid(unittest.TestCase):
     res = wf_hybrid.CalcHybridPropagationLoss(
         lat1, lng1, height1, lat2, lng2, height2,
         reliability=reliability, freq_mhz=3625.,
-        region='SUBURBAN')
+        region='SUBURBAN', return_internals=True)
     self.assertAlmostEqual(res.db_loss, expected_itm_loss, 2)
     self.assertEqual(res.db_loss, res.internals['itm_db_loss'])
     self.assertEqual(res.internals['hybrid_opcode'],
@@ -117,7 +117,7 @@ class TestWfHybrid(unittest.TestCase):
     res = wf_hybrid.CalcHybridPropagationLoss(
         lat1, lng1, height1, lat2, lng2, height2,
         reliability=reliability, freq_mhz=3625.,
-        region='SUBURBAN')
+        region='SUBURBAN', return_internals=True)
     self.assertAlmostEqual(res.db_loss, expected_loss, 2)
     self.assertEqual(res.internals['hybrid_opcode'],
                      wf_hybrid.HybridMode.EHATA_DOMINANT)
@@ -149,7 +149,7 @@ class TestWfHybrid(unittest.TestCase):
     res = wf_hybrid.CalcHybridPropagationLoss(
         lat1, lng1, height1, lat2, lng2, height2,
         reliability=0.5, freq_mhz=3625.,
-        region='SUBURBAN')
+        region='SUBURBAN', return_internals=True)
     self.assertAlmostEqual(res.db_loss, expected_loss, 3)
     self.assertAlmostEqual(expected_itm_loss, res.internals['itm_db_loss'], 0)
     self.assertEqual(res.internals['hybrid_opcode'],
@@ -169,7 +169,7 @@ class TestWfHybrid(unittest.TestCase):
     avg_res = wf_hybrid.CalcHybridPropagationLoss(
         lat1, lng1, height1, lat2, lng2, height2,
         reliability=-1, freq_mhz=3625.,
-        region='SUBURBAN')
+        region='SUBURBAN', return_internals=True)
     self.assertEqual(avg_res.internals['hybrid_opcode'],
                      wf_hybrid.HybridMode.ITM_DOMINANT)
     self.assertAlmostEqual(avg_res.db_loss,

--- a/src/harness/reference_models/propagation/wf_itm.py
+++ b/src/harness/reference_models/propagation/wf_itm.py
@@ -123,6 +123,13 @@ def CalcItmPropagationLoss(lat_cbsd, lon_cbsd, height_cbsd,
   Raises:
     Exception if input parameters invalid or out of range.
   """
+  # Case of same points
+  if (lat_cbsd == lat_rx and lon_cbsd == lon_rx):
+    return _PropagResult(
+        db_loss = 0,
+        incidence_angles = _IncidenceAngles(0,0,0,0),
+        internals = {})
+
   # Sanity checks on input parameters
   if freq_mhz < 40.0 or freq_mhz > 10000:
     raise Exception('Frequency outside range [40MHz - 10GHz]')

--- a/src/harness/reference_models/propagation/wf_itm_test.py
+++ b/src/harness/reference_models/propagation/wf_itm_test.py
@@ -166,6 +166,11 @@ class TestWfItm(unittest.TestCase):
       self.assertAlmostEqual(inc_angles.ver_cbsd, a_tx, 14)
       self.assertAlmostEqual(inc_angles.ver_rx, a_rx, 14)
 
+  def test_same_location(self):
+    result = wf_itm.CalcItmPropagationLoss(45, -80, 10, 45, -80, 10)
+    self.assertEqual(result.db_loss, 0)
+    self.assertTupleEqual(result.incidence_angles, (0, 0, 0, 0))
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/src/harness/reference_models/propagation/wf_itm_test.py
+++ b/src/harness/reference_models/propagation/wf_itm_test.py
@@ -52,7 +52,8 @@ class TestWfItm(unittest.TestCase):
     lat2, lng2, height2 = 37.756559, -122.507882, 10.0
     reliability = 0.5
     res = wf_itm.CalcItmPropagationLoss(lat1, lng1, height1, lat2, lng2, height2,
-                                        reliability=reliability, freq_mhz=3625.)
+                                        reliability=reliability, freq_mhz=3625.,
+                                        return_internals=True)
     self.assertAlmostEqual(res.db_loss, 78.7408, 4)
     self.assertAlmostEqual(res.incidence_angles.ver_cbsd, -res.incidence_angles.ver_rx, 3)
     self.assertEqual(res.internals['itm_err_num'], wf_itm.ItmErrorCode.OTHER)  # LOS mode
@@ -65,7 +66,8 @@ class TestWfItm(unittest.TestCase):
 
     for rel, exp_loss in zip(reliabilities, expected_losses):
       res = wf_itm.CalcItmPropagationLoss(lat1, lng1, height1, lat2, lng2, height2,
-                                          reliability=rel, freq_mhz=3625.)
+                                          reliability=rel, freq_mhz=3625.,
+                                          return_internals=True)
       self.assertAlmostEqual(res.db_loss, exp_loss, 2)
       self.assertEqual(res.internals['itm_err_num'], wf_itm.ItmErrorCode.WARNING)  # Double horizon
 


### PR DESCRIPTION
Fix crash if Tx and Rx location are the same.

Also disable the return of the "internals" information which are not used anywhere as part of test harness.
This contains big arrays and prevent efficient caching of the propagation results.

