### PR TITLE
add simple MCP check and update FAD.2 device 4

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_EPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_EPR_testcase.py
@@ -154,10 +154,9 @@ class EscProtectionTestcase(McpXprCommonTestcase):
         'dpaDeactivationList': [],
         'sasTestHarnessData': []
     }
-
     # Create the actual config.
     config = {
-        'initialCbsdRequestsWithDomainProxies': [],
+        'initialCbsdRequestsWithDomainProxies': self.getEmptyCbsdRequestsWithDomainProxies(2),
         'initialCbsdRecords': [],
         'iterationData': [iteration_config],
         'sasTestHarnessConfigs': [],
@@ -364,7 +363,7 @@ class EscProtectionTestcase(McpXprCommonTestcase):
 
     # Create the actual config.
     config = {
-        'initialCbsdRequestsWithDomainProxies': [],
+        'initialCbsdRequestsWithDomainProxies': self.getEmptyCbsdRequestsWithDomainProxies(2),
         'initialCbsdRecords': [],
         'iterationData': [iteration_config],
         'sasTestHarnessConfigs': [

--- a/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
@@ -582,8 +582,9 @@ class FullActivityDumpTestcase(sas_testcase.SasTestCase):
         open(os.path.join('testcases', 'testdata', 'device_d.json')))
 
     # Move device_c4 in the neighborhood area of the PPA
-    device_c4['installationParam']['latitude'] = 38.805335
-    device_c4['installationParam']['longitude'] = -97.289500
+    device_c4['installationParam']['latitude'] = 38.8363
+    device_c4['installationParam']['longitude'] = -97.2642
+    device_c4['installationParam']['antennaBeamwidth'] = 0
 
     # Creating conditionals for Cat B devices.
     self.assertEqual(device_c4['cbsdCategory'], 'B')

--- a/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
@@ -231,7 +231,7 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     }
 
     config = {
-        'initialCbsdRequestsWithDomainProxies': [],
+        'initialCbsdRequestsWithDomainProxies': self.getEmptyCbsdRequestsWithDomainProxies(2),
         'initialCbsdRecords': [],
         'iterationData': [iteration0_config],
         'sasTestHarnessConfigs': [sas_test_harness_0_config, sas_test_harness_1_config],
@@ -487,7 +487,7 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
 
     # Create the actual config.
     config = {
-        'initialCbsdRequestsWithDomainProxies': [],
+        'initialCbsdRequestsWithDomainProxies': self.getEmptyCbsdRequestsWithDomainProxies(2),
         'initialCbsdRecords': [],
         'iterationData': [iteration_config],
         'sasTestHarnessConfigs': [sas_test_harness_0_config,
@@ -685,7 +685,7 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     }
 
     config = {
-        'initialCbsdRequestsWithDomainProxies': [],
+        'initialCbsdRequestsWithDomainProxies': self.getEmptyCbsdRequestsWithDomainProxies(2),
         'initialCbsdRecords': [],
         'iterationData': [iteration0_config],
         'sasTestHarnessConfigs': [sas_test_harness_0_config, sas_test_harness_1_config],
@@ -896,7 +896,7 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
 
     # Create the actual config.
     config = {
-        'initialCbsdRequestsWithDomainProxies': [],
+        'initialCbsdRequestsWithDomainProxies': self.getEmptyCbsdRequestsWithDomainProxies(2),
         'initialCbsdRecords': [],
         'iterationData': [iteration_config],
         'sasTestHarnessConfigs': [sas_test_harness_0_config,

--- a/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
@@ -142,7 +142,7 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
 
     # Create the actual config.
     config = {
-        'initialCbsdRequestsWithDomainProxies': [],
+        'initialCbsdRequestsWithDomainProxies': self.getEmptyCbsdRequestsWithDomainProxies(2),
         'initialCbsdRecords': [],
         'iterationData': [iteration_config],
         'sasTestHarnessConfigs': [],
@@ -340,7 +340,7 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
 
     # Create the actual config.
     config = {
-        'initialCbsdRequestsWithDomainProxies': [],
+        'initialCbsdRequestsWithDomainProxies': self.getEmptyCbsdRequestsWithDomainProxies(2),
         'initialCbsdRecords': [],
         'iterationData': [iteration_config],
         'sasTestHarnessConfigs': [sas_test_harness_0_config,

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -46,13 +46,13 @@ ONE_MHZ = 1000000
 
 class McpXprCommonTestcase(sas_testcase.SasTestCase):
 
-  def getEmptyCbsdRequestsWithDomainProxies(numberOfElements):
+  def getEmptyCbsdRequestsWithDomainProxies(self, number_of_elements):
     empty_cbsd_records_domain_proxy = {
         'registrationRequests': [],
         'grantRequests': [],
         'conditionalRegistrationData': []
     }
-    return [empty_cbsd_records_domain_proxy] * numberOfElements
+    return [empty_cbsd_records_domain_proxy] * number_of_elements
 
   def checkMcpConfig(self, config, test_type):
     self.assertIn(test_type, ('MCP', 'xPR1', 'xPR2'))

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -46,6 +46,14 @@ ONE_MHZ = 1000000
 
 class McpXprCommonTestcase(sas_testcase.SasTestCase):
 
+  def getEmptyCbsdRequestsWithDomainProxies(numberOfElements):
+    empty_cbsd_records_domain_proxy = {
+        'registrationRequests': [],
+        'grantRequests': [],
+        'conditionalRegistrationData': []
+    }
+    return [empty_cbsd_records_domain_proxy] * numberOfElements
+
   def checkMcpConfig(self, config, test_type):
     self.assertIn(test_type, ('MCP', 'xPR1', 'xPR2'))
 
@@ -80,10 +88,10 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
           len(config['domainProxyConfigs']),
           'Mismatch in the number of domain proxies and the configuration for this iteration: %s.'
           % str(iteration_data))
-      self.assertLessEqual(
+      self.assertEqual(
           len(iteration_data['initialCbsdRequestsWithDomainProxies']),
           len(config['domainProxyConfigs']),
-          'The number of domain proxies of initial CbsdRequests is bigger than the number of configured domain proxies')
+          'Mismatch in the number of domain proxies and the configuration of initial CbsdRequests')
       for domain_proxy in iteration_data['cbsdRequestsWithDomainProxies']:
         self.assertValidConfig(
             domain_proxy, {
@@ -1087,7 +1095,7 @@ class MultiConstraintProtectionTestcase(McpXprCommonTestcase):
         'sasTestHarnessData': [dump_records_iteration_1_sas_test_harness_0, dump_records_iteration_1_sas_test_harness_1]
     }
     config = {
-        'initialCbsdRequestsWithDomainProxies': [],
+        'initialCbsdRequestsWithDomainProxies': self.getEmptyCbsdRequestsWithDomainProxies(2),
         'initialCbsdRecords': [],
         'iterationData': [iteration0_config, iteration1_config],
         'sasTestHarnessConfigs': [sas_test_harness_0_config, sas_test_harness_1_config],

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -89,7 +89,7 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
           'Mismatch in the number of domain proxies and the configuration for this iteration: %s.'
           % str(iteration_data))
       self.assertEqual(
-          len(iteration_data['initialCbsdRequestsWithDomainProxies']),
+          len(config['initialCbsdRequestsWithDomainProxies']),
           len(config['domainProxyConfigs']),
           'Mismatch in the number of domain proxies and the configuration of initial CbsdRequests')
       for domain_proxy in iteration_data['cbsdRequestsWithDomainProxies']:

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -80,6 +80,10 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
           len(config['domainProxyConfigs']),
           'Mismatch in the number of domain proxies and the configuration for this iteration: %s.'
           % str(iteration_data))
+      self.assertLessEqual(
+          len(iteration_data['initialCbsdRequestsWithDomainProxies']),
+          len(config['domainProxyConfigs']),
+          'The number of domain proxies of initial CbsdRequests is bigger than the number of configured domain proxies')
       for domain_proxy in iteration_data['cbsdRequestsWithDomainProxies']:
         self.assertValidConfig(
             domain_proxy, {

--- a/src/harness/testcases/WINNF_FT_S_PPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_PPR_testcase.py
@@ -155,7 +155,7 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
 
     # Create the actual config.
     config = {
-        'initialCbsdRequestsWithDomainProxies': [],
+        'initialCbsdRequestsWithDomainProxies': self.getEmptyCbsdRequestsWithDomainProxies(2),
         'initialCbsdRecords': [],
         'iterationData': [iteration_config],
         'sasTestHarnessConfigs': [],
@@ -367,7 +367,7 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
 
     # Create the actual config.
     config = {
-        'initialCbsdRequestsWithDomainProxies': [],
+        'initialCbsdRequestsWithDomainProxies': self.getEmptyCbsdRequestsWithDomainProxies(2),
         'initialCbsdRecords': [],
         'iterationData': [iteration_config],
         'sasTestHarnessConfigs': [sas_test_harness_0_config,


### PR DESCRIPTION
- add simple MCP check for initial cbsdRequests
- update FAD.2 device 4, so the Eirp of its Grant is reduced after CPAS(the reference model result now for this grant is 12 dBm)