### PR TITLE
IAP/AggInterf: insure the protection channel aligned to multiple of 5MHz

### DIFF
--- a/src/harness/reference_models/interference/aggregate_interference.py
+++ b/src/harness/reference_models/interference/aggregate_interference.py
@@ -141,6 +141,9 @@ def calculateAggregateInterferenceForFssCochannel(fss_record, grants):
 
   # Get channels for co-channel CBSDs
   fss_high_freq = min(fss_high_freq, interf.CBRS_HIGH_FREQ_HZ)
+  if fss_high_freq < interf.CBRS_HIGH_FREQ_HZ:
+    raise ValueError('FSS high frequency should not be less than CBRS high frequency')
+
   protection_channels = interf.getProtectedChannels(fss_low_freq, fss_high_freq)
 
   aggr_interference = interf.getInterferenceObject()

--- a/src/harness/reference_models/interference/aggregate_interference.py
+++ b/src/harness/reference_models/interference/aggregate_interference.py
@@ -140,11 +140,10 @@ def calculateAggregateInterferenceForFssCochannel(fss_record, grants):
   fss_low_freq, fss_high_freq = fss_freq_range
 
   # Get channels for co-channel CBSDs
-  fss_high_freq = min(fss_high_freq, interf.CBRS_HIGH_FREQ_HZ)
   if fss_high_freq < interf.CBRS_HIGH_FREQ_HZ:
     raise ValueError('FSS high frequency should not be less than CBRS high frequency')
 
-  protection_channels = interf.getProtectedChannels(fss_low_freq, fss_high_freq)
+  protection_channels = interf.getProtectedChannels(fss_low_freq, interf.CBRS_HIGH_FREQ_HZ)
 
   aggr_interference = interf.getInterferenceObject()
   aggregateInterferenceForPoint(fss_point,

--- a/src/harness/reference_models/interference/interference.py
+++ b/src/harness/reference_models/interference/interference.py
@@ -192,8 +192,9 @@ def getProtectedChannels(low_freq_hz, high_freq_hz):
   """
   if low_freq_hz >= high_freq_hz:
     raise ValueError('Low frequency is greater than high frequency')
+  # Align the low_freq to multiple of 5MHZ
+  low_freq_hz = int(low_freq_hz / (5*MHZ)) * (5*MHZ)
   channels = np.arange( max(low_freq_hz, 3550*MHZ), min(high_freq_hz, 3700*MHZ), 5*MHZ)
-
   return [(low, high) for low, high in zip(channels, channels+5*MHZ)]
 
 

--- a/src/harness/reference_models/interference/interference_test.py
+++ b/src/harness/reference_models/interference/interference_test.py
@@ -94,7 +94,6 @@ class TestAggInterf(unittest.TestCase):
         dist_type='REAL', factor=1.0, offset=70 - 30.0)
     antenna.GetFssAntennaGains = mock.create_autospec(antenna.GetFssAntennaGains,
                                                       return_value=2.8)
-    import ipdb; ipdb.set_trace()
     # Create FSS and a CBSD at 30km
     fss_point, fss_info, _ = data.getFssInfo(TestAggInterf.fss_record)
     fss_freq_range = (3650e6, 3750e6)
@@ -116,6 +115,15 @@ class TestAggInterf(unittest.TestCase):
                            - 3.1634, # FSS mask loss for adjacent 10MHz
                            4)
 
+  def test_getProtectedChannels(self):
+    self.assertEqual(interf.getProtectedChannels(3660e6, 3675e6),
+                     [(3660e6, 3665e6), (3665e6, 3670e6), (3670e6, 3675e6)])
+    self.assertEqual(interf.getProtectedChannels(3662e6, 3671e6),
+                     [(3660e6, 3665e6), (3665e6, 3670e6), (3670e6, 3675e6)])
+    self.assertEqual(interf.getProtectedChannels(3540e6, 3555e6),
+                     [(3550e6, 3555e6)])
+    self.assertEqual(interf.getProtectedChannels(3692e6, 3722e6),
+                     [(3690e6, 3695e6), (3695e6, 3700e6) ])
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
- Some FSS and GWPZ may not be aligned with a multiple of 5MHz. The generate channels to protect were then also unaligned. For example see the GWPZ database at:
https://opendata.fcc.gov/Wireless/ULS-3650-Locations/euz5-46g2/data
Line 9:   center freq 3661.5 MHz   bandwidth 6.94 MHz

- Add unit test on that function

- Add the frequency check that FSS high passband frequency beyond 3700MHz. This test is done in the IAP but not in aggregated interference code.