### PR TITLE
Fix IPR2 issue caused by temporary DPA KML

### DIFF
--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -418,7 +418,7 @@ def GetDpaProtectedChannels(freq_ranges_mhz, is_portal_dpa=False):
   channels = set()
   for freq_range in freq_ranges_mhz:
     min_freq = int(freq_range[0] / DPA_CHANNEL_BANDWIDTH) * DPA_CHANNEL_BANDWIDTH
-    max_freq = int(freq_range[1] / DPA_CHANNEL_BANDWIDTH) * DPA_CHANNEL_BANDWIDTH
+    max_freq = freq_range[1]
     freqs = np.arange(min_freq, max_freq, DPA_CHANNEL_BANDWIDTH)
     for freq in freqs:
       channels.add((freq, freq + DPA_CHANNEL_BANDWIDTH))

--- a/src/harness/reference_models/dpa/dpa_mgr_test.py
+++ b/src/harness/reference_models/dpa/dpa_mgr_test.py
@@ -1,0 +1,56 @@
+#    Copyright 2018 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+
+import os
+import unittest
+import numpy as np
+
+from reference_models.tools import testutils
+from reference_models.tools import entities
+from reference_models.propagation import wf_itm
+
+from reference_models.dpa import dpa_mgr
+
+
+class TestDpa(unittest.TestCase):
+
+  def setUp(self):
+    self.original_itm = wf_itm.CalcItmPropagationLoss
+
+  def tearDown(self):
+    wf_itm.CalcItmPropagationLoss = self.original_itm
+
+  def test_channelization(self):
+    channels = dpa_mgr.GetDpaProtectedChannels([(3550, 3650)], is_portal_dpa=False)
+    self.assertListEqual(channels, [(f, f+10) for f in range(3550, 3650, 10)])
+    channels = dpa_mgr.GetDpaProtectedChannels([(3500, 3650)], is_portal_dpa=False)
+    self.assertListEqual(channels, [(f, f+10) for f in range(3540, 3650, 10)])
+    channels = dpa_mgr.GetDpaProtectedChannels([(3500, 3650)], is_portal_dpa=True)
+    self.assertListEqual(channels, [(f, f+10) for f in range(3500, 3650, 10)])
+    channels = dpa_mgr.GetDpaProtectedChannels([(3500, 3550), (3550, 3650)],
+                                               is_portal_dpa=True)
+    self.assertListEqual(channels, [(f, f+10) for f in range(3500, 3650, 10)])
+    channels = dpa_mgr.GetDpaProtectedChannels([(3500, 3600), (3550, 3650)],
+                                               is_portal_dpa=True)
+    self.assertListEqual(channels, [(f, f+10) for f in range(3500, 3650, 10)])
+    channels = dpa_mgr.GetDpaProtectedChannels([(3572, 3585)], is_portal_dpa=False)
+    self.assertListEqual(channels, [(3570, 3580), (3580, 3590)])
+    channels = dpa_mgr.GetDpaProtectedChannels([(3572, 3575)], is_portal_dpa=False)
+    self.assertListEqual(channels, [(3570, 3580)])
+
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/src/harness/reference_models/geo/zones.py
+++ b/src/harness/reference_models/geo/zones.py
@@ -401,6 +401,10 @@ def _LoadDpaZones(kml_path, properties, fix_invalid=True):
   for name, zone in dpa_zones.items():
     # CatA neighborhood specified with default value if not in file,
     # so this is managed in the declaration.
+    # However since the KML are currently using NaN for that param, manage
+    # the NaN case here.
+    if np.isnan(zone.catANeighborhoodDistanceKm):
+      zone.catANeighborhoodDistanceKm = 150
     # Others seems mandatory:
     # CatB not yet defined set as NaN
     if np.isnan(zone.catBNeighborhoodDistanceKm):

--- a/src/harness/reference_models/geo/zones.py
+++ b/src/harness/reference_models/geo/zones.py
@@ -71,6 +71,8 @@ USBORDER_FILE = 'usborder.kmz'
 URBAN_AREAS_FILE = 'Urban_Areas_3601.kmz'
 USCANADA_BORDER_FILE = 'uscabdry_sampled.kmz'
 
+# The constants
+DPA_CATA_DEFAULT_NEIGHBOR_DIST = 150
 
 # A frequency splitter - used as DPA properties converter.
 def _SplitFreqRange(freq_range):
@@ -103,7 +105,7 @@ COASTAL_DPA_PROPERTIES = [('freqRangeMHz', _SplitFreqRange, None),
                           ('antennaBeamwidthDeg', float, 3.),
                           ('minAzimuthDeg', float, 0.),
                           ('maxAzimuthDeg', float, 360.),
-                          ('catANeighborhoodDistanceKm', float, 150),
+                          ('catANeighborhoodDistanceKm', float, DPA_CATA_DEFAULT_NEIGHBOR_DIST),
                           ('catBNeighborhoodDistanceKm', float, None),
                           ('catAOOBNeighborhoodDistanceKm', float, float('nan')),
                           ('catBOOBNeighborhoodDistanceKm', float, float('nan'))]
@@ -115,7 +117,7 @@ PORTAL_DPA_PROPERTIES = [('freqRangeMHz', _SplitFreqRange, None),
                          ('antennaBeamwidthDeg', float, None),
                          ('minAzimuthDeg', float, 0),
                          ('maxAzimuthDeg', float, 360),
-                         ('catANeighborhoodDistanceKm', float, 150),
+                         ('catANeighborhoodDistanceKm', float, DPA_CATA_DEFAULT_NEIGHBOR_DIST),
                          ('catBNeighborhoodDistanceKm', float, None),
                          ('catAOOBNeighborhoodDistanceKm', float, float('nan')),
                          ('catBOOBNeighborhoodDistanceKm', float, float('nan')),
@@ -404,7 +406,7 @@ def _LoadDpaZones(kml_path, properties, fix_invalid=True):
     # However since the KML are currently using NaN for that param, manage
     # the NaN case here.
     if np.isnan(zone.catANeighborhoodDistanceKm):
-      zone.catANeighborhoodDistanceKm = 150
+      zone.catANeighborhoodDistanceKm = DPA_CATA_DEFAULT_NEIGHBOR_DIST
     # Others seems mandatory:
     # CatB not yet defined set as NaN
     if np.isnan(zone.catBNeighborhoodDistanceKm):


### PR DESCRIPTION
DPA KML are not yet finalized in the sense that:
  - all mandatory OOB neighbor distances are currently set as NaN
  - the catA optional distance is also set to NaN instead of either being specified or left blank

This second point means that the code was using a NaN distance for CatA, and this breaks IPR2: 
you then have CatA CBSD in Oregon being in neighborhood of east coast DPA. 
Running such long range path loss calculation is extremely slow obviously as a lot of terrain tiles need to be loaded.

In addition fixed the channelization of the DPA channel for the case where the DPA bandwidth are not multiple of 10MHz. Although they are all in the current DPA KML, the original list of inland DPAs had radar operating only in small frequency band of few MHz. This change will support these cases if they are provided back in future portal DPA update.