### PR TITLE
Add utility routine to insure a geojson is a FeatureCollection

### DIFF
--- a/src/harness/reference_models/geo/utils.py
+++ b/src/harness/reference_models/geo/utils.py
@@ -182,6 +182,33 @@ def ToGeoJson(geometry, as_dict=False):
   return json.loads(json_geometry) if as_dict else json_geometry
 
 
+def InsureFeatureCollection(geometry, as_dict=False):
+  """Returns a GeoJSON feature collection from a geojson geometry.
+
+  Args:
+    geometry: A geojson geometry, either as dict or str. Can be any type
+      of GeoJSON: standard geometry, feature or feature collection.
+  """
+  if isinstance(geometry, basestring):
+    geometry = json.loads(geometry)
+  if 'type' not in geometry:
+    raise ValueError('Invalid GeoJSON geometry.')
+  if geometry['type'] == 'FeatureCollection':
+    pass
+  elif geometry['type'] == 'Feature':
+    geometry = {'type': 'FeatureCollection',
+                'features': [geometry]}
+  else:
+    geometry = {'type': 'FeatureCollection',
+                'features': [
+                    {'type': 'Feature',
+                    'properties': {},
+                    'geometry': geometry}
+                ]
+    }
+  return geometry if as_dict else json.dumps(geometry)
+
+
 def GridPolygon(poly, res_arcsec):
   """Grids a polygon or multi-polygon.
 

--- a/src/harness/reference_models/geo/utils_test.py
+++ b/src/harness/reference_models/geo/utils_test.py
@@ -286,6 +286,29 @@ class TestUtils(unittest.TestCase):
                                                           270, 360)
     self.assertTrue(status)
 
+  def test_insure_feature_collection(self):
+    with open(os.path.join(TEST_DIR, 'ppa_record_0.json'), 'r') as fd:
+      ppa = json.load(fd)
+    feature_col = ppa['zone']
+    feature_col_str = json.dumps(feature_col)
+    feature = ppa['zone']['features'][0]
+    geometry = ppa['zone']['features'][0]['geometry']
+    geometry_str = json.dumps(geometry)
+    self.assertDictEqual(utils.InsureFeatureCollection(feature_col, as_dict=True),
+                          feature_col)
+    self.assertDictEqual(utils.InsureFeatureCollection(feature_col_str, as_dict=True),
+                          feature_col)
+    self.assertDictEqual(utils.InsureFeatureCollection(feature, as_dict=True),
+                          feature_col)
+    self.assertDictEqual(utils.InsureFeatureCollection(geometry, as_dict=True),
+                          feature_col)
+    self.assertDictEqual(utils.InsureFeatureCollection(geometry_str, as_dict=True),
+                          feature_col)
+    self.assertEqual(utils.InsureFeatureCollection(geometry),
+                      feature_col_str)
+    self.assertEqual(utils.InsureFeatureCollection(geometry_str),
+                      feature_col_str)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
To use on a geojson geometry do:
```
  ppa = utils.InsureFeatureCollection(ppa)  # to get it in string
  ppa = utils.InsureFeatureCollection(ppa, as_dict=True)  # to get it as a json dict
```

This will handle the ppa whatever its format: Polygon, Feature or FeatureCollection, and also either dict or str. So it can be used safely on the returned PPA from the PpaCreationModel().