### PR TITLE
Fixes invalid configs for FDB_3 and FDB_8.

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_FDB_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FDB_testcase.py
@@ -570,7 +570,6 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
         'lowFrequency': 3650000000,
         'highFrequency': 3660000000
     }
-    grant_g_a['operationParam']['maxEirp'] = 0
     grant_g_b['operationParam']['operationFrequencyRange'] = {
         'lowFrequency': 3650000000,
         'highFrequency': 3660000000
@@ -1317,7 +1316,6 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
         'lowFrequency': 3650000000,
         'highFrequency': 3660000000
     }
-    grant_g_a['operationParam']['maxEirp'] = 0
     grant_g_b['operationParam']['operationFrequencyRange'] = {
         'lowFrequency': 3650000000,
         'highFrequency': 3660000000


### PR DESCRIPTION
The maxEirp is set to zero, and hence the corresponding grant will not be terminated, since the aggregate interference to the FSS site is below threshold. 

Removed the lines setting the maxEirp so that the default value (10) is used. Verified that with that change the aggregate interference is exceeded.