### PR TITLE
Bug fix on the ESC neighborhood for CatA during IAP.

### DIFF
--- a/src/harness/reference_models/interference/interference.py
+++ b/src/harness/reference_models/interference/interference.py
@@ -184,7 +184,8 @@ def grantFrequencyOverlapCheck(grant, ch_low_freq, ch_high_freq, protection_ent_
   # constraint frequency range 3550-3660MHz
   if (protection_ent_type == data.ProtectedEntityType.ESC and
       grant.cbsd_category == 'A' and
-      ch_low_freq >= ESC_CAT_A_HIGH_FREQ_HZ):
+      (grant.low_frequency >= ESC_CAT_A_HIGH_FREQ_HZ or
+       ch_low_freq >= ESC_CAT_A_HIGH_FREQ_HZ)):
     return False
 
   # Check frequency range overlap


### PR DESCRIPTION
The special CatA with ESC case was done with the implicit assumption
that the channels are the 5MHz IAP channels. The code works in that
case (for example: aggregateInterference check).
But the IAP runs the overlap selection using the whole ESC band
3550-3680 to filter the grants in the neighborhood. The code was not
working in that condition and CatA beyond 3660 were kept in the
neighborhood, preventing the IAP loop to ever converge.