### PR TITLE
Fix  ShrinkAndCleanPolygon to actually shrink and not expand.

### DIFF
--- a/src/harness/reference_models/geo/utils.py
+++ b/src/harness/reference_models/geo/utils.py
@@ -409,7 +409,7 @@ def ShrinkAndCleanPolygon(poly, shrink_deg, min_poly_ratio=0.01):
     poly = ToShapely(poly)
   if not isinstance(poly, sgeo.Polygon):
     raise ValueError('Input is not a polygon.')
-  poly = poly.buffer(shrink_deg)
+  poly = poly.buffer(-shrink_deg)
   if isinstance(poly, sgeo.MultiPolygon):
     # Cleanup multi-polygon.
     max_poly_area = max(p.area for p in poly)

--- a/src/harness/reference_models/geo/utils_test.py
+++ b/src/harness/reference_models/geo/utils_test.py
@@ -332,6 +332,7 @@ class TestUtils(unittest.TestCase):
                                sgeo.Point(2,0).buffer(0.1)])
     poly1 = utils.ShrinkAndCleanPolygon(geometry, 1e-2)
     poly2 = utils.ShrinkAndCleanPolygon(spoly, 1e-2)
+    self.assertTrue(poly2.area < spoly.area)
     with self.assertRaises(ValueError):
       poly = utils.ShrinkAndCleanPolygon(mpoly, 1e-2)
     self.assertEqual(poly1['type'], 'Polygon')


### PR DESCRIPTION
A minus was missing. As a consequence the default PPA for PCR3 and PCR7 are expanded instead of shrinked (and vice versa for PCR6)