### PR TITLE
By default, allow NLCD voting

### DIFF
--- a/src/harness/reference_models/geo/nlcd.py
+++ b/src/harness/reference_models/geo/nlcd.py
@@ -243,7 +243,7 @@ class NlcdDriver:
     elif isinstance(lat, np.ndarray):
       return codes
 
-  def RegionNlcdVote(self, points, out_forbid=True):
+  def RegionNlcdVote(self, points, out_forbid=False):
     """Vote on most common NLCD in a region.
 
     According to WinnForum spec R2-SGN-04.


### PR DESCRIPTION
...even when the NLCD data isn't available (uses the default value instead). Without this change, GWPZs in e.g. Hawaii will cause the test harness to crash.