### PR TITLE
Improved logging for DPA and IAP aggr interference

### DIFF
--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -222,6 +222,7 @@ class Dpa(object):
                  self.name, self.channels, self.threshold, self.beamwidth,
                  self.radar_height, Dpa.num_iteration,
                  self.azimuth_range, self.neighbor_distances)
+    logging.debug('  protected points: %s', self.protected_points)
     pool = mpool.Pool()
     self.ResetLists()
     for low_freq, high_freq in self.channels:

--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -80,6 +80,7 @@ class Dpa(object):
   for which special protection logic is run.
 
   Attributes:
+    name: The DPA name (informative).
     channels: The list of 10MHz channels (freq_min_mhz, freq_max_mhz) to protect for
       that DPA.
     protected_points: A list of namedtuple (latitude, longitude) defining the actual
@@ -126,6 +127,7 @@ class Dpa(object):
     cls.num_iteration = num_iteration
 
   def __init__(self, protected_points,
+               name='None',
                threshold=DPA_DEFAULT_THRESHOLD_PER_10MHZ,
                radar_height=DPA_DEFAULT_RADAR_HEIGHT,
                beamwidth=DPA_DEFAULT_BEAMWIDTH,
@@ -134,6 +136,7 @@ class Dpa(object):
                neighbor_distances=DPA_DEFAULT_DISTANCES,
                monitor_type='esc'):
     """Initialize the DPA attributes."""
+    self.name = name
     self.protected_points = protected_points
     self.threshold = threshold
     self.radar_height = radar_height
@@ -214,6 +217,11 @@ class Dpa(object):
     To retrieve the list, see the routines GetMoveList(), GetNeighborList() and
     GetKeepList().
     """
+    logging.info('DPA Compute movelist `%s`- channels %s thresh %s bw %s height %s '
+                 'iter %s azi_range %s nbor_dists %s',
+                 self.name, self.channels, self.threshold, self.beamwidth,
+                 self.radar_height, Dpa.num_iteration,
+                 self.azimuth_range, self.neighbor_distances)
     pool = mpool.Pool()
     self.ResetLists()
     for low_freq, high_freq in self.channels:
@@ -237,6 +245,9 @@ class Dpa(object):
       nbor_list = set().union(*nbor_list)
       self.move_lists.append(move_list)
       self.nbor_lists.append(nbor_list)
+
+    logging.info('DPA Result movelist `%s`- MOVE_LIST:%s NBOR_LIST: %s',
+                 self.name, self.move_lists, self.nbor_lists)
 
   def _GetChanIdx(self, channel):
     """Gets the channel idx for a given channel."""
@@ -381,10 +392,14 @@ class Dpa(object):
     if do_abs_check_single_uut and not self._has_th_grants:
       hard_threshold = self.threshold
 
-    logging.info('DPA Check interference - channel %s thresh %s bw %s'
+    logging.info('DPA Check interf `%s`- channel %s thresh %s bw %s '
                  'iter %s azi_range %s nbor_dists %s',
-                 channel, hard_threshold if hard_threshold else 'MoveList',
+                 self.name, channel, hard_threshold if hard_threshold else '`MoveList`',
                  self.beamwidth, num_iter, self.azimuth_range, self.neighbor_distances)
+    logging.debug('DPA Check interf `%s` - KL_TH_MGR: %s KL_TH_OTHER: %s KL_UUT_MGR: %s',
+                  self.name,
+                  keep_list_th_managing_sas, keep_list_th_other_sas,
+                  keep_list_uut_managing_sas)
 
     checkPointInterf = functools.partial(
         _CalcTestPointInterfDiff,
@@ -404,9 +419,14 @@ class Dpa(object):
     pool = mpool.Pool()
     result = pool.map(checkPointInterf, self.protected_points)
     max_diff_interf = max(result)
+
     if max_diff_interf > margin_db:
-      logging.warning('DPA Check Fail - channel %s thresh %s',
-                      channel, hard_threshold if hard_threshold else 'MoveList')
+      logging.warning('DPA Check Fail `%s`- channel %s thresh %s max_diff %s',
+                      self.name, channel,
+                      hard_threshold if hard_threshold else '`MoveList`',
+                      max_diff_interf)
+    else:
+      logging.info('DPA Check Succeed - max_diff %s', max_diff_interf)
 
     return max_diff_interf <= margin_db
 
@@ -513,12 +533,12 @@ def _CalcTestPointInterfDiff(point,
         neighbor_distances=neighbor_distances)
     if threshold is not None:
       result = np.max(uut_interferences - threshold)
-      logging.debug('%s UUT interf @ %s Thresh %sdBm : %s',
-                    'Bad' if result > 0 else 'Ok',
-                    point, threshold, uut_interferences)
+      logging.debug('%s UUT interf @ %s Thresh %sdBm Diff %sdB: %s',
+                    'Exceeded' if result > 0 else 'Ok',
+                    point, threshold, result, uut_interferences)
       if result > 0:
-        logging.info('Bad UUT interf @ %s Thresh %sdBm : %s',
-                     point, threshold, uut_interferences)
+        logging.info('Exceeded UUT interf @ %s Thresh %sdBm Diff %sdB: %s',
+                     point, threshold, result, uut_interferences)
       return result
 
     th_interferences = ml.calcAggregatedInterference(
@@ -534,12 +554,14 @@ def _CalcTestPointInterfDiff(point,
         neighbor_distances=neighbor_distances)
 
     result = np.max(uut_interferences - th_interferences)
-    logging.debug('%s UUT interf @ %s : %s',
-                  'Bad' if result > 0 else 'Ok',
-                  point, zip(th_interferences, uut_interferences))
+    logging.debug('%s UUT interf @ %s Diff %sdB: %s',
+                  'Exceeded' if result > 0 else 'Ok',
+                  point, result,
+                  zip(np.atleast_1d(th_interferences), np.atleast_1d(uut_interferences)))
     if result > 0:
-      logging.info('Bad UUT interf @ %s : %s',
-                   point, zip(th_interferences, uut_interferences))
+      logging.info('Exceeded UUT interf @ %s Diff %sdB: %s',
+                   point, result,
+                   zip(np.atleast_1d(th_interferences), np.atleast_1d(uut_interferences)))
 
     return result
 
@@ -609,6 +631,7 @@ def BuildDpa(dpa_name, protection_points_method=None):
                         dpa_zone.catAOOBNeighborhoodDistanceKm,
                         dpa_zone.catBOOBNeighborhoodDistanceKm)
   return Dpa(protection_points,
+             name=dpa_name,
              threshold=protection_threshold,
              radar_height=radar_height,
              beamwidth=radar_beamwidth,

--- a/src/harness/reference_models/dpa/dpa_mgr_example.py
+++ b/src/harness/reference_models/dpa/dpa_mgr_example.py
@@ -50,6 +50,7 @@ if __name__ == '__main__':
   # Configure operating parameters
   dpa_mgr.Dpa.Configure(num_iteration=num_iter)
   dpa_ref = dpa_mgr.Dpa(protection_points,
+                        name='test(East1)',
                         threshold=-144,
                         beamwidth=3,
                         radar_height=50,
@@ -110,6 +111,7 @@ if __name__ == '__main__':
                        ProtectionPoint(latitude=36.102, longitude=-73.312),
                        ProtectionPoint(latitude=36.12, longitude=-75.58)]
   dpa_uut = dpa_mgr.Dpa(protection_points,
+                        name='alt(East1)',
                         threshold=-144,
                         beamwidth=3,
                         radar_height=50,

--- a/src/harness/reference_models/dpa/move_list.py
+++ b/src/harness/reference_models/dpa/move_list.py
@@ -403,7 +403,7 @@ def moveListConstraint(protection_point, low_freq, high_freq,
       + the grants on the move list.
       + the grants in the neighborhood list.
   """
-  logging.info('Creating move list for point (%s), freq (%s, %s), threshold (%s), neighborhood distance (%r)',
+  logging.debug('DPA Create move list for point (%s), freq (%s, %s), threshold (%s), neighborhood distance (%r)',
                protection_point, low_freq, high_freq, threshold, neighbor_distances)
   if not grants:
     return [], []
@@ -466,7 +466,7 @@ def moveListConstraint(protection_point, low_freq, high_freq,
 
       neighbor_grants.extend(extra_grants)
 
-  logging.info('Returning movelist_grants=(%s), neighbor_grants=(%s)',
+  logging.debug('DPA Returning movelist_grants=(%s), neighbor_grants=(%s)',
                movelist_grants, neighbor_grants)
   return (movelist_grants, neighbor_grants)
 
@@ -618,10 +618,6 @@ def findMoveList(protection_specs, protection_points, registration_requests,
                         grant_requests) with TRUE elements at indices having
                         grants on the move list
   """
-  logging.info(
-      'Finding reference move list for protection specs (%s), protection points (%s), registration requests (%s), grant requests (%s), num iter (%s), num_processes (%s)',
-      protection_specs, protection_points, registration_requests,
-      grant_requests, num_iter, num_processes)
   grants = data.getGrantsFromRequests(registration_requests, grant_requests)
   # Find the move list of each protection constraint with a pool of parallel processes.
   if pool is None:
@@ -658,5 +654,4 @@ def findMoveList(protection_specs, protection_points, registration_requests,
     if grant in M:
       result[k] = True
   output = result.tolist()
-  logging.info('DPA ML output = %s', output)
   return output

--- a/src/harness/reference_models/iap/iap.py
+++ b/src/harness/reference_models/iap/iap.py
@@ -262,6 +262,10 @@ def iapPointConstraint(protection_point, channels, low_freq, high_freq,
           if not grants_satisfied[grant_idx]:
             grants_eirp[grant_idx] -= 1
 
+  logging.debug('IAP point_constraint @ point %s: %s',
+                (protection_point[1], protection_point[0]),
+                zip(asas_interf, aggr_interf))
+
   # Return the computed data
   return protection_point[1], protection_point[0], asas_interf, aggr_interf
 

--- a/src/harness/reference_models/interference/aggregate_interference.py
+++ b/src/harness/reference_models/interference/aggregate_interference.py
@@ -115,7 +115,7 @@ def aggregateInterferenceForPoint(protection_point, channels, grants,
       if not neighborhood_grants:
         interferences.append(0)
         continue
-        
+
       cbsd_interferences = [
           interf.computeInterference(grant, grant.max_eirp, protection_constraint,
                                      fss_info, esc_antenna_info, region_type)
@@ -124,6 +124,8 @@ def aggregateInterferenceForPoint(protection_point, channels, grants,
       total_interference = convertAndSumInterference(cbsd_interferences)
       interferences.append(total_interference)
 
+  logging.debug('Agg Interf @ point %s: %s',
+                (protection_point[1], protection_point[0]), interferences)
   return protection_point[1], protection_point[0], interferences
 
 
@@ -149,9 +151,9 @@ def calculateAggregateInterferenceForFssCochannel(fss_record, grants):
 
   protection_channels = interf.getProtectedChannels(fss_low_freq, interf.CBRS_HIGH_FREQ_HZ)
 
-  logging.info(
-      'Computing aggregateInterferenceForPoint for FSS Coch: channels (%s), grants (%s), point (%s), fss_info (%s)',
-      protection_channels, grants, fss_point, fss_info)
+  logging.info('Computing aggregateInterferenceForPoint for FSS Coch: channels (%s), '
+               'point (%s), grants (%s), fss_info (%s)',
+               protection_channels, fss_point, grants, fss_info)
 
   interferences = aggregateInterferenceForPoint(fss_point,
                                 protection_channels,
@@ -192,9 +194,9 @@ def calculateAggregateInterferenceForFssBlocking(fss_record, grants):
   # FSS TT&C Blocking Algorithm
   protection_channels = [(interf.CBRS_LOW_FREQ_HZ, fss_low_freq)]
 
-  logging.info(
-      'Computing aggregateInterferenceForPoint for FSS Blocking: channels (%s), grants (%s), point (%s), fss_info (%s)',
-      protection_channels, grants, fss_point, fss_info)
+  logging.info('Computing aggregateInterferenceForPoint for FSS Blocking: channels (%s), '
+               'point (%s), grants (%s), fss_info (%s)',
+               protection_channels, fss_point, grants, fss_info)
 
   interferences = aggregateInterferenceForPoint(fss_point,
                                 protection_channels,
@@ -226,9 +228,9 @@ def calculateAggregateInterferenceForEsc(esc_record, grants):
   protection_channels = interf.getProtectedChannels(interf.ESC_LOW_FREQ_HZ,
                                                     interf.ESC_HIGH_FREQ_HZ)
 
-  logging.info(
-      'Computing aggregateInterferenceForPoint for ESC: channels (%s), grants (%s), point (%s), antenna_info (%s)',
-      protection_channels, grants, protection_point, esc_antenna_info)
+  logging.info('Computing aggregateInterferenceForPoint for ESC: channels (%s), '
+               'point (%s), grants (%s), antenna_info (%s)',
+               protection_channels, protection_point, grants, esc_antenna_info)
 
   interferences = aggregateInterferenceForPoint(protection_point,
                                 protection_channels,
@@ -268,9 +270,10 @@ def calculateAggregateInterferenceForGwpz(gwpz_record, grants):
 
   # Calculate aggregate interference from each protection constraint with a
   # pool of parallel processes.
-  logging.info(
-      'Computing aggregateInterferenceForPoint for PPA (%s), channels (%s), grants (%s), region_type (%s) - nPoints (%d)',
-      gwpz_record, protection_channels, grants, gwpz_region, len(protection_points))
+  logging.info('Computing aggregateInterferenceForPoint for PPA (%s), channels (%s), '
+               'nPoints (%d), grants (%s), region_type (%s)',
+               gwpz_record, protection_channels, len(protection_points), grants, gwpz_region)
+  logging.debug('  points: %s', protection_points)
 
   interfCalculator = partial(aggregateInterferenceForPoint,
                              channels=protection_channels,
@@ -323,9 +326,10 @@ def calculateAggregateInterferenceForPpa(ppa_record, pal_records, grants):
   # Get channels over which area incumbent needs partial/full protection
   protection_channels = interf.getProtectedChannels(ppa_low_freq, ppa_high_freq)
 
-  logging.info(
-      'Computing aggregateInterferenceForPoint for PPA (%s), channels (%s), grants (%s), region_type (%s) - nPoints (%d)',
-      ppa_record, protection_channels, grants, ppa_region, len(protection_points))
+  logging.info('Computing aggregateInterferenceForPoint for PPA (%s), channels (%s), ',
+               'nPoints (%d), grants (%s), region_type (%s)',
+               ppa_record, protection_channels, len(protection_points), grants, ppa_region)
+  logging.debug('  points: %s', protection_points)
 
   # Calculate aggregate interference from each protection constraint with a
   # pool of parallel processes.

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -747,16 +747,16 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
 
     scalar = isinstance(ap_iap_ref_values, numbers.Number)
 
+    logging.info('IAP aggr interference checking - Entity: %s Thresh: %s',
+                 entity_type, str(ap_iap_ref_values) if scalar else 'from IAP')
     for lat_val, lat_dict in aggr_interference.iteritems():
       for long_val, interf_list in lat_dict.iteritems():
-        logging.info('Looking at lat %s long %s.', lat_val, long_val)
         if scalar:
           # iter produces a infinite generator of the scalar, as zip iterates
           # till one of the passed iterators is empty this will produce the same
           # result as a list of len(interf_list) with the scalar in every field,
           # but without having to construct the list.
           ref_interf_list = iter((lambda : ap_iap_ref_values), 1)
-          logging.info('Reference interference is a scalar: %s mW/IAPBW', ap_iap_ref_values)
         else:
           ref_interf_list = ap_iap_ref_values[lat_val][long_val]
           self.assertEqual(len(interf_list), len(ref_interf_list))
@@ -766,28 +766,28 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
           iter_cnt += 1
           below_threshold = True
           list_index = 0
+          logging.debug('Check lat %s long %s: %s',
+                        lat_val, long_val, zip(interf_list, ref_interf_list))
           for interf, ref_interf in zip(interf_list, ref_interf_list):
-            logging.info(
-                'IAP aggregate interference comparison for index %d: interf=%s ref_interf=%s',
-                list_index, interf, ref_interf)
             list_index += 1
             if interf > ref_interf * iap_margin_lin:
               below_threshold = False
-              logging.info('This ^^^ point exceeded the threshold!')
+              logging.info('Threshold exceeded for chan %d: interf=%s ref_interf=%s',
+                           list_index, interf, ref_interf)
           if below_threshold:
             match_cnt += 1
         else:
           list_index = 0
+          logging.debug('Check lat %s long %s: %s',
+                        lat_val, long_val, zip(interf_list, ref_interf_list))
           for interf, ref_interf in zip(interf_list, ref_interf_list):
             iter_cnt += 1
-            logging.info(
-                'IAP aggregate interference comparison for index %d: interf=%s ref_interf=%s',
-                list_index, interf, ref_interf)
             list_index += 1
             if interf <= ref_interf * iap_margin_lin:
               match_cnt += 1
             else:
-              logging.info('This ^^^ point exceeded the threshold!')
+              logging.info('Threshold exceeded for chan %d: interf=%s ref_interf=%s',
+                           list_index, interf, ref_interf)
 
     # All types of protection must have at least one point.
     self.assertGreater(iter_cnt, 0, msg=common_strings.CONFIG_ERROR_SUSPECTED)


### PR DESCRIPTION
Current logging is either too extensive (IAP aggr interference check) or not enough (DPA).
For facilitating the analysis of the testcases, improved the INFO logging, and the WARNING/DEBUG logging.

Note one minor addition in the dpa_mgr to store the DPA name in the object, as it is useful in the log.