### PR TITLE
Fix for getFqdnLocalhost()/getUnusedPort()

### DIFF
--- a/src/harness/database.py
+++ b/src/harness/database.py
@@ -71,7 +71,7 @@ class DatabaseServer(threading.Thread):
     self.port = port
     self.base_url = 'http' + ('s' if https else '') + '://' + self.address
     self.setDaemon(True)
-    self.server = DatabaseHTTPServer(('localhost', port), DatabaseHandler, name, authorization)
+    self.server = DatabaseHTTPServer(('', port), DatabaseHandler, name, authorization)
     if https:
       self.server.socket = ssl.wrap_socket(
           self.server.socket,

--- a/src/harness/database.py
+++ b/src/harness/database.py
@@ -34,6 +34,7 @@ import ssl
 import threading
 from BaseHTTPServer import HTTPServer
 from SimpleHTTPServer import SimpleHTTPRequestHandler
+from util import releasePort
 
 
 # Create the authorization string.
@@ -67,9 +68,10 @@ class DatabaseServer(threading.Thread):
     super(DatabaseServer, self).__init__()
     self.name = name
     self.address = host_name + ':' + str(port)
+    self.port = port
     self.base_url = 'http' + ('s' if https else '') + '://' + self.address
     self.setDaemon(True)
-    self.server = DatabaseHTTPServer((host_name, port), DatabaseHandler, name, authorization)
+    self.server = DatabaseHTTPServer(('localhost', port), DatabaseHandler, name, authorization)
     if https:
       self.server.socket = ssl.wrap_socket(
           self.server.socket,
@@ -77,6 +79,9 @@ class DatabaseServer(threading.Thread):
           keyfile=_SSL_KEY,
           ca_certs=_SSL_CA_CERT_FILE,
           server_side=True)
+
+  def __del__(self):
+    releasePort(self.port)
 
   def run(self):
     """ Starts the HTTPServer as background thread.

--- a/src/harness/sas_test_harness.py
+++ b/src/harness/sas_test_harness.py
@@ -34,6 +34,7 @@ import traceback
 from datetime import datetime, timedelta
 from BaseHTTPServer import HTTPServer
 from SimpleHTTPServer import SimpleHTTPRequestHandler
+from util import releasePort
 
 DEFAULT_CERT_FILE = 'certs/server.cert'
 DEFAULT_KEY_FILE = 'certs/server.key'
@@ -91,7 +92,7 @@ class SasTestHarnessServer(threading.Thread):
     self.setDaemon(True)
     self.server = SasHttpServer(
         self.dump_path,
-        (self.host_name, self.port),
+        ('localhost', self.port),
         SasTestHarnessServerHandler,
         self.getSasTestHarnessVersion(),
     )
@@ -107,6 +108,7 @@ class SasTestHarnessServer(threading.Thread):
 
   def __del__(self):
     self.cleanDumpFiles()
+    releasePort(self.port)
 
   def generateTempDirectory(self):
     """ This method will generate a random directory using the current timestamp.

--- a/src/harness/sas_test_harness.py
+++ b/src/harness/sas_test_harness.py
@@ -92,7 +92,7 @@ class SasTestHarnessServer(threading.Thread):
     self.setDaemon(True)
     self.server = SasHttpServer(
         self.dump_path,
-        ('localhost', self.port),
+        ('', self.port),
         SasTestHarnessServerHandler,
         self.getSasTestHarnessVersion(),
     )

--- a/src/harness/test.cfg
+++ b/src/harness/test.cfg
@@ -3,5 +3,5 @@
 hostname: localhost
 # Defines a range of continuous ports to be used by the TH.
 # Special value < 0 mean 'any unused port'
-minPort: -1
-maxPort: -1
+minPort: 9010
+maxPort: 9020

--- a/src/harness/test.cfg
+++ b/src/harness/test.cfg
@@ -1,0 +1,7 @@
+[TestConfig]
+# The FQDN hostname of the machine running the TH, as seen by the SAS UUT.
+hostname: localhost
+# Defines a range of continuous ports to be used by the TH.
+# Special value < 0 mean 'any unused port'
+minPort: -1
+maxPort: -1

--- a/src/harness/util.py
+++ b/src/harness/util.py
@@ -74,6 +74,7 @@ def configurable_testcase(default_config_function):
       def _func(*a):
         if generate_default_func:
           generate_default_func(*a)
+          _releaseAllPorts()
         _log_testcase_header(name, func.func_doc)
         return func(*a, config_filename=config)
       _func.__name__ = name
@@ -564,7 +565,7 @@ def getUnusedPort():
   To be used when starting peer SAS webserver or other database webserver.
   """
   _initTestConfig()
-  if _test_config.min_port < 0:
+  if int(_test_config.min_port) < 0:
     return portpicker.pick_unused_port()
   global _ports
   # Find the first available port in the defined range.
@@ -575,10 +576,14 @@ def getUnusedPort():
   raise AssertionError('No available new ports')
 
 def releasePort(port):
-  """Release a used port after a webserevr goes down."""
+  """Release a used port after a webserver goes down."""
   _initTestConfig()
   if _test_config.min_port < 0:
     portpicker.return_port(port)
   global _ports
   if port in _ports:
     _ports.remove(port)
+
+def _releaseAllPorts():
+  """Release all used ports."""
+  _ports.clear()

--- a/src/harness/util_test.py
+++ b/src/harness/util_test.py
@@ -23,14 +23,14 @@ class UtilTest(unittest.TestCase):
 
   def test_getFqdnLocalhost(self):
     # Initialize the testConfig with our test data.
-    util._initTestConfig()
+    util._test_config = util._GetSharedTestConfig()
     util._test_config.hostname = 'foo.bar.com'
 
     self.assertEqual(util.getFqdnLocalhost(), 'foo.bar.com')
 
   def test_getUnusedPort_pickAny(self):
     # Initialize the testConfig with our test data.
-    util._initTestConfig()
+    util._test_config = util._GetSharedTestConfig()
     util._test_config.min_port = -1
     util._test_config.min_port = -1
 
@@ -38,7 +38,7 @@ class UtilTest(unittest.TestCase):
 
   def test_getUnusedPort_pickRange(self):
     # Initialize the testConfig with our test data.
-    util._initTestConfig()
+    util._test_config = util._GetSharedTestConfig()
     # Note that the could failed if these port are already in use...
     START_PORT = 12345
     util._test_config.min_port = START_PORT

--- a/src/harness/util_test.py
+++ b/src/harness/util_test.py
@@ -1,0 +1,58 @@
+#    Copyright 2018 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+"""Tests for the util.py."""
+
+import unittest
+import mock
+
+import util
+
+
+class UtilTest(unittest.TestCase):
+
+  def test_getFqdnLocalhost(self):
+    # Initialize the testConfig with our test data.
+    util._initTestConfig()
+    util._test_config.hostname = 'foo.bar.com'
+
+    self.assertEqual(util.getFqdnLocalhost(), 'foo.bar.com')
+
+  def test_getUnusedPort_pickAny(self):
+    # Initialize the testConfig with our test data.
+    util._initTestConfig()
+    util._test_config.min_port = -1
+    util._test_config.min_port = -1
+
+    self.assertGreater(util.getUnusedPort(), 0)
+
+  def test_getUnusedPort_pickRange(self):
+    # Initialize the testConfig with our test data.
+    util._initTestConfig()
+    # Note that the could failed if these port are already in use...
+    START_PORT = 12345
+    util._test_config.min_port = START_PORT
+    util._test_config.max_port = START_PORT + 5
+
+    self.assertEqual(util.getUnusedPort(), START_PORT)
+    self.assertEqual(util.getUnusedPort(), START_PORT + 1)
+    self.assertEqual(util.getUnusedPort(), START_PORT + 2)
+    self.assertEqual(util.getUnusedPort(), START_PORT + 3)
+    self.assertEqual(util.getUnusedPort(), START_PORT + 4)
+    with self.assertRaises(AssertionError):
+      util.getUnusedPort()
+
+    util.releasePort(START_PORT + 2)
+    self.assertEqual(util.getUnusedPort(), START_PORT + 2)
+    with self.assertRaises(AssertionError):
+      util.getUnusedPort()


### PR DESCRIPTION
Following discussion about getFqdnLocalhost()/getUnusedPort() in [Sas_test_dev]

Here the proposed solution, assuming Dorch comment about the ITS system architecture:
We assume that ITS will use a different machine for each SAS provider,
directly connected to internet to run the TH.
This machine has a firewall that open only a limited contiguous number of ports.

The previous solution of using 'random available' port sdon't fit this configuration.
Also it can produce problem with generated config file where the saved port became
unavailable.

The new proposed solution:
- we use a configured range of port, that must be keep available only for the TH
- in each webserver implementation (database.py, sas_test_harness.py), we:
  - always use '' when creating the server socket to listen to all interface
  - in the destructor, we ensure that we release the allocated port, to allow
    reusing port accross testcase
- configuration is done in a new test.cfg
- we correctly manage the generation of default config file, which occur during the import