### PR TITLE
FSS blocking interference: fix issue with wrong bandwidth

### DIFF
--- a/src/harness/reference_models/interference/interference.py
+++ b/src/harness/reference_models/interference/interference.py
@@ -484,8 +484,12 @@ def computeInterferenceFssBlocking(cbsd_grant, constraint, fss_info, max_eirp):
 
   # Compute EIRP of CBSD grant inside the frequency range of
   # protection constraint
+  eff_bandwidth = (min(cbsd_grant.high_frequency, constraint.high_frequency)
+                   - cbsd_grant.low_frequency)
+  if eff_bandwidth < 0:
+    raise ValueError('Computing FSS blocking on grant fully inside FSS passband')
   eirp = getEffectiveSystemEirp(max_eirp, cbsd_grant.antenna_gain,
-           effective_ant_gain, (cbsd_grant.high_frequency - cbsd_grant.low_frequency))
+                                effective_ant_gain, eff_bandwidth)
   # Calculate the interference contribution
   interference = eirp - getFssMaskLoss(cbsd_grant, constraint) - db_loss
 


### PR DESCRIPTION
The channel bandwidth used is not right. It should capture only the part of the grant within the protection constraint.

Also add some unit test on this specific case (indirectly test other things)