### PR TITLE
Remove multiprocess Manager

### DIFF
--- a/src/harness/reference_models/common/mpool.py
+++ b/src/harness/reference_models/common/mpool.py
@@ -48,7 +48,7 @@ pool.apply_async(...)
 
 from functools import partial
 import multiprocessing
-
+import time
 
 class _DummyPool(object):
   """A dummy pool for replacement of `multiprocessing.Pool`
@@ -105,7 +105,11 @@ def GetNumWorkerProcesses():
 
 
 def _partial_fn(fn):
+  # sleep to avoid returning too fast so each worker
+  # gets one job in the RunOnEachWorkerProcess.
+  time.sleep(0.5)
   return fn()
+
 
 def RunOnEachWorkerProcess(fn, * args, **kwargs):
   """Runs a function on each of the pool process."""

--- a/src/harness/reference_models/common/mpool.py
+++ b/src/harness/reference_models/common/mpool.py
@@ -88,14 +88,20 @@ _pool = _DummyPool()
 _num_workers = 0
 
 # External interface
-def Pool():
+def Pool(reinit=False):
   """Returns the worker pool.
 
   It supports routines:
     map()
     apply_async()
   And other `multiprocessing.Pool` routines if not a dummy pool.
+
+  Args:
+    reinit: If True, a brand new pool is created, and the old one discarded.
   """
+  global _pool
+  if reinit and _num_workers:
+    _pool = multiprocessing.Pool(processes=_num_workers)
   return _pool
 
 

--- a/src/harness/reference_models/iap/iap.py
+++ b/src/harness/reference_models/iap/iap.py
@@ -82,8 +82,8 @@ FSS_RBW_HZ = 1*MHZ
 ESC_RBW_HZ = 1*MHZ
 
 # The grid resolution for area based protection entities.
-GWPZ_GRID_RES_ARCSEC = 20
-PPA_GRID_RES_ARCSEC = 20
+GWPZ_GRID_RES_ARCSEC = 2
+PPA_GRID_RES_ARCSEC = 2
 
 
 def iapPointConstraint(protection_point, channels, low_freq, high_freq,

--- a/src/harness/reference_models/iap/iap.py
+++ b/src/harness/reference_models/iap/iap.py
@@ -88,19 +88,12 @@ PPA_GRID_RES_ARCSEC = 2
 
 def iapPointConstraint(protection_point, channels, low_freq, high_freq,
                        grants, fss_info, esc_antenna_info,
-                       region_type, threshold, protection_ent_type,
-                       asas_interference, aggr_interference):
+                       region_type, threshold, protection_ent_type):
   """Computes aggregate interference(Ap and ASASp) from authorized grants.
 
   This routine is applicable for FSS Co-Channel and ESC Sensor protection points,
   and PPA/GWPZ protection areas. It calculates aggregate interference over all
   5MHz channels, and feeds post-IAP assessment of allowed interference margins.
-
-  This routine modifies the `asas_interference` and `aggr_interference`
-  interference container objects of type |interf.AggregateInterferenceOutputFormat|,
-  which holds entries like:
-     {latitude : {longitude : [asas_p(mW/IAPBW),.. ]}}
-     {latitude : {longitude : [a_p(mW/IAPBW),..] }}
 
   Args:
     protection_point: A protection point as a tuple (longitude, latitude).
@@ -113,10 +106,11 @@ def iapPointConstraint(protection_point, channels, low_freq, high_freq,
     region_type: Region type of the protection point: 'URBAN', 'SUBURBAN' or 'RURAL'.
     threshold: The protection threshold (mW).
     protection_ent_type: The entity type (|data.ProtectedEntityType|).
-    asas_interference: The |interf.AggregateInterferenceOutputFormat| interference
-      container for the managing SAS.
-    aggr_interference: The |interf.AggregateInterferenceOutputFormat| interference
-      container for the all SAS: managing SAS and peer SASes.
+
+  Returns:
+    A tuple (latitude, longitude, asas_interference, agg_interference) where:
+      asas_interference: a list of interference (per channel) for managing SAS.
+      agg_interference: a list of total interference (per channel).
   """
   # Get protection constraint of protected entity
   protection_constraint = data.ProtectionConstraint(
@@ -134,12 +128,8 @@ def iapPointConstraint(protection_point, channels, low_freq, high_freq,
       protection_constraint)
 
   if not neighbor_grants:
-    for j in xrange(len(channels)):
-      asas_interference.UpdateAggregateInterferenceInfo(
-          protection_point[1], protection_point[0], 0)
-      aggr_interference.UpdateAggregateInterferenceInfo(
-          protection_point[1], protection_point[0], 0)
-    return
+    return (protection_point[1], protection_point[0],
+            [0] * len(channels), [0] * len(channels))
 
   # Get number of grants, IAP protection threshold and fairshare per channel.
   num_unsatisfied_grants = len(neighbor_grants)
@@ -268,13 +258,8 @@ def iapPointConstraint(protection_point, channels, low_freq, high_freq,
         if not grants_satisfied[grant_idx]:
           grants_eirp[grant_idx] -= 1
 
-  # Update aggregate interference and asas_interference from all the grants
-  # at a protection point, channel
-  for j, interf_val in enumerate(aggr_interf):
-    asas_interference.UpdateAggregateInterferenceInfo(protection_point[1],
-      protection_point[0], asas_interf[j])
-    aggr_interference.UpdateAggregateInterferenceInfo(protection_point[1],
-      protection_point[0], interf_val)
+  # Return the computed data
+  return protection_point[1], protection_point[0], asas_interf, aggr_interf
 
 
 def performIapForEsc(esc_record, sas_uut_fad_object, sas_th_fad_objects):
@@ -312,17 +297,13 @@ def performIapForEsc(esc_record, sas_uut_fad_object, sas_th_fad_objects):
 
   logging.debug('$$$$ Calling ESC Protection $$$$')
   # ESC algorithm
-  asas_interference = interf.getInterferenceObject()
-  aggr_interference = interf.getInterferenceObject()
-  iapPointConstraint(protection_point, protection_channels,
-                     interf.ESC_LOW_FREQ_HZ, interf.ESC_HIGH_FREQ_HZ,
-                     grants, None, esc_antenna_info, None,
-                     esc_iap_threshold, data.ProtectedEntityType.ESC,
-                     asas_interference, aggr_interference)
+  iap_interfs = iapPointConstraint(protection_point, protection_channels,
+                               interf.ESC_LOW_FREQ_HZ, interf.ESC_HIGH_FREQ_HZ,
+                               grants, None, esc_antenna_info, None,
+                               esc_iap_threshold, data.ProtectedEntityType.ESC)
 
   ap_iap_ref = calculatePostIapAggregateInterference(
-      interf.dbToLinear(esc_thresh_q), num_sas,
-      asas_interference, aggr_interference)
+      interf.dbToLinear(esc_thresh_q), num_sas, iap_interfs)
   return ap_iap_ref
 
 
@@ -366,8 +347,6 @@ def performIapForGwpz(gwpz_record, sas_uut_fad_object, sas_th_fad_objects):
   # Get channels over which area incumbent needs partial/full protection
   protection_channels = interf.getProtectedChannels(gwpz_low_freq, gwpz_high_freq)
 
-  asas_interference = interf.getInterferenceObject()
-  aggr_interference = interf.getInterferenceObject()
   logging.debug('$$$$ Calling GWPZ Protection $$$$')
   iapPoint = partial(iapPointConstraint,
                      channels=protection_channels,
@@ -378,15 +357,13 @@ def performIapForGwpz(gwpz_record, sas_uut_fad_object, sas_th_fad_objects):
                      esc_antenna_info=None,
                      region_type=gwpz_region,
                      threshold=gwpz_iap_threshold,
-                     protection_ent_type=data.ProtectedEntityType.GWPZ_AREA,
-                     asas_interference=asas_interference,
-                     aggr_interference=aggr_interference)
+                     protection_ent_type=data.ProtectedEntityType.GWPZ_AREA)
+
   pool = mpool.Pool()
-  pool.map(iapPoint, protection_points)
+  iap_interfs = pool.map(iapPoint, protection_points)
 
   ap_iap_ref = calculatePostIapAggregateInterference(
-      interf.dbToLinear(gwpz_thresh_q), num_sas,
-      asas_interference, aggr_interference)
+      interf.dbToLinear(gwpz_thresh_q), num_sas, iap_interfs)
 
   return ap_iap_ref
 
@@ -449,8 +426,6 @@ def performIapForPpa(ppa_record, sas_uut_fad_object, sas_th_fad_objects,
   # Apply IAP for each protection constraint with a pool of parallel
   # processes.
   logging.debug('$$$$ Calling PPA Protection $$$$')
-  asas_interference = interf.getInterferenceObject()
-  aggr_interference = interf.getInterferenceObject()
   iapPoint = partial(iapPointConstraint,
                      channels=protection_channels,
                      low_freq=ppa_low_freq,
@@ -460,15 +435,13 @@ def performIapForPpa(ppa_record, sas_uut_fad_object, sas_th_fad_objects,
                      esc_antenna_info=None,
                      region_type=ppa_region,
                      threshold=ppa_iap_threshold,
-                     protection_ent_type=data.ProtectedEntityType.PPA_AREA,
-                     asas_interference=asas_interference,
-                     aggr_interference=aggr_interference)
+                     protection_ent_type=data.ProtectedEntityType.PPA_AREA)
+
   pool = mpool.Pool()
-  pool.map(iapPoint, protection_points)
+  iap_interfs = pool.map(iapPoint, protection_points)
 
   ap_iap_ref = calculatePostIapAggregateInterference(
-      interf.dbToLinear(ppa_thresh_q), num_sas,
-      asas_interference, aggr_interference)
+      interf.dbToLinear(ppa_thresh_q), num_sas, iap_interfs)
 
   return ap_iap_ref
 
@@ -509,11 +482,9 @@ def performIapForFssCochannel(fss_record, sas_uut_fad_object, sas_th_fad_objects
     raise ValueError('FSS high frequency should not be less than CBRS high frequency(Hz)')
   protection_channels = interf.getProtectedChannels(fss_low_freq, interf.CBRS_HIGH_FREQ_HZ)
 
-  asas_interference = interf.getInterferenceObject()
-  aggr_interference = interf.getInterferenceObject()
   # FSS Co-channel algorithm
   logging.debug('$$$$ Calling FSS co-channel Protection $$$$')
-  iapPointConstraint(fss_point,
+  iap_interfs = iapPointConstraint(fss_point,
                      protection_channels,
                      fss_low_freq,
                      interf.CBRS_HIGH_FREQ_HZ,
@@ -522,13 +493,10 @@ def performIapForFssCochannel(fss_record, sas_uut_fad_object, sas_th_fad_objects
                      None,
                      None,
                      fss_cochannel_iap_threshold,
-                     data.ProtectedEntityType.FSS_CO_CHANNEL,
-                     asas_interference,
-                     aggr_interference)
+                     data.ProtectedEntityType.FSS_CO_CHANNEL)
 
   ap_iap_ref = calculatePostIapAggregateInterference(
-      interf.dbToLinear(fss_cochannel_thresh_q), num_sas,
-      asas_interference, aggr_interference)
+      interf.dbToLinear(fss_cochannel_thresh_q), num_sas, iap_interfs)
 
   return ap_iap_ref
 
@@ -574,9 +542,8 @@ def performIapForFssBlocking(fss_record, sas_uut_fad_object, sas_th_fad_objects)
   logging.debug('$$$$ Calling FSS blocking Protection $$$$')
   # 5MHz channelization is not required for Blocking protection
   protection_channels = [(interf.CBRS_LOW_FREQ_HZ, fss_low_freq)]
-  asas_interference = interf.getInterferenceObject()
-  aggr_interference = interf.getInterferenceObject()
-  iapPointConstraint(fss_point,
+
+  iap_interfs = iapPointConstraint(fss_point,
                      protection_channels,
                      interf.CBRS_LOW_FREQ_HZ,
                      fss_low_freq,
@@ -585,19 +552,14 @@ def performIapForFssBlocking(fss_record, sas_uut_fad_object, sas_th_fad_objects)
                      None,
                      None,
                      fss_blocking_iap_threshold,
-                     data.ProtectedEntityType.FSS_BLOCKING,
-                     asas_interference,
-                     aggr_interference)
+                     data.ProtectedEntityType.FSS_BLOCKING)
 
   ap_iap_ref = calculatePostIapAggregateInterference(
-      interf.dbToLinear(THRESH_FSS_BLOCKING_DBM_PER_RBW), num_sas,
-      asas_interference, aggr_interference)
+      interf.dbToLinear(THRESH_FSS_BLOCKING_DBM_PER_RBW), num_sas, iap_interfs)
   return ap_iap_ref
 
 
-def calculatePostIapAggregateInterference(q_p, num_sas,
-                                          asas_interference,
-                                          aggr_interference):
+def calculatePostIapAggregateInterference(q_p, num_sas, iap_interfs):
   """Computes post IAP allowed aggregate interference.
 
   Routine to calculate aggregate interference from all the CBSDs managed by the
@@ -606,32 +568,25 @@ def calculatePostIapAggregateInterference(q_p, num_sas,
   Args:
     q_p: Pre IAP threshold value for protection type (mW)
     num_sas: Number of SASs in the peer group
-    asas_interference: The |interf.AggregateInterferenceOutputFormat| interference
-      container for the managing SAS. A dictionary in the format of
-      {latitude : {longitude : [asas_p(mW/IAPBW), asas_p(mW/IAPBW)]}}, where
-      asas_p is aggregate interference calculated within IAPBW by managing SAS using
-      the EIRP obtained from IAP results for that point p for CBSDs managed by the
-      managing SAS. Only grants overlapping IAPBW are used in the calculation
-    aggr_interference: The |interf.AggregateInterferenceOutputFormat| interference
-      container for the managing SAS and peer SASes. Same as `asas_interference`
-      but for all CBSDs managed by all SASes.
+    iap_interfs: A list of tuple
+      (latitude, longitude, asas_interference, agg_interference) where:
+        asas_interference: a list of interference (per channel) for managing SAS.
+        agg_interference: a list of total interference (per channel).
+      The interference is in mW/IAPBW.
 
   Returns:
     ap_iap_ref: The post-IAP allowed interference, as a dict formatted as:
         {latitude : {longitude : [interference(mW/IAPBW), .., interference(mW/IAPBW)]}}
       where the list holds all values per channel of that protection point.
   """
-  ap_iap_ref = {}
-  # Extract dictionary from DictProxy object using _getvalue object method
-  asas_info = asas_interference.GetAggregateInterferenceInfo()._getvalue()
-  a_p_info = aggr_interference.GetAggregateInterferenceInfo()._getvalue()
+  if not isinstance(iap_interfs, list):
+    iap_interfs = [iap_interfs]
 
-  # Compute AP_IAP_Ref
-  for latitude, a_p_ch in a_p_info.items():
-    ap_iap_ref[latitude] = {}
-    for longitude, a_p_list in a_p_ch.items():
-      ap_iap_ref[latitude][longitude] = [
-          ((q_p - a_p) / num_sas + asas_info[latitude][longitude][idx])
-          for idx, a_p in enumerate(a_p_list)]
+  ap_iap_ref = {}
+  for lat, lon, asas_interfs, agg_interfs in iap_interfs:
+    if lat not in ap_iap_ref: ap_iap_ref[lat] = {}
+    ap_iap_ref[lat][lon] = [
+        ((q_p - aggr_interf) / num_sas + asas_interf)
+        for aggr_interf, asas_interf in zip(asas_interfs, agg_interfs)]
 
   return ap_iap_ref

--- a/src/harness/reference_models/iap/iap.py
+++ b/src/harness/reference_models/iap/iap.py
@@ -82,8 +82,8 @@ FSS_RBW_HZ = 1*MHZ
 ESC_RBW_HZ = 1*MHZ
 
 # The grid resolution for area based protection entities.
-GWPZ_GRID_RES_ARCSEC = 2
-PPA_GRID_RES_ARCSEC = 2
+GWPZ_GRID_RES_ARCSEC = 20
+PPA_GRID_RES_ARCSEC = 20
 
 
 def iapPointConstraint(protection_point, channels, low_freq, high_freq,
@@ -586,7 +586,7 @@ def calculatePostIapAggregateInterference(q_p, num_sas, iap_interfs):
   for lat, lon, asas_interfs, agg_interfs in iap_interfs:
     if lat not in ap_iap_ref: ap_iap_ref[lat] = {}
     ap_iap_ref[lat][lon] = [
-        ((q_p - aggr_interf) / num_sas + asas_interf)
-        for aggr_interf, asas_interf in zip(asas_interfs, agg_interfs)]
+        (float(q_p - aggr_interf) / num_sas + asas_interf)
+        for asas_interf, aggr_interf in zip(asas_interfs, agg_interfs)]
 
   return ap_iap_ref

--- a/src/harness/reference_models/interference/aggregate_interference.py
+++ b/src/harness/reference_models/interference/aggregate_interference.py
@@ -48,6 +48,18 @@ GWPZ_GRID_RES_ARCSEC = 2
 PPA_GRID_RES_ARCSEC = 2
 
 
+def InterferenceDict(data_list):
+  """Creates an interferenceReturns a double dict from a list of lat,lng, interferences."""
+  if not isinstance(data_list, list):
+    data_list = [data_list]
+  result = {}
+  for lat, lon, data in data_list:
+    if lat not in result: result[lat] = {}
+    result[lat][lon] = data
+
+  return result
+
+
 def convertAndSumInterference(cbsd_interference_list):
   """Converts interference in dBm to mW to calculate aggregate interference"""
   interferences_in_dbm = np.array(cbsd_interference_list)
@@ -56,18 +68,11 @@ def convertAndSumInterference(cbsd_interference_list):
 
 def aggregateInterferenceForPoint(protection_point, channels, grants,
                                   fss_info, esc_antenna_info,
-                                  protection_ent_type, region_type,
-                                  aggr_interference):
+                                  protection_ent_type, region_type):
   """Computes the aggregate interference for a protection point.
 
   This routine is invoked to calculate aggregate interference for ESC sensor,
   FSS Co-channel/Blocking and PPA/GWPZ protection areas.
-
-  It updates the `aggr_interference` dictionary object with the aggregate
-  interference (in mW) for each protected channel of a protection point.
-  The dictionary format is:
-      {latitude : {longitude : [aggr_interference(mW), ..., aggr_interference(mW)]}},
-  where the inner list holds all aggregated interference for the various channels.
 
   Args:
     protection_point: The location of a protected entity as (longitude, latitude) tuple.
@@ -77,7 +82,10 @@ def aggregateInterferenceForPoint(protection_point, channels, grants,
     esc_antenna_info: ESC antenna information of type |data.EscInformation| (optional).
     protection_ent_type: The entity type (|data.ProtectedEntityType|).
     region: Region type of the protection point: 'URBAN', 'SUBURBAN' or 'RURAL'.
-    aggr_interference : An object of class type |AggregateInterferenceOutputFormat|.
+
+  Returns:
+    A tuple (latitude, longitude, interferences) where interferences is a list
+    of interference per channel.
   """
 
   # Get all the grants inside neighborhood of the protection entity
@@ -86,11 +94,9 @@ def aggregateInterferenceForPoint(protection_point, channels, grants,
 
   if not grants_inside:
     # We need one entry per channel, even if they're all zero.
-    for channel in channels:
-      aggr_interference.UpdateAggregateInterferenceInfo(
-          protection_point[1], protection_point[0], 0)
-    return
+    return protection_point[1], protection_point[0], [0]*len(channels)
 
+  interferences = []
   for channel in channels:
     # Get protection constraint over 5MHz channel range
     protection_constraint = data.ProtectionConstraint(
@@ -103,10 +109,7 @@ def aggregateInterferenceForPoint(protection_point, channels, grants,
     neighborhood_grants = interf.findOverlappingGrants(grants_inside, protection_constraint)
 
     if not neighborhood_grants:
-      # As number of neighborhood grants are zero, setting
-      # aggr_interference to '0' for a protection_constraint
-      aggr_interference.UpdateAggregateInterferenceInfo(
-          protection_point[1], protection_point[0], 0)
+      interferences.append(0)
       continue
 
     cbsd_interferences = [
@@ -115,8 +118,9 @@ def aggregateInterferenceForPoint(protection_point, channels, grants,
         for grant in neighborhood_grants]
 
     total_interference = convertAndSumInterference(cbsd_interferences)
-    aggr_interference.UpdateAggregateInterferenceInfo(
-        protection_point[1], protection_point[0], total_interference)
+    interferences.append(total_interference)
+
+  return protection_point[1], protection_point[0], interferences
 
 
 def calculateAggregateInterferenceForFssCochannel(fss_record, grants):
@@ -141,23 +145,18 @@ def calculateAggregateInterferenceForFssCochannel(fss_record, grants):
 
   protection_channels = interf.getProtectedChannels(fss_low_freq, interf.CBRS_HIGH_FREQ_HZ)
 
-  aggr_interference = interf.getInterferenceObject()
-
   logging.info(
       'Computing aggregateInterferenceForPoint for FSS Coch: channels (%s), grants (%s), point (%s), fss_info (%s)',
       protection_channels, grants, fss_point, fss_info)
 
-  aggregateInterferenceForPoint(fss_point,
+  interferences = aggregateInterferenceForPoint(fss_point,
                                 protection_channels,
                                 grants,
                                 fss_info,
                                 None,
                                 data.ProtectedEntityType.FSS_CO_CHANNEL,
-                                None,
-                                aggr_interference)
-
-  # Gets the aggregate interference dict content
-  return aggr_interference.GetAggregateInterferenceContent()
+                                None)
+  return InterferenceDict(interferences)
 
 
 def calculateAggregateInterferenceForFssBlocking(fss_record, grants):
@@ -189,23 +188,19 @@ def calculateAggregateInterferenceForFssBlocking(fss_record, grants):
   # FSS TT&C Blocking Algorithm
   protection_channels = [(interf.CBRS_LOW_FREQ_HZ, fss_low_freq)]
 
-  aggr_interference = interf.getInterferenceObject()
-
   logging.info(
       'Computing aggregateInterferenceForPoint for FSS Blocking: channels (%s), grants (%s), point (%s), fss_info (%s)',
       protection_channels, grants, fss_point, fss_info)
 
-  aggregateInterferenceForPoint(fss_point,
+  interferences = aggregateInterferenceForPoint(fss_point,
                                 protection_channels,
                                 grants,
                                 fss_info,
                                 None,
                                 data.ProtectedEntityType.FSS_BLOCKING,
-                                None,
-                                aggr_interference)
+                                None)
 
-  # Gets the aggregate interference dict content
-  return aggr_interference.GetAggregateInterferenceContent()
+  return InterferenceDict(interferences)
 
 
 def calculateAggregateInterferenceForEsc(esc_record, grants):
@@ -227,23 +222,19 @@ def calculateAggregateInterferenceForEsc(esc_record, grants):
   protection_channels = interf.getProtectedChannels(interf.ESC_LOW_FREQ_HZ,
                                                     interf.ESC_HIGH_FREQ_HZ)
 
-  aggr_interference = interf.getInterferenceObject()
-
   logging.info(
       'Computing aggregateInterferenceForPoint for ESC: channels (%s), grants (%s), point (%s), antenna_info (%s)',
       protection_channels, grants, protection_point, esc_antenna_info)
 
-  aggregateInterferenceForPoint(protection_point,
+  interferences = aggregateInterferenceForPoint(protection_point,
                                 protection_channels,
                                 grants,
                                 None,
                                 esc_antenna_info,
                                 data.ProtectedEntityType.ESC,
-                                None,
-                                aggr_interference)
+                                None)
 
-  # Gets the aggregate interference dict content
-  return aggr_interference.GetAggregateInterferenceContent()
+  return InterferenceDict(interferences)
 
 
 def calculateAggregateInterferenceForGwpz(gwpz_record, grants):
@@ -273,8 +264,6 @@ def calculateAggregateInterferenceForGwpz(gwpz_record, grants):
 
   # Calculate aggregate interference from each protection constraint with a
   # pool of parallel processes.
-  aggr_interference = interf.getInterferenceObject()
-
   logging.info(
       'Computing aggregateInterferenceForPoint for PPA (%s), channels (%s), grants (%s), region_type (%s) - nPoints (%d)',
       gwpz_record, protection_channels, grants, gwpz_region, len(protection_points))
@@ -285,14 +274,12 @@ def calculateAggregateInterferenceForGwpz(gwpz_record, grants):
                              fss_info=None,
                              esc_antenna_info=None,
                              protection_ent_type=data.ProtectedEntityType.GWPZ_AREA,
-                             region_type=gwpz_region,
-                             aggr_interference=aggr_interference)
+                             region_type=gwpz_region)
 
   pool = mpool.Pool()
-  pool.map(interfCalculator, protection_points)
+  interferences = pool.map(interfCalculator, protection_points)
+  return InterferenceDict(interferences)
 
-  # Gets the aggregate interference dict content
-  return aggr_interference.GetAggregateInterferenceContent()
 
 
 def calculateAggregateInterferenceForPpa(ppa_record, pal_records, grants):
@@ -332,8 +319,6 @@ def calculateAggregateInterferenceForPpa(ppa_record, pal_records, grants):
   # Get channels over which area incumbent needs partial/full protection
   protection_channels = interf.getProtectedChannels(ppa_low_freq, ppa_high_freq)
 
-  aggr_interference = interf.getInterferenceObject()
-
   logging.info(
       'Computing aggregateInterferenceForPoint for PPA (%s), channels (%s), grants (%s), region_type (%s) - nPoints (%d)',
       ppa_record, protection_channels, grants, ppa_region, len(protection_points))
@@ -346,11 +331,8 @@ def calculateAggregateInterferenceForPpa(ppa_record, pal_records, grants):
                              fss_info=None,
                              esc_antenna_info=None,
                              protection_ent_type=data.ProtectedEntityType.PPA_AREA,
-                             region_type=ppa_region,
-                             aggr_interference=aggr_interference)
+                             region_type=ppa_region)
 
   pool = mpool.Pool()
-  pool.map(interfCalculator, protection_points)
-
-  # Gets the aggregate interference dict content
-  return aggr_interference.GetAggregateInterferenceContent()
+  interferences = pool.map(interfCalculator, protection_points)
+  return InterferenceDict(interferences)

--- a/src/harness/reference_models/tools/benchmark/prof_agg_interf.py
+++ b/src/harness/reference_models/tools/benchmark/prof_agg_interf.py
@@ -1,0 +1,206 @@
+#    Copyright 2018 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""Runs the aggregate interference code under profiler.
+
+This script creates several profile output:
+  profile-<idx>.out
+where idx:
+  0 is the main process
+  1-N: for each workers
+
+Note: script derived from the aggregate_interference_example.py
+"""
+
+import json
+import os
+import time
+import cProfile
+
+from reference_models.common import data
+from reference_models.common import mpool
+from reference_models.interference import interference as interf
+from reference_models.interference import aggregate_interference
+from reference_models.tools import profpool
+
+# Number of parallel processes
+NUM_PROCESS = 4
+
+def CvtToList(data):
+  """Convert interf to a sorted list suitable for comparison."""
+  out_dict = {}
+  for k0, v0 in data.items():
+    for k1, v1 in v0.items():
+      out_dict[(k0, k1)] = v1
+
+  out_list = list(out_dict.items())
+  out_list.sort()
+  return out_list
+
+if __name__ == '__main__':
+
+  #=======================================
+  # Decrease resolution of GWPZ/PPA for reducing time
+  aggregate_interference.GWPZ_GRID_RES_ARCSEC = 20
+  aggregate_interference.PPA_GRID_RES_ARCSEC = 20
+
+  #=======================================
+  # Configure the multiprocess pool with profiler enabled
+  pool = profpool.PoolWithProfiler(NUM_PROCESS)
+  mpool.Configure(pool=pool)
+  prof0 = cProfile.Profile()
+
+  #=======================================
+  # Data directory
+  _BASE_DATA_DIR = os.path.join(os.path.dirname(__file__),
+                                '../../interference/test_data')
+
+  # Populate a list of CBSD registration requests
+  cbsd_filename = ['cbsd_0.json',
+                   'cbsd_1.json', 'cbsd_2.json', 'cbsd_3.json',
+                   'cbsd_4.json', 'cbsd_5.json', 'cbsd_6.json',
+                   'cbsd_7.json', 'cbsd_8.json', 'cbsd_9.json',
+                   'cbsd_10.json', 'cbsd_11.json', 'cbsd_12.json',
+                   'cbsd_13.json', 'cbsd_14.json', 'cbsd_15.json',
+                   'cbsd_16.json', 'cbsd_17.json', 'cbsd_18.json',
+                   'cbsd_19.json', 'cbsd_20.json', 'cbsd_21.json',
+                   'cbsd_22.json', 'cbsd_23.json'
+                   ]
+  cbsd_list = []
+  for cbsd_file in cbsd_filename:
+    cbsd_record = json.load(open(os.path.join(_BASE_DATA_DIR, cbsd_file)))
+    cbsd_list.append(cbsd_record)
+
+  # Populate FSS
+  fss_filename = ['fss_0.json', 'fss_1.json']
+  fss_list = []
+  for fss_file in fss_filename:
+    fss_record = json.load(open(os.path.join(_BASE_DATA_DIR, fss_file)))
+    fss_list.append(fss_record)
+
+  # Populate ESC
+  esc_filename = ['esc_0.json']
+  esc_list = []
+  for esc_file in esc_filename:
+    esc_record = json.load(
+      open(os.path.join(_BASE_DATA_DIR, esc_file)))
+    esc_list.append(esc_record)
+
+  # Populate GWPZ
+  gwpz_filename = ['gwpz_0.json', 'gwpz_1.json']
+  gwpz_list = []
+  for gwpz_file in gwpz_filename:
+    gwpz_record = json.load(
+        open(os.path.join(_BASE_DATA_DIR, gwpz_file)))
+    gwpz_list.append(gwpz_record)
+
+  # Populate PPA/PAL
+  ppa_filename = ['ppa_0.json', 'ppa_1.json', 'ppa_2.json', 'ppa_3.json']
+  ppa_list = []
+  for ppa_file in ppa_filename:
+    # load and inject PPA data with Overlapping Frequency of CBSD
+    ppa_record = json.load(open(os.path.join(_BASE_DATA_DIR, ppa_file)))
+    ppa_list.append(ppa_record)
+
+  pal_filename = ['pal_0.json', 'pal_1.json', 'pal_2.json', 'pal_3.json']
+  ppa_filename = []
+  pal_list = []
+  for pal_file in pal_filename:
+    pal_record = json.load(open(os.path.join(_BASE_DATA_DIR, pal_file)))
+    pal_list.append(pal_record)
+
+  #=======================================
+  # Determine aggregate interference caused by the grants in the neighborhood
+  start_time = time.time()
+  prof0.enable()
+
+  #--- FSS ---
+  for fss_record in fss_list:
+    # Get the frequency range of the FSS
+    fss_freq_range = fss_record['record']['deploymentParam'][0]\
+        ['operationParam']['operationFrequencyRange']
+    fss_low_freq = fss_freq_range['lowFrequency']
+    fss_high_freq = fss_freq_range['highFrequency']
+
+    # Get FSS T&C Flag value
+    fss_ttc_flag = fss_record['ttc']
+
+    # FSS Passband is between 3600 and 4200
+    if (fss_low_freq >= interf.FSS_LOW_FREQ_HZ and
+        fss_low_freq < interf.CBRS_HIGH_FREQ_HZ):
+      fss_cochannel_aggr_interference = aggregate_interference.\
+        calculateAggregateInterferenceForFssCochannel(
+            fss_record, data.getAllGrantInfoFromCbsdDataDump(cbsd_list))
+      print('Aggregate Interference (mW) output at FSS co-channel: %s\n'
+            % (CvtToList(fss_cochannel_aggr_interference)))
+      fss_blocking_aggr_interference = aggregate_interference.\
+        calculateAggregateInterferenceForFssBlocking(
+            fss_record, data.getAllGrantInfoFromCbsdDataDump(cbsd_list))
+      print('\nAggregate Interference (mW) output at FSS blocking: %s\n'
+            % (CvtToList(fss_blocking_aggr_interference)))
+
+    # FSS Passband is between 3700 and 4200 and TT&C flag is set to TRUE
+    elif (fss_low_freq >= interf.FSS_TTC_LOW_FREQ_HZ and
+          fss_high_freq <= interf.FSS_TTC_HIGH_FREQ_HZ and
+          fss_ttc_flag is True):
+      fss_blocking_aggr_interference = aggregate_interference.\
+        calculateAggregateInterferenceForFssBlocking(
+            fss_record, data.getAllGrantInfoFromCbsdDataDump(cbsd_list))
+      print('\nAggregate Interference (mW) output at FSS blocking: %s\n'
+            % (CvtToList(fss_blocking_aggr_interference)))
+
+  #--- ESC ---
+  for esc_record in esc_list:
+    esc_aggr_interference = aggregate_interference.\
+      calculateAggregateInterferenceForEsc(
+          esc_record, data.getAllGrantInfoFromCbsdDataDump(cbsd_list))
+    print('\nAggregate Interference (mW) output at ESC: %s\n'
+          % (CvtToList(esc_aggr_interference)))
+
+  #--- GWPZ ---
+  for gwpz_record in gwpz_list:
+    gwpz_aggr_interference = aggregate_interference.\
+      calculateAggregateInterferenceForGwpz(
+          gwpz_record, data.getAllGrantInfoFromCbsdDataDump(cbsd_list))
+    print('\nAggregate Interference (mW) output at GWPZ: %s\n'
+          % (CvtToList(gwpz_aggr_interference)))
+
+  #--- PPA ---
+  for ppa_record in ppa_list:
+    ppa_aggr_interference = aggregate_interference.\
+      calculateAggregateInterferenceForPpa(
+          ppa_record, pal_list,
+          data.getAllGrantInfoFromCbsdDataDump(cbsd_list, ppa_record=ppa_record))
+    print('\nAggregate Interference (mW) output at PPA: %s\n'
+          % (CvtToList(ppa_aggr_interference)))
+
+  prof0.disable()
+  end_time = time.time()
+  #=======================================
+  print('\nComputation time: %.4f\n' % (end_time - start_time))
+  print('Saving profile')
+  prof0.dump_stats('profile-0m.out')
+  pool.dump_stats()
+
+  #=======================================
+  # Print on screen basic data
+  import pstats
+  print('******* Profiling on main process *******')
+  p0 = pstats.Stats('profile-0m.out')
+  p0.sort_stats('cumulative')
+  p0.print_stats(20)
+  print('******* Profiling on worker1 *******')
+  p1 = pstats.Stats('profile-1.out')
+  p1.sort_stats('cumulative')
+  p1.print_stats(20)

--- a/src/harness/reference_models/tools/benchmark/prof_agg_interf.py
+++ b/src/harness/reference_models/tools/benchmark/prof_agg_interf.py
@@ -52,8 +52,8 @@ if __name__ == '__main__':
 
   #=======================================
   # Decrease resolution of GWPZ/PPA for reducing time
-  aggregate_interference.GWPZ_GRID_RES_ARCSEC = 20
-  aggregate_interference.PPA_GRID_RES_ARCSEC = 20
+  aggregate_interference.GWPZ_GRID_RES_ARCSEC = 10
+  aggregate_interference.PPA_GRID_RES_ARCSEC = 10
 
   #=======================================
   # Configure the multiprocess pool with profiler enabled
@@ -173,8 +173,8 @@ if __name__ == '__main__':
     gwpz_aggr_interference = aggregate_interference.\
       calculateAggregateInterferenceForGwpz(
           gwpz_record, data.getAllGrantInfoFromCbsdDataDump(cbsd_list))
-    print('\nAggregate Interference (mW) output at GWPZ: %s\n'
-          % (CvtToList(gwpz_aggr_interference)))
+    print('\nAggregate Interference (mW) output at GWPZ: \n' +
+          str(CvtToList(gwpz_aggr_interference))[0:400])
 
   #--- PPA ---
   for ppa_record in ppa_list:
@@ -182,8 +182,8 @@ if __name__ == '__main__':
       calculateAggregateInterferenceForPpa(
           ppa_record, pal_list,
           data.getAllGrantInfoFromCbsdDataDump(cbsd_list, ppa_record=ppa_record))
-    print('\nAggregate Interference (mW) output at PPA: %s\n'
-          % (CvtToList(ppa_aggr_interference)))
+    print('\nAggregate Interference (mW) output at PPA: \n' +
+          str(CvtToList(gwpz_aggr_interference))[0:400])
 
   prof0.disable()
   end_time = time.time()

--- a/src/harness/reference_models/tools/benchmark/prof_prop.py
+++ b/src/harness/reference_models/tools/benchmark/prof_prop.py
@@ -1,0 +1,69 @@
+#    Copyright 2017 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""Script for profiling the propagation model timing.
+
+Usage:
+  To profile per function:
+     python -m cProfile -s cumulative prof_prop.py > fn_profile.txt
+
+  To profile per line:
+    - put @profile decorator on functions to be profiled
+    - run:
+      kernprof -l -v prof_prop.py > line_profile.txt
+"""
+
+from reference_models.propagation import wf_itm
+from reference_models.propagation import wf_hybrid
+from reference_models.geo import drive
+from reference_models.geo import vincenty
+
+# Tx location
+cbsd_lat = 40.5
+cbsd_lon = -90.5
+
+# Rx location
+max_distance = 300
+distance = 60
+bearing = 90
+freq_mhz = 3625
+rx_lat, rx_lng, _ = vincenty.GeodesicPoints(cbsd_lat,cbsd_lon,
+                                            distance, bearing)
+
+def CalcHybrid(rel, rx_lat, rx_lng):
+  res = wf_hybrid.CalcHybridPropagationLoss(
+      cbsd_lat, cbsd_lon, 10,
+      rx_lat, rx_lng, 1.5,
+      False, rel, freq_mhz, 'SUBURBAN')
+  return res
+
+def CalcItm(rel, rx_lat, rx_lng):
+  res = wf_itm.CalcItmPropagationLoss(
+      cbsd_lat, cbsd_lon, 10,
+      rx_lat, rx_lng, 1.5,
+      False, rel, freq_mhz)
+  return res
+
+if __name__ == '__main__':
+  # First calc to load the terrain data in cache
+  print '# Pre-Loading the terrain'
+  res = CalcItm(0.5, rx_lat, rx_lng)
+  print '## Initial driver report'
+  drive.terrain_driver.stats.Report()
+  print ''
+  print '# Propagation calculation'
+  for k in xrange(1000):
+    CalcItm(-1, rx_lat, rx_lng)
+  print '## Final driver report'
+  drive.terrain_driver.stats.Report()

--- a/src/harness/reference_models/tools/profpool.py
+++ b/src/harness/reference_models/tools/profpool.py
@@ -1,0 +1,88 @@
+#    Copyright 2018 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""Multiprocessing pool with profiling abilities.
+
+Standard program profiling can usually be done with:
+  python -m cProfile -s cumulative <your_script.py>
+However this profiles only the main process. To profile
+each worker thread this module provides a drop-in replacement
+of a multiprocessibf pool with profiling enabled.
+
+This is to be used only during code analys and dev as it
+introduces running overhead.
+
+Usage:
+  # Create a special pool with profiler enabled
+  pool = profpool.PoolWithProfiler(processes=4)
+
+  # Configure the test harness mpool manager
+  mpool.Configure(pool=pool)
+
+  ... run the test cases to profile ...
+
+  # Dump the profile output
+  pool.dump_stats()
+
+  # To print the profiling data
+  import pstats
+  p = pstats.Stats('profile-<pid>.stats')
+  p.sort_stats('cumulative')
+  p.print_stats(20) # 20 most significant lines
+"""
+
+import cProfile
+import os
+import multiprocessing
+
+# The profiler object
+_prof = None
+
+def _process_profile_init():
+  """Initialize the process profiler."""
+  global _prof
+  _prof = cProfile.Profile()
+
+
+class _FnRunnerWithProfiler(object):
+  """A functor to run a function within profiler."""
+  def __init__(self, fn):
+    self.fn = fn
+  def __call__(self, arg):
+    _prof.enable()
+    res = self.fn(arg)
+    _prof.disable()
+    return res
+
+
+def _dump_stats(idx):
+  """Dumps the stats."""
+  _prof.dump_stats('profile-%s.out' % idx)
+
+
+class PoolWithProfiler(object):
+  """A multiprocessing pool with profiling on each worker."""
+  def __init__(self, processes):
+    self.pool = multiprocessing.Pool(processes=processes,
+                                     initializer=_process_profile_init)
+    self.num_processes = processes
+
+  def map(self, fn, iterable, chunksize=None):
+    return self.pool.map(_FnRunnerWithProfiler(fn), iterable, chunksize=chunksize)
+
+  def apply_async(self, fn, args=(), kwds={}, callback=None):
+    return self.pool.apply_async(_FnRunnerWithProfiler(fn), args, kwds)
+
+  def dump_stats(self):
+    self.pool.map(_dump_stats, range(1, self.num_processes+1), chunksize=1)


### PR DESCRIPTION
+ Remove the use of the mp Manager, and using the pool mechanism instead.
Some profiling of the Manager as used in the code shows that it does not
scale at all, as it constantly fork new process and lock during
contention when updating the shared dict (plus IPC overheads).
As a consequence, beyond a few processes, the actual running time is
constant or actually increase. All gains from parallel calculation is
lost on the shared objects management, which can take typically:
  - 60% for 4 processes 
  - 85% for 12 processes
  - and so on..

Using simply the regular returned value from pool.map is much more
scalable, in addition of being simple.

+ Add profile script in tools/benchmark + a `profpool.py` utility in tools/
to enable the ability to profile each process. To run, simply launch the
tools/benchmark/prof_agg_interp.py script.
 