### PR TITLE
Fix xPR tests for interference check when no peer SAS.

### DIFF
--- a/src/harness/reference_models/common/data.py
+++ b/src/harness/reference_models/common/data.py
@@ -67,7 +67,7 @@ class CbsdGrantInfo(namedtuple('CbsdGrantInfo',
     antenna_gain: The antenna nominal gain (dBi).
     antenna_beamwidth: The 3dB antenna beamwidth (degrees).
     cbsd_category: Either 'A' for Cat A or 'B' for Cat B CBSD.
-    max_eirp: The maximum EIRP of the CBSD (dBm).
+    max_eirp: The maximum EIRP of the CBSD (dBm per MHz).
     low_frequency: The grant min frequency (Hz).
     high_frequency: The gran max frequency (Hz).
     is_managed_grant: True iff the grant belongs to the managing SAS.

--- a/src/harness/reference_models/iap/iap.py
+++ b/src/harness/reference_models/iap/iap.py
@@ -71,17 +71,21 @@ MHZ = 1.e6
 # Channel bandwidth over which SASs execute the IAP process
 IAPBW_HZ = 5*MHZ
 
-# GWPZ Area Protection reference bandwidth for the IAP process
+# Reference bandwidth for the IAP process for each protection type
 GWPZ_RBW_HZ = 10*MHZ
-
-# PPA Area Protection reference bandwidth for the IAP process
 PPA_RBW_HZ = 10*MHZ
-
-# FSS Point Protection reference bandwidth for the IAP process
 FSS_RBW_HZ = 1*MHZ
-
-# ESC Point Protection reference bandwidth for the IAP process
 ESC_RBW_HZ = 1*MHZ
+
+# Normalized threshold on the IAP channel bandwidth
+THRESH_PPA_DBM_PER_IAPBW = (THRESH_PPA_DBM_PER_RBW +
+                            interf.linearToDb(IAPBW_HZ / PPA_RBW_HZ))
+THRESH_GWPZ_DBM_PER_IAPBW = (THRESH_GWPZ_DBM_PER_RBW +
+                             interf.linearToDb(IAPBW_HZ / GWPZ_RBW_HZ))
+THRESH_FSS_CO_CHANNEL_DBM_PER_IAPBW = (THRESH_FSS_CO_CHANNEL_DBM_PER_RBW
+                                       + interf.linearToDb(IAPBW_HZ / FSS_RBW_HZ))
+THRESH_ESC_DBM_PER_IAPBW = (THRESH_ESC_DBM_PER_RBW +
+                            interf.linearToDb(IAPBW_HZ / ESC_RBW_HZ))
 
 # The grid resolution for area based protection entities.
 GWPZ_GRID_RES_ARCSEC = 2
@@ -281,7 +285,7 @@ def performIapForEsc(esc_record, sas_uut_fad_object, sas_th_fad_objects):
         {latitude : {longitude : [interference(mW/IAPBW), .., interference(mW/IAPBW)]}}
       where the list holds all values per channel of that protection point.
   """
-  esc_thresh_q = THRESH_ESC_DBM_PER_RBW + interf.linearToDb(IAPBW_HZ / ESC_RBW_HZ)
+  esc_thresh_q = THRESH_ESC_DBM_PER_IAPBW
 
   # Actual protection threshold used for IAP - calculated by applying
   # a pre-defined Pre-IAP headroom (Mg) at each protection threshold(Q)
@@ -326,7 +330,7 @@ def performIapForGwpz(gwpz_record, sas_uut_fad_object, sas_th_fad_objects):
         {latitude : {longitude : [interference(mW/IAPBW), .., interference(mW/IAPBW)]}}
       where the list holds all values per channel of that protection point.
   """
-  gwpz_thresh_q = THRESH_GWPZ_DBM_PER_RBW + interf.linearToDb(IAPBW_HZ / GWPZ_RBW_HZ)
+  gwpz_thresh_q = THRESH_GWPZ_DBM_PER_IAPBW
 
   # Actual protection threshold used for IAP - calculated by applying
   # a pre-defined Pre-IAP headroom (Mg) at each protection threshold(Q)
@@ -389,7 +393,7 @@ def performIapForPpa(ppa_record, sas_uut_fad_object, sas_th_fad_objects,
         {latitude : {longitude : [interference(mW/IAPBW), .., interference(mW/IAPBW)]}}
       where the list holds all values per channel of that protection point.
   """
-  ppa_thresh_q = THRESH_PPA_DBM_PER_RBW + interf.linearToDb(IAPBW_HZ / PPA_RBW_HZ)
+  ppa_thresh_q = THRESH_PPA_DBM_PER_IAPBW
 
   # Actual protection threshold used for IAP - calculated by applying
   # a pre-defined Pre-IAP headroom (Mg) at each protection threshold(Q)
@@ -464,8 +468,7 @@ def performIapForFssCochannel(fss_record, sas_uut_fad_object, sas_th_fad_objects
         {latitude : {longitude : [interference(mW/IAPBW), .., interference(mW/IAPBW)]}}
       where the list holds all values per channel of that protection point.
   """
-  fss_cochannel_thresh_q = (THRESH_FSS_CO_CHANNEL_DBM_PER_RBW
-                            + interf.linearToDb(IAPBW_HZ / FSS_RBW_HZ))
+  fss_cochannel_thresh_q = THRESH_FSS_CO_CHANNEL_DBM_PER_IAPBW
 
   # Actual protection threshold used for IAP - calculated by applying
   # a pre-defined Pre-IAP headroom (Mg) at each protection threshold(Q)

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -645,7 +645,7 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
         if self.num_peer_sases > 0:
           ppa_ap_iap_ref_values = self.ppa_ap_iap_ref_values_list[index]
         else:
-          ppa_ap_iap_ref_values = interference.dbToLinear(iap.THRESH_PPA_DBM_PER_RBW)
+          ppa_ap_iap_ref_values = interference.dbToLinear(iap.THRESH_PPA_DBM_PER_IAPBW)
         # Compare the interference values calculated from both models
         self.compareIapAndAggregateResults(ppa_ap_iap_ref_values, ppa_aggr_interference, 'area')
 
@@ -662,7 +662,7 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
         if self.num_peer_sases > 0:
           gwpz_ap_iap_ref_values = self.gwpz_ap_iap_ref_values_list[index]
         else:
-          gwpz_ap_iap_ref_values = interference.dbToLinear(iap.THRESH_GWPZ_DBM_PER_RBW)
+          gwpz_ap_iap_ref_values = interference.dbToLinear(iap.THRESH_GWPZ_DBM_PER_IAPBW)
         # Compare the interference values calculated from both models
         self.compareIapAndAggregateResults(gwpz_ap_iap_ref_values, gwpz_aggr_interference, 'area')
 
@@ -688,7 +688,7 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
             fss_cochannel_ap_iap_ref_values = self.fss_cochannel_ap_iap_ref_values_list[index]
             fss_blocking_ap_iap_ref_values = self.fss_blocking_ap_iap_ref_values_list[index]
           else:
-            fss_cochannel_ap_iap_ref_values = interference.dbToLinear(iap.THRESH_FSS_CO_CHANNEL_DBM_PER_RBW)
+            fss_cochannel_ap_iap_ref_values = interference.dbToLinear(iap.THRESH_FSS_CO_CHANNEL_DBM_PER_IAPBW)
             fss_blocking_ap_iap_ref_values = interference.dbToLinear(iap.THRESH_FSS_BLOCKING_DBM_PER_RBW)
           # Check and compare interference for FSS entity
           logging.info('Checking cochannel.')
@@ -722,7 +722,7 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
         if self.num_peer_sases > 0:
           esc_ap_iap_ref_values = self.esc_ap_iap_ref_values_list[index]
         else:
-          esc_ap_iap_ref_values = interference.dbToLinear(iap.THRESH_ESC_DBM_PER_RBW)
+          esc_ap_iap_ref_values = interference.dbToLinear(iap.THRESH_ESC_DBM_PER_IAPBW)
         # Compare the interference values calculated from both models
         self.compareIapAndAggregateResults(esc_ap_iap_ref_values, esc_aggr_interference, 'point')
 


### PR DESCRIPTION
The absolute threshold need to be scaled to be relative to same
bandwidth as the one used for aggregate interference calculation,
ie IAP_BW (5MHz) in most cases, except for FSS blocking where it
is a general threshold.