### PR TITLE
Updates the cert generation scripts:

### DIFF
--- a/src/harness/certs/generate_fake_certs.sh
+++ b/src/harness/certs/generate_fake_certs.sh
@@ -600,7 +600,7 @@ cat ca.cert crl/ca_sxs11.crl > ca_crl_chain_sxs11.cert
 cat crl/revoked_cbsd_ca.crl crl/revoked_sas_ca.crl crl/revoked_proxy_ca.crl crl/root_ca.crl > crl/ca_sxs16.crl
 cat ca.cert crl/ca_sxs16.crl > ca_crl_chain_sxs16.cert
 
-# Cleanup: remove all files not directly used by the testcases.
-rm -rf root
+# Cleanup: remove all files not directly used by the testcases or other scripts.
 rm *.csr
+
 

--- a/src/harness/certs/generate_sas_cert.sh
+++ b/src/harness/certs/generate_sas_cert.sh
@@ -6,13 +6,44 @@ if [ -z "$1" ]
     exit
 fi
 
-
 echo -e "\n\nGenerating 'SAS cert' certificate/key with CN=$1"
+
+echo "Subject Alt Name should be of the form: 'DNS:foo.bar.com,DNS:bar.com'"
+if [ -z "$2" ]
+  then
+    echo "Warning: no Subject Alt Name specified."
+    echo "[san_ext]" > san.cnf
+  else
+    echo "Using SAN = $2"
+    echo -e "[san_ext]\nsubjectAltName=$2" > san.cnf
+fi
+
+echo "Using the following SAN config:"
+cat san.cnf
+
+echo "Generating RSA cert"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_req -config ../../../cert/openssl.cnf \
-    -out sas.csr -keyout sas.key \
+    -out sas_uut.csr -keyout sas_uut.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=$1"
-openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas.csr \
-    -out sas.cert -outdir ./root \
+openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas_uut.csr \
+    -out sas_uut.cert -outdir ./root \
     -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
-    -batch -notext -create_serial -utf8 -days 1185 -md sha384
+    -batch -notext -create_serial -utf8 -days 1185 -md sha384 \
+    -extfile san.cnf -extensions san_ext
+
+echo "Generating ECC cert"
+openssl ecparam -genkey -out sas_uut-ecc.key -name secp521r1
+openssl req -new -nodes \
+    -reqexts sas_req -config ../../../cert/openssl.cnf \
+    -out sas_uut-ecc.csr -key sas_uut-ecc.key \
+    -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=$1"
+openssl ca -cert sas-ecc_ca.cert -keyfile private/sas-ecc_ca.key -in sas_uut-ecc.csr \
+    -out sas_uut-ecc.cert -outdir ./root \
+    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
+    -batch -notext -create_serial -utf8 -days 1185 -md sha384 \
+    -extfile san.cnf -extensions san_ext
+
+# Clean up.
+rm san.cnf
+


### PR DESCRIPTION
(1) Fixes the problem where root/ was deleted in generate_fake_certs.sh but required by generate_sas_cert.sh.
(2) Adds SAN support to generate_sas_cert.sh.
(3) Now also generates an ECC cert for SAS UUT.
(4) Fixes the filenames of the SAS UUT certs so that they do not overwrite certs generated by generate_fake_certs.sh.