### PR TITLE
FSS cochannel: support partial overlap with grant

### DIFF
--- a/src/harness/reference_models/interference/interference.py
+++ b/src/harness/reference_models/interference/interference.py
@@ -399,8 +399,13 @@ def computeInterferenceFssCochannel(cbsd_grant, constraint, fss_info, max_eirp):
   effective_ant_gain = ant_gain + fss_ant_gain
 
   # Compute the interference value for Fss co-channel entity
+  eff_bandwidth = (min(cbsd_grant.high_frequency, constraint.high_frequency)
+                   - max(cbsd_grant.low_frequency, constraint.low_frequency))
+  if eff_bandwidth <= 0:
+    raise ValueError('Computing FSS co-channel on grant fully outside FSS passband')
+
   eirp = getEffectiveSystemEirp(max_eirp, cbsd_grant.antenna_gain,
-                   effective_ant_gain)
+                                effective_ant_gain, eff_bandwidth)
   interference = eirp - db_loss - IN_BAND_INSERTION_LOSS
   return interference
 
@@ -481,7 +486,7 @@ def computeInterferenceFssBlocking(cbsd_grant, constraint, fss_info, max_eirp):
   # protection constraint
   eff_bandwidth = (min(cbsd_grant.high_frequency, constraint.high_frequency)
                    - cbsd_grant.low_frequency)
-  if eff_bandwidth < 0:
+  if eff_bandwidth <= 0:
     raise ValueError('Computing FSS blocking on grant fully inside FSS passband')
   eirp = getEffectiveSystemEirp(max_eirp, cbsd_grant.antenna_gain,
                                 effective_ant_gain, eff_bandwidth)

--- a/src/harness/reference_models/interference/interference_test.py
+++ b/src/harness/reference_models/interference/interference_test.py
@@ -94,7 +94,7 @@ class TestAggInterf(unittest.TestCase):
         dist_type='REAL', factor=1.0, offset=70 - 30.0)
     antenna.GetFssAntennaGains = mock.create_autospec(antenna.GetFssAntennaGains,
                                                       return_value=2.8)
-    #import ipdb; ipdb.set_trace()
+    import ipdb; ipdb.set_trace()
     # Create FSS and a CBSD at 30km
     fss_point, fss_info, _ = data.getFssInfo(TestAggInterf.fss_record)
     fss_freq_range = (3650e6, 3750e6)
@@ -122,7 +122,7 @@ class TestAggInterf(unittest.TestCase):
         dist_type='REAL', factor=1.0, offset=70 - 30.0)
     antenna.GetFssAntennaGains = mock.create_autospec(antenna.GetFssAntennaGains,
                                                       return_value=2.8)
-    import ipdb; ipdb.set_trace()
+
     # Create FSS and a CBSD at 30km
     fss_point, fss_info, _ = data.getFssInfo(TestAggInterf.fss_record)
     fss_freq_range = (3652e6, 3750e6)


### PR DESCRIPTION
Some FSS do not start at a multiple of 5MHz. 
Interference calculation need to take into account actual frequency overlap.