### PR TITLE
Fix the non-standard layout/encoding of CRL files

### DIFF
--- a/cert/openssl.cnf
+++ b/cert/openssl.cnf
@@ -44,11 +44,11 @@ TEST = 1.3.6.1.4.1.46609.1.999
 default_ca = CA_default  # The default ca section
 ####################################################################
 [ CA_default ]
-dir = ./root
+dir = ${ENV::OPENSSL_CNF_CA_DIR}
 certs = $dir/certs
 crl_dir = $dir/crl
-new_certs_dir = .
-database = index.txt
+new_certs_dir = $dir
+database = $dir/index.txt
 serial = $dir/serial
 RANDFILE = $dir/private/.rand
 

--- a/cert/openssl.cnf
+++ b/cert/openssl.cnf
@@ -18,6 +18,11 @@
 # =============                                                    #
 ####################################################################
 
+# Default ENV values.  If these strings appear in a generated certificate or
+# error message, then a script should've set the environment variable prior
+# to invoking openssl.
+OPENSSL_CNF_CA_DIR = _ca_dir_not_set_by_environment_
+OPENSSL_CNF_CRLDP = _crldp_not_set_by_environment_
 
 ####################################################################
 # Defining OIDS registered by The Wireless Innovation Forum
@@ -132,7 +137,7 @@ keyUsage = critical, digitalSignature, cRLSign, keyCertSign
 
 [ crl_section ]
 
-URI.0 = http://localhost:9007/ca.crl
+URI.0 = ${ENV::OPENSSL_CNF_CRLDP}
 
 ####################################################################
 # Not used yet

--- a/cert/openssl.cnf
+++ b/cert/openssl.cnf
@@ -1,7 +1,7 @@
 ####################################################################
-#OpenSSL Configuration file for WInnForum CA					   #
-#v0.2
-#============
+# OpenSSL Configuration file for WInnForum CA                      #
+# v0.2
+# ============
 #   Copyright 2016 SAS Project Authors. All Rights Reserved.
 #
 #   Licensed under the Apache License, Version 2.0 (the "License");
@@ -15,56 +15,56 @@
 #   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
-#=============															   #
+# =============                                                    #
 ####################################################################
 
 
 ####################################################################
-#Defining OIDS registered by The Wireless Innovation Forum
+# Defining OIDS registered by The Wireless Innovation Forum
 
-oid_section		= new_oids
+oid_section = new_oids
 
 [ new_oids ]
-ROLE_SAS=1.3.6.1.4.1.46609.1.1.1
-ROLE_INSTALLER=1.3.6.1.4.1.46609.1.1.2
-ROLE_CBSD=1.3.6.1.4.1.46609.1.1.3
-ROLE_OPERATOR=1.3.6.1.4.1.46609.1.1.4
-ROLE_CA=1.3.6.1.4.1.46609.1.1.5
-ROLE_PAL=1.3.6.1.4.1.46609.1.1.6
+ROLE_SAS = 1.3.6.1.4.1.46609.1.1.1
+ROLE_INSTALLER = 1.3.6.1.4.1.46609.1.1.2
+ROLE_CBSD = 1.3.6.1.4.1.46609.1.1.3
+ROLE_OPERATOR = 1.3.6.1.4.1.46609.1.1.4
+ROLE_CA = 1.3.6.1.4.1.46609.1.1.5
+ROLE_PAL = 1.3.6.1.4.1.46609.1.1.6
 
-ZONE=1.3.6.1.4.1.46609.1.2
-FREQUENCY=1.3.6.1.4.1.46609.1.3
-FCCID=1.3.6.1.4.1.46609.1.4
-SERIAL=1.3.6.1.4.1.46609.1.5
-FRN=1.3.6.1.4.1.46609.1.6
-TEST=1.3.6.1.4.1.46609.1.999
+ZONE = 1.3.6.1.4.1.46609.1.2
+FREQUENCY = 1.3.6.1.4.1.46609.1.3
+FCCID = 1.3.6.1.4.1.46609.1.4
+SERIAL = 1.3.6.1.4.1.46609.1.5
+FRN = 1.3.6.1.4.1.46609.1.6
+TEST = 1.3.6.1.4.1.46609.1.999
 
 ####################################################################
 [ ca ]
-default_ca	= CA_default		# The default ca section
+default_ca = CA_default  # The default ca section
 ####################################################################
 [ CA_default ]
-dir               	= ./root
-certs             	= $dir/certs
-crl_dir           	= $dir/crl
-new_certs_dir     	= .
-database          	= index.txt
-serial            	= $dir/serial
-RANDFILE          	= $dir/private/.rand
+dir = ./root
+certs = $dir/certs
+crl_dir = $dir/crl
+new_certs_dir = .
+database = index.txt
+serial = $dir/serial
+RANDFILE = $dir/private/.rand
 
 # For certificate revocation lists.
-#crlnumber         	= $dir/crlnumber
-#crl               	= $dir/crl/ca.crl.pem
-#crl_extensions    	= crl_ext
-#default_crl_days  	= 30
+#crlnumber = $dir/crlnumber
+#crl = $dir/crl/ca.crl.pem
+#crl_extensions = crl_ext
+#default_crl_days = 30
 
-default_md        	= sha384
+default_md = sha384
 
-name_opt          	= ca_default
-cert_opt          	= ca_default
-default_days      	= 1095
-preserve          	= no
-policy            	= policy_match
+name_opt = ca_default
+cert_opt = ca_default
+default_days = 1095
+preserve = no
+policy = policy_match
 
 # Extension copying option: use with caution.
 # This can be commented in for testing, but don't use this with a production system.
@@ -73,60 +73,60 @@ policy            	= policy_match
 
 # For the CA policy
 [ policy_match ]
-countryName				= match
-stateOrProvinceName		= match
-localityName			= optional
-organizationName		= match
-organizationalUnitName	= optional
-commonName				= supplied
+countryName = match
+stateOrProvinceName = match
+localityName = optional
+organizationName = match
+organizationalUnitName = optional
+commonName = supplied
 
 # For the 'anything' policy
 # At this point in time, you must list all acceptable 'object' types.
 [ policy_anything ]
-countryName				= optional
-stateOrProvinceName		= optional
-localityName			= optional
-organizationName		= optional
-organizationalUnitName	= optional
-commonName				= supplied
+countryName = optional
+stateOrProvinceName = optional
+localityName = optional
+organizationName = optional
+organizationalUnitName = optional
+commonName = supplied
 
 ####################################################################
 [ req ]
-default_bits			= 2048
-distinguished_name		= req_distinguished_name
-x509_extensions			= v3_ca
-string_mask 			= utf8only
-default_md				= sha384
+default_bits = 2048
+distinguished_name = req_distinguished_name
+x509_extensions = v3_ca
+string_mask = utf8only
+default_md = sha384
 
-#req_extensions = v3_ca # The extensions to add to a certificate request
+#req_extensions = v3_ca  # The extensions to add to a certificate request
 
 [ req_distinguished_name ]
 
-#values
-countryName					= Country Name (2 letter code)
-stateOrProvinceName			= State or Province Name (full name)
-localityName				= Locality Name (eg, city)
-0.organizationName			= Organization Name (eg, company)
-organizationalUnitName		= Organizational Unit Name (eg, section)
-commonName					= Common Name
+# values
+countryName = Country Name (2 letter code)
+stateOrProvinceName = State or Province Name (full name)
+localityName = Locality Name (eg, city)
+0.organizationName = Organization Name (eg, company)
+organizationalUnitName = Organizational Unit Name (eg, section)
+commonName = Common Name
 
-#min and max
-countryName_min				= 2
-countryName_max				= 2
-commonName_max				= 64
+# min and max
+countryName_min = 2
+countryName_max = 2
+commonName_max = 64
 
-#defaults
-countryName_default				= US
-stateOrProvinceName_default		= Washington, D.C.
-localityName_default 			= Washington, D.C.
-0.organizationName_default		= Wireless Innovation Forum
-organizationalUnitName_default	= www.wirelessinnovation.org
+# defaults
+countryName_default = US
+stateOrProvinceName_default = Washington, D.C.
+localityName_default = Washington, D.C.
+0.organizationName_default = Wireless Innovation Forum
+organizationalUnitName_default = www.wirelessinnovation.org
 
 [ v3_ca ]
 
-subjectKeyIdentifier			= hash
-basicConstraints 				= critical, CA:true
-keyUsage 						= critical, digitalSignature, cRLSign, keyCertSign
+subjectKeyIdentifier = hash
+basicConstraints = critical, CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
 
 ####################################################################
 
@@ -135,7 +135,7 @@ keyUsage 						= critical, digitalSignature, cRLSign, keyCertSign
 URI.0 = http://localhost:9007/ca.crl
 
 ####################################################################
-#Not used yet
+# Not used yet
 [ ocsp_section ]
 
 caIssuers;URI.0 = http://cacerts.digicert.com/WinnForumCA.crt
@@ -144,33 +144,33 @@ OCSP;URI.0 = http://ocsp.digicert.com
 ####################################################################
 [ root_ca ]
 
-subjectKeyIdentifier	= hash
-authorityKeyIdentifier	= keyid:always,issuer
-basicConstraints 		= critical, CA:true
-keyUsage 				= critical, digitalSignature, cRLSign, keyCertSign
-certificatePolicies=@cps,ROLE_CA
+subjectKeyIdentifier = hash
+authorityKeyIdentifier = keyid:always, issuer
+basicConstraints = critical, CA:true
+keyUsage = critical, digitalSignature, cRLSign, keyCertSign
+certificatePolicies = @cps, ROLE_CA
 
 [ cps ]
 
 policyIdentifier = 2.16.840.1.114412.2.1
-CPS.1="https://www.digicert.com/CPS"
+CPS.1 = "https://www.digicert.com/CPS"
 
 ####################################################################
 [ sas_ca ]
 
 subjectKeyIdentifier = hash
-#authorityKeyIdentifier = keyid:always,issuer
+#authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = critical, CA:true, pathlen:0
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
-certificatePolicies=@cps,ROLE_CA,ROLE_SAS
+certificatePolicies = @cps, ROLE_CA, ROLE_SAS
 
 [ sas_ca_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = critical, CA:true, pathlen:0
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
-certificatePolicies=@cps,ROLE_CA,ROLE_SAS
+certificatePolicies = @cps, ROLE_CA, ROLE_SAS
 
 ####################################################################
 [ oper_ca ]
@@ -178,15 +178,15 @@ certificatePolicies=@cps,ROLE_CA,ROLE_SAS
 subjectKeyIdentifier = hash
 basicConstraints = critical, CA:true, pathlen:0
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
-certificatePolicies=@cps,ROLE_CA,ROLE_OPERATOR
+certificatePolicies = @cps, ROLE_CA, ROLE_OPERATOR
 
 [ oper_ca_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = critical, CA:true, pathlen:0
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
-certificatePolicies=@cps,ROLE_CA,ROLE_OPERATOR
+certificatePolicies = @cps, ROLE_CA, ROLE_OPERATOR
 
 ####################################################################
 [ pi_ca ]
@@ -194,15 +194,15 @@ certificatePolicies=@cps,ROLE_CA,ROLE_OPERATOR
 subjectKeyIdentifier = hash
 basicConstraints = critical, CA:true, pathlen:0
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
-certificatePolicies=@cps,ROLE_CA,ROLE_INSTALLER
+certificatePolicies = @cps, ROLE_CA, ROLE_INSTALLER
 
 [ pi_ca_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = critical, CA:true, pathlen:0
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
-certificatePolicies=@cps,ROLE_CA,ROLE_INSTALLER
+certificatePolicies = @cps, ROLE_CA, ROLE_INSTALLER
 
 ####################################################################
 [ pal_ca ]
@@ -210,15 +210,15 @@ certificatePolicies=@cps,ROLE_CA,ROLE_INSTALLER
 subjectKeyIdentifier = hash
 basicConstraints = critical, CA:true, pathlen:0
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
-certificatePolicies=@cps,ROLE_CA,ROLE_PAL
+certificatePolicies = @cps, ROLE_CA, ROLE_PAL
 
 [ pal_ca_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = critical, CA:true, pathlen:0
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
-certificatePolicies=@cps,ROLE_CA,ROLE_PAL
+certificatePolicies = @cps, ROLE_CA, ROLE_PAL
 
 ####################################################################
 [ cbsd_ca ]
@@ -226,15 +226,15 @@ certificatePolicies=@cps,ROLE_CA,ROLE_PAL
 subjectKeyIdentifier = hash
 basicConstraints = critical, CA:true, pathlen:1
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
-certificatePolicies=@cps,ROLE_CA,ROLE_CBSD
+certificatePolicies = @cps, ROLE_CA, ROLE_CBSD
 
 [ cbsd_ca_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = critical, CA:true, pathlen:1
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
-certificatePolicies=@cps,ROLE_CA,ROLE_CBSD
+certificatePolicies = @cps, ROLE_CA, ROLE_CBSD
 
 ####################################################################
 [ cbsd_oem_ca ]
@@ -242,15 +242,15 @@ certificatePolicies=@cps,ROLE_CA,ROLE_CBSD
 subjectKeyIdentifier = hash
 basicConstraints = critical, CA:true, pathlen:0
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
-certificatePolicies=@cps,ROLE_CA,ROLE_CBSD
+certificatePolicies = @cps, ROLE_CA, ROLE_CBSD
 
 [ cbsd_oem_ca_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = critical, CA:true, pathlen:0
 keyUsage = critical, digitalSignature, cRLSign, keyCertSign
-certificatePolicies=@cps,ROLE_CA,ROLE_CBSD
+certificatePolicies = @cps, ROLE_CA, ROLE_CBSD
 
 
 ####################################################################
@@ -260,38 +260,38 @@ certificatePolicies=@cps,ROLE_CA,ROLE_CBSD
 subjectKeyIdentifier = hash
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, cRLSign
-extendedKeyUsage = serverAuth,clientAuth
-certificatePolicies=@cps,ROLE_SAS
-crlDistributionPoints=@crl_section
-# subjectAltName=DNS:localhost,otherName:1.3.6.1.4.1.46609.1.6;UTF8:0123456789
+extendedKeyUsage = serverAuth, clientAuth
+certificatePolicies = @cps, ROLE_SAS
+crlDistributionPoints = @crl_section
+#subjectAltName = DNS:localhost, otherName:1.3.6.1.4.1.46609.1.6;UTF8:0123456789
 
 [ sas_req_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, cRLSign
-extendedKeyUsage = serverAuth,clientAuth
-certificatePolicies=@cps,ROLE_SAS
-crlDistributionPoints=@crl_section
-# subjectAltName=DNS:localhost,otherName:1.3.6.1.4.1.46609.1.6;UTF8:0123456789
+extendedKeyUsage = serverAuth, clientAuth
+certificatePolicies = @cps, ROLE_SAS
+crlDistributionPoints = @crl_section
+#subjectAltName = DNS:localhost, otherName:1.3.6.1.4.1.46609.1.6;UTF8:0123456789
 
 ####################################################################
 
 [ cps ]
 
 policyIdentifier = 2.16.840.1.114412.2.1
-CPS.1="https://www.digicert.com/CPS"
+CPS.1 = "https://www.digicert.com/CPS"
 
 
 [ sas_req_inapplicable_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth, clientAuth
-certificatePolicies=@cps,ROLE_SAS,ZONE
+certificatePolicies = @cps, ROLE_SAS, ZONE
 
 ####################################################################
 [ oper_req ]
@@ -300,29 +300,29 @@ subjectKeyIdentifier = hash
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_OPERATOR
-crlDistributionPoints=@crl_section
-# subjectAltName=otherName:1.3.6.1.4.1.46609.1.6;UTF8:0123456789
+certificatePolicies = @cps, ROLE_OPERATOR
+crlDistributionPoints = @crl_section
+#subjectAltName = otherName:1.3.6.1.4.1.46609.1.6;UTF8:0123456789
 
 [ oper_req_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_OPERATOR
-crlDistributionPoints=@crl_section
-# subjectAltName=otherName:1.3.6.1.4.1.46609.1.6;UTF8:0123456789
+certificatePolicies = @cps, ROLE_OPERATOR
+crlDistributionPoints = @crl_section
+#subjectAltName = otherName:1.3.6.1.4.1.46609.1.6;UTF8:0123456789
 
 [ oper_req_inapplicable_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_OPERATOR,ZONE
+certificatePolicies = @cps, ROLE_OPERATOR, ZONE
 
 ####################################################################
 [ pi_req ]
@@ -331,16 +331,16 @@ subjectKeyIdentifier = hash
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
-certificatePolicies=@cps,ROLE_INSTALLER
+certificatePolicies = @cps, ROLE_INSTALLER
 
 [ pi_req_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
-certificatePolicies=@cps,ROLE_INSTALLER
+certificatePolicies = @cps, ROLE_INSTALLER
 
 ####################################################################
 [ pal_req ]
@@ -349,18 +349,18 @@ subjectKeyIdentifier = hash
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
-certificatePolicies=@cps,ROLE_PAL
-# subjectAltName=otherName:1.3.6.1.4.1.46609.1.2;UTF8:zone_id_1,otherName:1.3.6.1.4.1.46609.1.3;UTF8:3650
+certificatePolicies = @cps, ROLE_PAL
+#subjectAltName = otherName:1.3.6.1.4.1.46609.1.2;UTF8:zone_id_1, otherName:1.3.6.1.4.1.46609.1.3;UTF8:3650
 
 [ pal_req_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
-certificatePolicies=@cps,ROLE_PAL
-# subjectAltName=otherName:1.3.6.1.4.1.46609.1.2;UTF8:zone_id,otherName:1.3.6.1.4.1.46609.1.3;UTF8:3650
+certificatePolicies = @cps, ROLE_PAL
+#subjectAltName = otherName:1.3.6.1.4.1.46609.1.2;UTF8:zone_id, otherName:1.3.6.1.4.1.46609.1.3;UTF8:3650
 
 ####################################################################
 [ cbsd_req ]
@@ -368,147 +368,147 @@ certificatePolicies=@cps,ROLE_PAL
 subjectKeyIdentifier = hash
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
-certificatePolicies=@cps,ROLE_CBSD
-crlDistributionPoints=@crl_section
-# subjectAltName=otherName:1.3.6.1.4.1.46609.1.4;UTF8:fcc_id,otherName:1.3.6.1.4.1.46609.1.5;UTF8:serial
+certificatePolicies = @cps, ROLE_CBSD
+crlDistributionPoints = @crl_section
+#subjectAltName = otherName:1.3.6.1.4.1.46609.1.4;UTF8:fcc_id, otherName:1.3.6.1.4.1.46609.1.5;UTF8:serial
 
 [ cbsd_req_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_CBSD
-crlDistributionPoints=@crl_section
-# subjectAltName=otherName:1.3.6.1.4.1.46609.1.4;UTF8:fcc_id,otherName:1.3.6.1.4.1.46609.1.5;UTF8:serial
+certificatePolicies = @cps, ROLE_CBSD
+crlDistributionPoints = @crl_section
+#subjectAltName = otherName:1.3.6.1.4.1.46609.1.4;UTF8:fcc_id, otherName:1.3.6.1.4.1.46609.1.5;UTF8:serial
 
 [ cbsd_req_device_a_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_CBSD
-crlDistributionPoints=@crl_section
-subjectAltName=otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_a,otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_a
+certificatePolicies = @cps, ROLE_CBSD
+crlDistributionPoints = @crl_section
+subjectAltName = otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_a, otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_a
 
 [ cbsd_req_device_b_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_CBSD
-crlDistributionPoints=@crl_section
-subjectAltName=otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_b,otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_b
+certificatePolicies = @cps, ROLE_CBSD
+crlDistributionPoints = @crl_section
+subjectAltName = otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_b, otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_b
 
 [ cbsd_req_device_c_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_CBSD
-crlDistributionPoints=@crl_section
-subjectAltName=otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_c,otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_c
+certificatePolicies = @cps, ROLE_CBSD
+crlDistributionPoints = @crl_section
+subjectAltName = otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_c, otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_c
 
 [ cbsd_req_device_d_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_CBSD
-crlDistributionPoints=@crl_section
-subjectAltName=otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_d,otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_d
+certificatePolicies = @cps, ROLE_CBSD
+crlDistributionPoints = @crl_section
+subjectAltName = otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_d, otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_d
 
 [ cbsd_req_device_e_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_CBSD
-crlDistributionPoints=@crl_section
-subjectAltName=otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_e,otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_e
+certificatePolicies = @cps, ROLE_CBSD
+crlDistributionPoints = @crl_section
+subjectAltName = otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_e, otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_e
 
 [ cbsd_req_device_f_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_CBSD
-crlDistributionPoints=@crl_section
-subjectAltName=otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_f,otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_f
+certificatePolicies = @cps, ROLE_CBSD
+crlDistributionPoints = @crl_section
+subjectAltName = otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_f, otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_f
 
 [ cbsd_req_device_g_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_CBSD
-crlDistributionPoints=@crl_section
-subjectAltName=otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_g,otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_g
+certificatePolicies = @cps, ROLE_CBSD
+crlDistributionPoints = @crl_section
+subjectAltName = otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_g, otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_g
 
 [ cbsd_req_device_h_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_CBSD
-crlDistributionPoints=@crl_section
-subjectAltName=otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_h,otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_h
+certificatePolicies = @cps, ROLE_CBSD
+crlDistributionPoints = @crl_section
+subjectAltName = otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_h, otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_h
 
 [ cbsd_req_device_i_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_CBSD
-crlDistributionPoints=@crl_section
-subjectAltName=otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_i,otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_i
+certificatePolicies = @cps, ROLE_CBSD
+crlDistributionPoints = @crl_section
+subjectAltName = otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_i, otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_i
 
 [ cbsd_req_device_j_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment, cRLSign
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_CBSD
-crlDistributionPoints=@crl_section
-subjectAltName=otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_j,otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_j
+certificatePolicies = @cps, ROLE_CBSD
+crlDistributionPoints = @crl_section
+subjectAltName = otherName:1.3.6.1.4.1.46609.1.4;UTF8:test_fcc_id_j, otherName:1.3.6.1.4.1.46609.1.5;UTF8:test_serial_number_j
 
 [ cbsd_req_inapplicable_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_CBSD,ZONE
+certificatePolicies = @cps, ROLE_CBSD, ZONE
 
 [ wrong_cbsd_req_sign ]
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = clientAuth
-certificatePolicies=@cps,ROLE_SAS
+certificatePolicies = @cps, ROLE_SAS
 
 ####################################################################
 
@@ -517,28 +517,28 @@ certificatePolicies=@cps,ROLE_SAS
 subjectKeyIdentifier = hash
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
-certificatePolicies=@cps,ROLE_CBSD
+certificatePolicies = @cps, ROLE_CBSD
 
 [ cbsd_oem_req_sign ]
 
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid:always,issuer
+authorityKeyIdentifier = keyid:always, issuer
 basicConstraints = CA:FALSE
 keyUsage = critical, digitalSignature, keyEncipherment
 extendedKeyUsage = serverAuth
-certificatePolicies=@cps,ROLE_CBSD
+certificatePolicies = @cps, ROLE_CBSD
 
 ####################################################################
 [ crl_ext ]
 
-authorityKeyIdentifier=keyid:always
+authorityKeyIdentifier = keyid:always
 
 ####################################################################
 [ ocsp ]
 
 basicConstraints = CA:FALSE
 subjectKeyIdentifier = hash
-authorityKeyIdentifier = keyid,issuer
+authorityKeyIdentifier = keyid, issuer
 keyUsage = critical, digitalSignature
 extendedKeyUsage = critical, OCSPSigning
 
@@ -546,29 +546,38 @@ extendedKeyUsage = critical, OCSPSigning
 # Probably won't be used
 [ tsa ]
 
-default_tsa = tsa_config1	# the default TSA section
+default_tsa = tsa_config1  # the default TSA section
 
 [ tsa_config ]
 
 # These are used by the TSA reply generation only.
-dir		= ./demoCA		# TSA root directory
-serial		= $dir/tsaserial	# The current serial number (mandatory)
-crypto_device	= builtin		# OpenSSL engine to use for signing
-signer_cert	= $dir/tsacert.pem 	# The TSA signing certificate
-					# (optional)
-certs		= $dir/cacert.pem	# Certificate chain to include in reply
-					# (optional)
-signer_key	= $dir/private/tsakey.pem # The TSA private key (optional)
 
-default_policy	= tsa_policy1		# Policy if request did not specify it
-					# (optional)
-other_policies	= tsa_policy2, tsa_policy3	# acceptable policies (optional)
-digests		= md5, sha1		# Acceptable message digests (mandatory)
-accuracy	= secs:1, millisecs:500, microsecs:100	# (optional)
-clock_precision_digits  = 0	# number of digits after dot. (optional)
-ordering		= yes	# Is ordering defined for timestamps?
-				# (optional, default: no)
-tsa_name		= yes	# Must the TSA name be included in the reply?
-				# (optional, default: no)
-ess_cert_id_chain	= no	# Must the ESS cert id chain be included?
-				# (optional, default: no)
+# TSA root directory
+dir = ./demoCA
+# The current serial number (mandatory)
+serial = $dir/tsaserial
+# OpenSSL engine to use for signing
+crypto_device = builtin
+# The TSA signing certificate (optional)
+signer_cert = $dir/tsacert.pem
+# Certificate chain to include in reply (optional)
+certs = $dir/cacert.pem
+# The TSA private key (optional)
+signer_key = $dir/private/tsakey.pem
+
+# Policy if request did not specify it (optional)
+default_policy = tsa_policy1
+# acceptable policies (optional)
+other_policies = tsa_policy2, tsa_policy3
+# Acceptable message digests (mandatory)
+digests = md5, sha1
+# (optional)
+accuracy = secs:1, millisecs:500, microsecs:100
+# number of digits after dot. (optional)
+clock_precision_digits = 0
+# Is ordering defined for timestamps? (optional, default: no)
+ordering = yes
+# Must the TSA name be included in the reply? (optional, default: no)
+tsa_name = yes
+# Must the ESS cert id chain be included? (optional, default: no)
+ess_cert_id_chain = no

--- a/src/harness/certs/.gitignore
+++ b/src/harness/certs/.gitignore
@@ -4,5 +4,4 @@
 *.key
 *.csr
 *.crl
-index.txt*
-
+db/

--- a/src/harness/certs/.gitignore
+++ b/src/harness/certs/.gitignore
@@ -4,4 +4,5 @@
 *.key
 *.csr
 *.crl
+crl/
 db/

--- a/src/harness/certs/generate_fake_certs.sh
+++ b/src/harness/certs/generate_fake_certs.sh
@@ -13,32 +13,35 @@ touch index.txt
 echo -n 'unique_subject = no' > index.txt.attr
 
 function gen_cbsd_cert {
-    # Called with:
-    # $1 = device name (For example device_a)
-    # $2 = fcc_id (For example test_fcc_id_a)
-    # $3 = serial number (For example test_serial_number_a)
-    echo "Generating cert $1 for device with fcc_id=$2 sn=$3"
-    openssl req -new -newkey rsa:2048 -nodes \
-        -reqexts cbsd_req -config ../../../cert/openssl.cnf \
-        -out $1.csr -keyout $1.key \
-        -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum CBSD Certificate/CN=$2:$3"
-        echo "Signing cert $1 for device with fcc_id=$2 sn=$3"
-    openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in $1.csr \
-        -out $1.cert -outdir ./root \
-        -policy policy_anything -extensions cbsd_req_$1_sign -config ../../../cert/openssl.cnf \
-        -batch -notext -create_serial -utf8 -days 1185 -md sha384
+  # Called with:
+  # $1 = device name (For example device_a)
+  # $2 = fcc_id (For example test_fcc_id_a)
+  # $3 = serial number (For example test_serial_number_a)
+  echo "Generating cert $1 for device with fcc_id=$2 sn=$3"
+  openssl req -new -newkey rsa:2048 -nodes \
+      -reqexts cbsd_req -config ../../../cert/openssl.cnf \
+      -out $1.csr -keyout $1.key \
+      -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum CBSD Certificate/CN=$2:$3"
+  echo "Signing cert $1 for device with fcc_id=$2 sn=$3"
+  openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in $1.csr \
+      -out $1.cert -outdir ./root \
+      -policy policy_anything -extensions cbsd_req_$1_sign \
+      -config ../../../cert/openssl.cnf \
+      -batch -notext -create_serial -utf8 -days 1185 -md sha384
 }
 
-function gen_corrupt_cert()
-{
+function gen_corrupt_cert() {
   cp $1 $3
   cp $2 $4
-  # cert file have first header line with 28 char: we want to change the 20th cert character
-     pos=48
+  # cert file have first header line with 28 char: we want to change the
+  # 20th cert character
+  pos=48
   hex_byte=$(xxd -seek $((10#$pos)) -l 1 -ps $4 -)
-  #Modifying the byte value. If the byte character is 'z' or 'Z' or '9', then it is decremented by 1 to 'y' or 'Y' or '8' respectively.
-  #If the value is '+' or '/' then we set it to 'A', else the current character value is incremented by 1.
-  #This takes care of all the 64 characters of Base64 encoding.
+  # Modifying the byte value. If the byte character is 'z' or 'Z' or '9',
+  # then it is decremented to 'y' or 'Y' or '8' respectively.
+  # If the value is '+' or '/' then we set it to 'A', else the current character
+  # value is incremented by 1.
+  # This takes care of all the 64 characters of Base64 encoding.
   if [[ $hex_byte == "7a"  ||  $hex_byte == "5a" || $hex_byte == "39" ]]; then
     corrupted_dec_byte=$(($((16#$hex_byte)) -1))
   elif [[ $hex_byte == "2f"  ||  $hex_byte == "2b" ]]; then
@@ -51,7 +54,8 @@ function gen_corrupt_cert()
 }
 
 # Generate root and intermediate CA certificate/key.
-echo -e "\n\nGenerate 'root_ca' and 'root-ecc_ca' certificate/key"
+printf "\n\n"
+echo "Generate 'root_ca' and 'root-ecc_ca' certificate/key"
 openssl req -new -x509 -newkey rsa:4096 -sha384 -nodes -days 7300 \
     -extensions root_ca -config ../../../cert/openssl.cnf \
     -out root_ca.cert -keyout private/root_ca.key \
@@ -59,16 +63,19 @@ openssl req -new -x509 -newkey rsa:4096 -sha384 -nodes -days 7300 \
 
 openssl ecparam -genkey -out  private/root-ecc_ca.key -name secp521r1
 openssl req -new -x509 -key private/root-ecc_ca.key -out root-ecc_ca.cert \
-    -sha384 -nodes -days 7300 -extensions root_ca -config ../../../cert/openssl.cnf \
+    -sha384 -nodes -days 7300 -extensions root_ca \
+    -config ../../../cert/openssl.cnf \
     -subj "/C=US/O=WInnForum/OU=ECC Root CA0001/CN=WInnForum ECC Root CA"
 
-echo -e "\n\nGenerate 'sas_ca' and 'sas-ecc_ca' certificate/key"
+printf "\n\n"
+echo "Generate 'sas_ca' and 'sas-ecc_ca' certificate/key"
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts sas_ca  -config ../../../cert/openssl.cnf \
     -out sas_ca.csr -keyout private/sas_ca.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=RSA SAS Provider CA0001/CN=WInnForum RSA SAS Provider CA"
 openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in sas_ca.csr \
-    -policy policy_anything -extensions sas_ca_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_ca_sign \
+    -config ../../../cert/openssl.cnf \
     -out sas_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
@@ -77,18 +84,21 @@ openssl req -new -nodes \
     -reqexts sas_ca  -config ../../../cert/openssl.cnf \
     -out sas-ecc_ca.csr -key private/sas-ecc_ca.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=ECC SAS Provider CA0001/CN=WInnForum ECC SAS Provider CA"
-openssl ca -cert root-ecc_ca.cert -keyfile private/root-ecc_ca.key -in sas-ecc_ca.csr \
-    -policy policy_anything -extensions sas_ca_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert root-ecc_ca.cert -keyfile private/root-ecc_ca.key \
+    -in sas-ecc_ca.csr -policy policy_anything -extensions sas_ca_sign \
+    -config ../../../cert/openssl.cnf \
     -out sas-ecc_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
-echo -e "\n\nGenerate 'cbsd_ca' certificate/key"
+printf "\n\n"
+echo "Generate 'cbsd_ca' certificate/key"
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts cbsd_ca  -config ../../../cert/openssl.cnf \
     -out cbsd_ca.csr -keyout private/cbsd_ca.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=RSA CBSD OEM CA0001/CN=WInnForum RSA CBSD OEM CA"
 openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in cbsd_ca.csr \
-    -policy policy_anything -extensions cbsd_ca_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions cbsd_ca_sign \
+    -config ../../../cert/openssl.cnf \
     -out cbsd_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
@@ -97,30 +107,35 @@ openssl req -new -nodes \
     -reqexts cbsd_ca  -config ../../../cert/openssl.cnf \
     -out cbsd-ecc_ca.csr -key private/cbsd-ecc_ca.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=ECC CBSD OEM CA0001/CN=WInnForum ECC CBSD OEM CA"
-openssl ca -cert root-ecc_ca.cert -keyfile private/root-ecc_ca.key -in cbsd-ecc_ca.csr \
-    -policy policy_anything -extensions cbsd_ca_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert root-ecc_ca.cert -keyfile private/root-ecc_ca.key \
+    -in cbsd-ecc_ca.csr -policy policy_anything -extensions cbsd_ca_sign \
+    -config ../../../cert/openssl.cnf \
     -out cbsd-ecc_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
-echo -e "\n\nGenerate 'proxy_ca' certificate/key"
+printf "\n\n"
+echo "Generate 'proxy_ca' certificate/key"
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts oper_ca  -config ../../../cert/openssl.cnf \
     -out proxy_ca.csr -keyout private/proxy_ca.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=RSA Domain Proxy CA0001/CN=WInnForum RSA Domain Proxy CA"
 openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in proxy_ca.csr \
-    -policy policy_anything -extensions oper_ca_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions oper_ca_sign \
+    -config ../../../cert/openssl.cnf \
     -out proxy_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
 # Generate fake server certificate/key.
-echo -e "\n\nGenerate 'server' certificate/key"
+printf "\n\n"
+echo "Generate 'server' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out server.csr -keyout server.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=localhost"
-openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in server.csr \
-    -out server.cert -outdir ./root \
-    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key \
+    -in server.csr -out server.cert -outdir ./root \
+    -policy policy_anything -extensions sas_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 openssl ecparam -genkey -out  server-ecc.key -name secp521r1
@@ -128,20 +143,23 @@ openssl req -new -nodes \
     -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out server-ecc.csr -key server-ecc.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=localhost"
-openssl ca -cert sas-ecc_ca.cert -keyfile private/sas-ecc_ca.key -in server-ecc.csr \
-    -out server-ecc.cert -outdir ./root \
-    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert sas-ecc_ca.cert -keyfile private/sas-ecc_ca.key \
+    -in server-ecc.csr -out server-ecc.cert -outdir ./root \
+    -policy policy_anything -extensions sas_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Generate sas server certificate/key.
-echo -e "\n\nGenerate 'sas server' certificate/key"
+printf "\n\n"
+echo "Generate 'sas server' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out sas.csr -keyout sas.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=localhost"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas.csr \
     -out sas.cert -outdir ./root \
-    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 openssl req -new -newkey rsa:2048 -nodes \
@@ -150,11 +168,13 @@ openssl req -new -newkey rsa:2048 -nodes \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate 001/CN=localhost"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas_1.csr \
     -out sas_1.cert -outdir ./root \
-    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Generate normal operation device certificate/key.
-echo -e "\n\nGenerate 'certs for devices' certificate/key"
+printf "\n\n"
+echo "Generate 'certs for devices' certificate/key"
 gen_cbsd_cert device_a test_fcc_id_a test_serial_number_a
 gen_cbsd_cert device_b test_fcc_id_b test_serial_number_b
 gen_cbsd_cert device_c test_fcc_id_c test_serial_number_c
@@ -166,38 +186,45 @@ gen_cbsd_cert device_h test_fcc_id_h test_serial_number_h
 gen_cbsd_cert device_i test_fcc_id_i test_serial_number_i
 gen_cbsd_cert device_j test_fcc_id_j test_serial_number_j
 
-echo -e "\n\nGenerate 'admin' certificate/key"
+printf "\n\n"
+echo "Generate 'admin' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts cbsd_req -config ../../../cert/openssl.cnf \
     -out admin.csr -keyout admin.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum Admin Certificate/CN=SAS admin Example"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in admin.csr \
     -out admin.cert -outdir ./root \
-    -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions cbsd_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Generate Domain Proxy certificate/key.
-echo -e "\n\nGenerate 'domain_proxy' certificate/key"
+printf "\n\n"
+echo "Generate 'domain_proxy' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts oper_req -config ../../../cert/openssl.cnf \
     -out domain_proxy.csr -keyout domain_proxy.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum Domain Proxy Certificate/CN=0123456789:0002"
-openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key -in domain_proxy.csr \
-    -out domain_proxy.cert -outdir ./root \
-    -policy policy_anything -extensions oper_req_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key \
+    -in domain_proxy.csr -out domain_proxy.cert -outdir ./root \
+    -policy policy_anything -extensions oper_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts oper_req -config ../../../cert/openssl.cnf \
     -out domain_proxy_1.csr -keyout domain_proxy_1.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum Domain Proxy Certificate/CN=0123456789:0003"
-openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key -in domain_proxy_1.csr \
-    -out domain_proxy_1.cert -outdir ./root \
-    -policy policy_anything -extensions oper_req_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key \
+    -in domain_proxy_1.csr -out domain_proxy_1.cert -outdir ./root \
+    -policy policy_anything -extensions oper_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-# Generate certificates for test case WINNF.FT.S.SCS.6 - Unrecognized root of trust certificate presented during registration
-echo -e "\n\nGenerate 'unrecognized_device' certificate/key"
+# Generate certificates for test case WINNF.FT.S.SCS.6 -
+# Unrecognized root of trust certificate presented during registration
+printf "\n\n"
+echo "Generate 'unrecognized_device' certificate/key"
 openssl req -new -x509 -newkey rsa:4096 -sha384 -nodes -days 7300 \
     -extensions root_ca -config ../../../cert/openssl.cnf \
     -out unrecognized_root_ca.cert -keyout private/unrecognized_root_ca.key \
@@ -207,391 +234,528 @@ openssl req -new -newkey rsa:2048 -nodes \
     -reqexts cbsd_req -config ../../../cert/openssl.cnf \
     -out unrecognized_device.csr -keyout unrecognized_device.key \
     -subj "/C=US/O=Generic Certification Organization/OU=www.example.org/CN=Unrecognized CBSD"
-openssl ca -cert unrecognized_root_ca.cert -keyfile private/unrecognized_root_ca.key -in unrecognized_device.csr \
+openssl ca -cert unrecognized_root_ca.cert \
+    -keyfile private/unrecognized_root_ca.key -in unrecognized_device.csr \
     -out unrecognized_device.cert -outdir ./root \
-    -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions cbsd_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-# Certificates for test case WINNF.FT.S.SCS.7 - corrupted certificate, based on device_a.cert
-echo -e "\n\nGenerate 'device_corrupted' certificate/key"
-gen_corrupt_cert device_a.key device_a.cert device_corrupted.key device_corrupted.cert
+# Certificates for test case WINNF.FT.S.SCS.7 -
+# corrupted certificate, based on device_a.cert
+printf "\n\n"
+echo "Generate 'device_corrupted' certificate/key"
+gen_corrupt_cert \
+    device_a.key device_a.cert device_corrupted.key device_corrupted.cert
 
-# Certificate for test case WINNF.FT.S.SCS.8 - Self-signed certificate presented during registration
-# Using the same CSR that was created for normal operation
-echo -e "\n\nGenerate 'device_self_signed' certificate/key"
+# Certificate for test case WINNF.FT.S.SCS.8 -
+# Self-signed certificate presented during registration using the same CSR that
+# was created for normal operation
+printf "\n\n"
+echo "Generate 'device_self_signed' certificate/key"
 openssl x509 -signkey device_a.key -in device_a.csr \
     -out device_self_signed.cert \
     -req -days 1185
 
-# Certificate for test case WINNF.FT.S.SCS.9 - Non-CBRS trust root signed certificate presented during registration
-echo -e "\n\nGenerate 'non_cbrs_signed_cbsd_ca' certificate/key"
+# Certificate for test case WINNF.FT.S.SCS.9 -
+# Non-CBRS trust root signed certificate presented during registration
+printf "\n\n"
+echo "Generate 'non_cbrs_signed_cbsd_ca' certificate/key"
 openssl req -new -x509 -newkey rsa:4096 -sha384 -nodes -days 7300 \
     -extensions root_ca -config ../../../cert/openssl.cnf \
     -out non_cbrs_root_ca.cert -keyout private/non_cbrs_root_ca.key \
     -subj "/C=US/O=Non CBRS company/OU=www.example.org/CN=Non CBRS Root CA"
 
-echo -e "\n\nGenerate 'non_cbrs_signed_cbsd_ca' certificate/key"
+printf "\n\n"
+echo "Generate 'non_cbrs_signed_cbsd_ca' certificate/key"
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts cbsd_ca  -config ../../../cert/openssl.cnf \
-    -out non_cbrs_root_signed_cbsd_ca.csr -keyout private/non_cbrs_root_signed_cbsd_ca.key \
+    -out non_cbrs_root_signed_cbsd_ca.csr \
+    -keyout private/non_cbrs_root_signed_cbsd_ca.key \
     -subj "/C=US/O=Non CBRS company/OU=www.example.org/CN=Non CBRS CBSD CA"
-openssl ca -cert non_cbrs_root_ca.cert -keyfile private/non_cbrs_root_ca.key -in non_cbrs_root_signed_cbsd_ca.csr \
-    -policy policy_anything -extensions cbsd_ca_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert non_cbrs_root_ca.cert -keyfile private/non_cbrs_root_ca.key \
+    -in non_cbrs_root_signed_cbsd_ca.csr \
+    -policy policy_anything -extensions cbsd_ca_sign \
+    -config ../../../cert/openssl.cnf \
     -out non_cbrs_root_signed_cbsd_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
-# Generate CBSD certificate signed by a intermediate CBSD CA which is signed by a non-CBRS root CA
+# Generate CBSD certificate signed by a intermediate CBSD CA which is signed
+# by a non-CBRS root CA
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts cbsd_req -config ../../../cert/openssl.cnf \
     -out non_cbrs_signed_device.csr -keyout non_cbrs_signed_device.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum CBSD Certificate/CN=test_fcc_id:0001"
-openssl ca -cert non_cbrs_root_signed_cbsd_ca.cert -keyfile private/non_cbrs_root_signed_cbsd_ca.key -in non_cbrs_signed_device.csr \
+openssl ca -cert non_cbrs_root_signed_cbsd_ca.cert \
+    -keyfile private/non_cbrs_root_signed_cbsd_ca.key \
+    -in non_cbrs_signed_device.csr \
     -out non_cbrs_signed_device.cert -outdir ./root \
-    -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions cbsd_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-# Certificate for test case WINNF.FT.S.SCS.10 - Certificate of wrong type presented during registration
-# Creating a wrong type certificate by reusing the server.csr and creating a server certificate.
-echo -e "\n\nGenerate wrong type certificate/key"
+# Certificate for test case WINNF.FT.S.SCS.10 -
+# Certificate of wrong type presented during registration.
+# Creating a wrong type certificate by reusing the server.csr and creating
+# a server certificate.
+printf "\n\n"
+echo "Generate wrong type certificate/key"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in server.csr \
     -out device_wrong_type.cert -outdir ./root \
-    -policy policy_anything -extensions sas_req_sign   -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Certificate for test case WINNF.FT.S.SCS.11
-echo -e "\n\nGenerate blacklisted client certificate/key"
+printf "\n\n"
+echo "Generate blacklisted client certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts cbsd_req -config ../../../cert/openssl.cnf \
     -out device_blacklisted.csr -keyout device_blacklisted.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum CBSD Certificate/CN=test_fcc_id:sn_0001"
-openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in device_blacklisted.csr \
-    -out device_blacklisted.cert -outdir ./root \
-    -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key \
+    -in device_blacklisted.csr -out device_blacklisted.cert -outdir ./root \
+    -policy policy_anything -extensions cbsd_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Revoke the device_blacklisted.cert for WINNF.FT.S.SCS.11
-openssl ca -revoke device_blacklisted.cert -keyfile private/cbsd_ca.key -cert cbsd_ca.cert \
-     -config ../../../cert/openssl.cnf
+openssl ca -revoke device_blacklisted.cert -keyfile private/cbsd_ca.key \
+    -cert cbsd_ca.cert -config ../../../cert/openssl.cnf
 
 # Certificate for test case WINNF.FT.S.SDS.11
-echo -e "\n\nGenerate blacklisted domain proxy certificate/key"
+printf "\n\n"
+echo "Generate blacklisted domain proxy certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts oper_req -config ../../../cert/openssl.cnf \
     -out domain_proxy_blacklisted.csr -keyout domain_proxy_blacklisted.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum Domain Proxy Certificate/CN=0123456789:0004"
-openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key -in domain_proxy_blacklisted.csr \
+openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key \
+    -in domain_proxy_blacklisted.csr \
     -out domain_proxy_blacklisted.cert -outdir ./root \
-    -policy policy_anything -extensions oper_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions oper_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Revoke the domain_proxy_blacklisted.cert for WINNF.FT.S.SDS.11
-openssl ca -revoke domain_proxy_blacklisted.cert -keyfile private/proxy_ca.key -cert proxy_ca.cert \
-     -config ../../../cert/openssl.cnf
+openssl ca -revoke domain_proxy_blacklisted.cert -keyfile private/proxy_ca.key \
+    -cert proxy_ca.cert -config ../../../cert/openssl.cnf
 
 # Certificate for test case WINNF.FT.S.SSS.11
-echo -e "\n\nGenerate blacklisted sas certificate/key"
+printf "\n\n"
+echo "Generate blacklisted sas certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out sas_blacklisted.csr -keyout sas_blacklisted.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=localhost"
-openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas_blacklisted.csr \
-    -out sas_blacklisted.cert -outdir ./root \
-    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key \
+    -in sas_blacklisted.csr -out sas_blacklisted.cert -outdir ./root \
+    -policy policy_anything -extensions sas_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Revoke the sas_blacklisted.cert for WINNF.FT.S.SSS.11
-openssl ca -revoke sas_blacklisted.cert -keyfile private/sas_ca.key -cert sas_ca.cert \
-    -config ../../../cert/openssl.cnf
+openssl ca -revoke sas_blacklisted.cert -keyfile private/sas_ca.key \
+    -cert sas_ca.cert -config ../../../cert/openssl.cnf
 
 # Create a CRL for root CA containing the revoked CBSD CA certificate
-echo -e "\n\nGenerate CRL for root_ca"
+printf "\n\n"
+echo "Generate CRL for root_ca"
 openssl ca -gencrl -keyfile private/root_ca.key -cert root_ca.cert \
     -config ../../../cert/openssl.cnf -crldays 365 \
     -out crl/root_ca.crl
 
 # Creating CRL for blacklisted certificates xxS.11 test cases
-echo -e "\n\nGenerate CRL for sas_ca"
+printf "\n\n"
+echo "Generate CRL for sas_ca"
 openssl ca -gencrl -keyfile private/sas_ca.key -cert sas_ca.cert \
     -config ../../../cert/openssl.cnf -crldays 365 \
     -out crl/sas_ca.crl
 
-echo -e "\n\nGenerate CRL for proxy_ca"
+printf "\n\n"
+echo "Generate CRL for proxy_ca"
 openssl ca -gencrl -keyfile private/proxy_ca.key -cert proxy_ca.cert \
     -config ../../../cert/openssl.cnf -crldays 365 \
     -out crl/proxy_ca.crl
 
-echo -e "\n\nGenerate CRL for cbsd_ca"
+printf "\n\n"
+echo "Generate CRL for cbsd_ca"
 openssl ca -gencrl -keyfile private/cbsd_ca.key -cert cbsd_ca.cert \
     -config ../../../cert/openssl.cnf -crldays 365 \
     -out crl/cbsd_ca.crl
 
-# Certificate for test case WINNF.FT.S.SCS.12 - Expired certificate presented during registration
-echo -e "\n\nGenerate 'device_expired' certificate/key"
+# Certificate for test case WINNF.FT.S.SCS.12 -
+# Expired certificate presented during registration
+printf "\n\n"
+echo "Generate 'device_expired' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts cbsd_req -config ../../../cert/openssl.cnf \
     -out device_expired.csr -keyout device_expired.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum CBSD Certificate/CN=test_fcc_id:0002"
-openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in device_expired.csr \
-    -out device_expired.cert -outdir ./root \
-    -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
-    -batch -notext -create_serial -utf8 -startdate 20150214120000Z -enddate 20160214120000Z -md sha384
+openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key \
+    -in device_expired.csr -out device_expired.cert -outdir ./root \
+    -policy policy_anything -extensions cbsd_req_sign \
+    -config ../../../cert/openssl.cnf \
+    -batch -notext -create_serial -utf8 \
+    -startdate 20150214120000Z -enddate 20160214120000Z -md sha384
 
-# Certificate for test case WINNF.FT.S.SCS.15 - Certificate with inapplicable fields presented during registration
-echo -e "\n\nGenerate 'inapplicable certificate for WINNF.FT.S.SCS.15' certificate/key"
+# Certificate for test case WINNF.FT.S.SCS.15 -
+# Certificate with inapplicable fields presented during registration
+printf "\n\n"
+echo "Generate 'inapplicable certificate for WINNF.FT.S.SCS.15' certificate/key"
 openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in device_a.csr \
     -out device_inapplicable.cert -outdir ./root \
-    -policy policy_anything -extensions cbsd_req_inapplicable_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions cbsd_req_inapplicable_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-# Generate certificates for test case WINNF.FT.S.SDS.6 - Unrecognized root of trust certificate presented during registration
-echo -e "\n\nGenerate 'unrecognized_domain_proxy' certificate/key"
+# Generate certificates for test case WINNF.FT.S.SDS.6 -
+# Unrecognized root of trust certificate presented during registration
+printf "\n\n"
+echo "Generate 'unrecognized_domain_proxy' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts oper_req -config ../../../cert/openssl.cnf \
     -out unrecognized_domain_proxy.csr -keyout unrecognized_domain_proxy.key \
     -subj "/C=US/O=Generic Certification Organization/OU=www.example.org/CN=Unrecognized Domain Proxy"
-openssl ca -cert unrecognized_root_ca.cert -keyfile private/unrecognized_root_ca.key -in unrecognized_domain_proxy.csr \
+openssl ca -cert unrecognized_root_ca.cert \
+    -keyfile private/unrecognized_root_ca.key \
+    -in unrecognized_domain_proxy.csr \
     -out unrecognized_domain_proxy.cert -outdir ./root \
-    -policy policy_anything -extensions oper_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions oper_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-# Certificates for test case WINN.FT.S.SDS.7 - corrupted certificate, based on domain_proxy.cert
-echo -e "\n\nGenerate 'domain_proxy_corrupted' certificate/key"
-gen_corrupt_cert domain_proxy.key domain_proxy.cert domain_proxy_corrupted.key domain_proxy_corrupted.cert
+# Certificates for test case WINN.FT.S.SDS.7 -
+# corrupted certificate, based on domain_proxy.cert
+printf "\n\n"
+echo "Generate 'domain_proxy_corrupted' certificate/key"
+gen_corrupt_cert \
+    domain_proxy.key domain_proxy.cert \
+    domain_proxy_corrupted.key domain_proxy_corrupted.cert
 
-# Certificate for test case WINNF.FT.S.SDS.8 - Self-signed certificate presented during registration
+# Certificate for test case WINNF.FT.S.SDS.8 -
+# Self-signed certificate presented during registration.
 # Using the same CSR that was created for normal operation
-echo -e "\n\nGenerate 'domain_proxy_self_signed' certificate/key"
+printf "\n\n"
+echo "Generate 'domain_proxy_self_signed' certificate/key"
 openssl x509 -signkey domain_proxy.key -in domain_proxy.csr \
     -out domain_proxy_self_signed.cert \
     -req -days 1185
 
-# Certificate for test case WINNF.FT.S.SDS.9 - Non-CBRS trust root signed certificate presented during registration
-echo -e "\n\nGenerate non_cbrs_root_signed_oper_ca.csr certificate/key"
+# Certificate for test case WINNF.FT.S.SDS.9 -
+# Non-CBRS trust root signed certificate presented during registration
+printf "\n\n"
+echo "Generate non_cbrs_root_signed_oper_ca.csr certificate/key"
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts oper_ca -config ../../../cert/openssl.cnf \
-    -out non_cbrs_root_signed_oper_ca.csr -keyout private/non_cbrs_root_signed_oper_ca.key \
+    -out non_cbrs_root_signed_oper_ca.csr \
+    -keyout private/non_cbrs_root_signed_oper_ca.key \
     -subj "/C=US/O=Non CBRS company/OU=www.example.org/CN=Non CBRS Domain Proxy CA"
 
-openssl ca -cert non_cbrs_root_ca.cert -keyfile private/non_cbrs_root_ca.key -in non_cbrs_root_signed_oper_ca.csr \
-    -policy policy_anything -extensions oper_ca_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert non_cbrs_root_ca.cert -keyfile private/non_cbrs_root_ca.key \
+    -in non_cbrs_root_signed_oper_ca.csr \
+    -policy policy_anything -extensions oper_ca_sign \
+    -config ../../../cert/openssl.cnf \
     -out non_cbrs_root_signed_oper_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
-# Generate a Domain Proxy certifcate signed by an intermediate Domain Proxy CA which is signed by a non-CBRS root CA
-echo -e "\n\nGenerate domain_proxy certificate/key"
+# Generate a Domain Proxy certifcate signed by an intermediate Domain Proxy CA
+# which is signed by a non-CBRS root CA
+printf "\n\n"
+echo "Generate domain_proxy certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts oper_req -config ../../../cert/openssl.cnf \
-    -out non_cbrs_signed_domain_proxy.csr -keyout non_cbrs_signed_domain_proxy.key \
+    -out non_cbrs_signed_domain_proxy.csr \
+    -keyout non_cbrs_signed_domain_proxy.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum Domain Proxy Certificate/CN=0123456789:0005"
-openssl ca -cert non_cbrs_root_signed_oper_ca.cert -keyfile private/non_cbrs_root_signed_oper_ca.key -in non_cbrs_signed_domain_proxy.csr \
+openssl ca -cert non_cbrs_root_signed_oper_ca.cert \
+    -keyfile private/non_cbrs_root_signed_oper_ca.key \
+    -in non_cbrs_signed_domain_proxy.csr \
     -out non_cbrs_signed_domain_proxy.cert -outdir ./root \
-    -policy policy_anything -extensions oper_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions oper_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-# Certificate for test case WINNF.FT.S.SDS.10 - Certificate of wrong type presented during registration
-# Creating a wrong type certificate by reusing the server.csr and creating a server certificate.
-echo -e "\n\nGenerate wrong type certificate/key"
+# Certificate for test case WINNF.FT.S.SDS.10 -
+# Certificate of wrong type presented during registration.
+# Creating a wrong type certificate by reusing the server.csr and creating
+# a server certificate.
+printf "\n\n"
+echo "Generate wrong type certificate/key"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in server.csr \
     -out domain_proxy_wrong_type.cert -outdir ./root \
-    -policy policy_anything -extensions sas_req_sign   -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-# Certificate for test case WINNF.FT.S.SDS.12 - Expired certificate presented during registration
-echo -e "\n\nGenerate 'domain_proxy_expired' certificate/key"
+# Certificate for test case WINNF.FT.S.SDS.12 -
+# Expired certificate presented during registration
+printf "\n\n"
+echo "Generate 'domain_proxy_expired' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts oper_req -config ../../../cert/openssl.cnf \
     -out domain_proxy_expired.csr -keyout domain_proxy_expired.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum Domain Proxy Certificate/CN=0123456789:0006"
-openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key -in domain_proxy_expired.csr \
-    -out domain_proxy_expired.cert -outdir ./root \
-    -policy policy_anything -extensions oper_req_sign -config ../../../cert/openssl.cnf \
-    -batch -notext -create_serial -utf8 -startdate 20150214120000Z -enddate 20160214120000Z -md sha384
+openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key \
+    -in domain_proxy_expired.csr -out domain_proxy_expired.cert -outdir ./root \
+    -policy policy_anything -extensions oper_req_sign \
+    -config ../../../cert/openssl.cnf \
+    -batch -notext -create_serial -utf8 \
+    -startdate 20150214120000Z -enddate 20160214120000Z -md sha384
 
-# Certificate for test case WINNF.FT.S.SDS.15 -Certificate with inapplicable fields presented during registration
-echo -e "\n\nGenerate 'inapplicable certificate for WINNF.FT.S.SDS.15' certificate"
-openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key -in domain_proxy.csr \
-    -out domain_proxy_inapplicable.cert -outdir ./root \
-    -policy policy_anything -extensions oper_req_inapplicable_sign -config ../../../cert/openssl.cnf \
+# Certificate for test case WINNF.FT.S.SDS.15 -
+# Certificate with inapplicable fields presented during registration
+printf "\n\n"
+echo "Generate 'inapplicable certificate for WINNF.FT.S.SDS.15' certificate"
+openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key \
+    -in domain_proxy.csr -out domain_proxy_inapplicable.cert -outdir ./root \
+    -policy policy_anything -extensions oper_req_inapplicable_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-# Generate certificates for test case WINNF.FT.S.SSS.6 - Unrecognized root of trust certificate presented during registration
-echo -e "\n\nGenerate 'unrecognized_sas' certificate/key"
+# Generate certificates for test case WINNF.FT.S.SSS.6 -
+# Unrecognized root of trust certificate presented during registration
+printf "\n\n"
+echo "Generate 'unrecognized_sas' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out unrecognized_sas.csr -keyout unrecognized_sas.key \
     -subj "/C=US/O=Generic Certification Organization/OU=www.example.org/CN=Unrecognized SAS Provider"
-openssl ca -cert unrecognized_root_ca.cert -keyfile private/unrecognized_root_ca.key -in unrecognized_sas.csr \
+openssl ca -cert unrecognized_root_ca.cert \
+    -keyfile private/unrecognized_root_ca.key -in unrecognized_sas.csr \
     -out unrecognized_sas.cert -outdir ./root \
-    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-# Certificates for test case WINN.FT.S.SSS.7 - corrupted certificate, based on sas.cert
-echo -e "\n\nGenerate 'sas_corrupted' certificate/key"
+# Certificates for test case WINN.FT.S.SSS.7 -
+# corrupted certificate, based on sas.cert
+printf "\n\n"
+echo "Generate 'sas_corrupted' certificate/key"
 gen_corrupt_cert sas.key sas.cert sas_corrupted.key sas_corrupted.cert
 
-# Certificate for test case WINNF.FT.S.SSS.8 - Self-signed certificate presented during registration
+# Certificate for test case WINNF.FT.S.SSS.8 -
+# Self-signed certificate presented during registration.
 # Using the same CSR that was created for normal operation
-echo -e "\n\nGenerate 'sas_self_signed' certificate/key"
+printf "\n\n"
+echo "Generate 'sas_self_signed' certificate/key"
 openssl x509 -signkey sas.key -in sas.csr \
     -out sas_self_signed.cert \
     -req -days 1185
 
-# Certificate for test case WINNF.FT.S.SSS.9 - Non-CBRS trust root signed certificate presented during registration
-echo -e "\n\nGenerate non_cbrs_root_signed_sas_ca.csr certificate/key"
-
+# Certificate for test case WINNF.FT.S.SSS.9 -
+# Non-CBRS trust root signed certificate presented during registration
+printf "\n\n"
+echo "Generate non_cbrs_root_signed_sas_ca.csr certificate/key"
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts sas_ca -config ../../../cert/openssl.cnf \
-    -out non_cbrs_root_signed_sas_ca.csr -keyout private/non_cbrs_root_signed_sas_ca.key \
+    -out non_cbrs_root_signed_sas_ca.csr \
+    -keyout private/non_cbrs_root_signed_sas_ca.key \
     -subj "/C=US/O=Non CBRS company/OU=www.example.org/CN=Non CBRS SAS Provider CA"
 
-openssl ca -cert non_cbrs_root_ca.cert -keyfile private/non_cbrs_root_ca.key -in non_cbrs_root_signed_sas_ca.csr \
-    -policy policy_anything -extensions sas_ca_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert non_cbrs_root_ca.cert -keyfile private/non_cbrs_root_ca.key \
+    -in non_cbrs_root_signed_sas_ca.csr \
+    -policy policy_anything -extensions sas_ca_sign \
+    -config ../../../cert/openssl.cnf \
     -out non_cbrs_root_signed_sas_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
-# Generate a SAS certificate signed by an intermediate SAS CA which is signed by a non-CBRS root CA
-echo -e "\n\nGenerate sas certificate/key"
+# Generate a SAS certificate signed by an intermediate SAS CA
+# which is signed by a non-CBRS root CA
+printf "\n\n"
+echo "Generate sas certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out non_cbrs_signed_sas.csr -keyout non_cbrs_signed_sas.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=non-cbrs.example.org"
-openssl ca -cert non_cbrs_root_signed_sas_ca.cert -keyfile private/non_cbrs_root_signed_sas_ca.key -in non_cbrs_signed_sas.csr \
-    -out non_cbrs_signed_sas.cert -outdir ./root \
-    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert non_cbrs_root_signed_sas_ca.cert \
+    -keyfile private/non_cbrs_root_signed_sas_ca.key \
+    -in non_cbrs_signed_sas.csr -out non_cbrs_signed_sas.cert -outdir ./root \
+    -policy policy_anything -extensions sas_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-# Certificate for test case WINNF.FT.S.SSS.10 - Certificate of wrong type presented by SAS Test Harness
-# Creating a wrong type certificate by reusing the device_a.csr and creating a client certificate.
-echo -e "\n\nGenerate wrong type certificate/key"
+# Certificate for test case WINNF.FT.S.SSS.10 -
+# Certificate of wrong type presented by SAS Test Harness.
+# Creating a wrong type certificate by reusing the device_a.csr and
+# creating a client certificate.
+printf "\n\n"
+echo "Generate wrong type certificate/key"
 openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in device_a.csr \
     -out sas_wrong_type.cert -outdir ./root \
-    -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions cbsd_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-# Certificate for test case WINNF.FT.S.SSS.12 - Expired certificate presented by SAS Test Harness
-echo -e "\n\nGenerate 'sas_expired' certificate/key"
+# Certificate for test case WINNF.FT.S.SSS.12 -
+# Expired certificate presented by SAS Test Harness
+printf "\n\n"
+echo "Generate 'sas_expired' certificate/key"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out sas_expired.csr -keyout sas_expired.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=expired.example.org"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas_expired.csr \
     -out sas_expired.cert -outdir ./root \
-    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
-    -batch -notext -create_serial -utf8 -startdate 20150214120000Z -enddate 20160214120000Z -md sha384
+    -policy policy_anything -extensions sas_req_sign \
+    -config ../../../cert/openssl.cnf \
+    -batch -notext -create_serial -utf8 \
+    -startdate 20150214120000Z -enddate 20160214120000Z -md sha384
 
-# Certificate for test case WINNF.FT.S.SSS.15 -Certificate with inapplicable fields presented by SAS Test Harness
-echo -e "\n\nGenerate 'inapplicable certificate for WINNF.FT.S.SSS.15' certificate"
+# Certificate for test case WINNF.FT.S.SSS.15 -
+# Certificate with inapplicable fields presented by SAS Test Harness
+printf "\n\n"
+echo "Generate 'inapplicable certificate for WINNF.FT.S.SSS.15' certificate"
 openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas.csr \
     -out sas_inapplicable.cert -outdir ./root \
-    -policy policy_anything -extensions sas_req_inapplicable_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_inapplicable_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
-# Certificate for test case WINNF.FT.S.SCS.16 - Certificate signed by a revoked CA presented during registration
-echo -e "\n\nGenerate 'revoked_cbsd_ca' certificate/key to revoke intermediate CA"
+# Certificate for test case WINNF.FT.S.SCS.16 -
+# Certificate signed by a revoked CA presented during registration
+printf "\n\n"
+echo "Generate 'revoked_cbsd_ca' certificate/key to revoke intermediate CA"
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts cbsd_ca  -config ../../../cert/openssl.cnf \
     -out revoked_cbsd_ca.csr -keyout private/revoked_cbsd_ca.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=RSA CBSD OEM CA0002/CN=WInnForum RSA CBSD OEM CA - Revoked"
-openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in revoked_cbsd_ca.csr \
-    -policy policy_anything -extensions cbsd_ca_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert root_ca.cert -keyfile private/root_ca.key \
+    -in revoked_cbsd_ca.csr \
+    -policy policy_anything -extensions cbsd_ca_sign \
+    -config ../../../cert/openssl.cnf \
     -out revoked_cbsd_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
 # Generate client certificate/key signed by valid CA.
-echo -e "\n\nGenerate 'client' certificate/key signed by revoked_cbsd_ca"
+printf "\n\n"
+echo "Generate 'client' certificate/key signed by revoked_cbsd_ca"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts cbsd_req -config ../../../cert/openssl.cnf \
-    -out device_cert_from_revoked_ca.csr -keyout device_cert_from_revoked_ca.key \
+    -out device_cert_from_revoked_ca.csr \
+    -keyout device_cert_from_revoked_ca.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum CBSD Certificate/CN=test_fcc_id:revoked"
-openssl ca -cert revoked_cbsd_ca.cert -keyfile private/revoked_cbsd_ca.key -in device_cert_from_revoked_ca.csr \
+openssl ca -cert revoked_cbsd_ca.cert -keyfile private/revoked_cbsd_ca.key \
+    -in device_cert_from_revoked_ca.csr \
     -out device_cert_from_revoked_ca.cert -outdir ./root \
-    -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions cbsd_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Revoke the CBSD CA Certificate.
-echo -e "\n\nRevoke intermediate CA (revoked_cbsd_ca) who already signed client certificate."
-openssl ca -revoke revoked_cbsd_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
-     -config ../../../cert/openssl.cnf
+printf "\n\n"
+echo "Revoke intermediate CA (revoked_cbsd_ca) who already signed client certificate."
+openssl ca -revoke revoked_cbsd_ca.cert -keyfile private/root_ca.key \
+    -cert root_ca.cert -config ../../../cert/openssl.cnf
 
-# Certificate for test case WINNF.FT.S.SDS.16 - Certificate signed by a revoked CA presented during registration.
-echo -e "\n\nGenerate 'revoked_proxy_ca' certificate/key to revoke intermediate CA."
+# Certificate for test case WINNF.FT.S.SDS.16 -
+# Certificate signed by a revoked CA presented during registration.
+printf "\n\n"
+echo "Generate 'revoked_proxy_ca' certificate/key to revoke intermediate CA."
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts oper_ca  -config ../../../cert/openssl.cnf \
     -out revoked_proxy_ca.csr -keyout private/revoked_proxy_ca.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=RSA Domain Proxy CA0002/CN=WInnForum RSA Domain Proxy CA - Revoked"
-openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in revoked_proxy_ca.csr \
-    -policy policy_anything -extensions oper_ca_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert root_ca.cert -keyfile private/root_ca.key \
+    -in revoked_proxy_ca.csr \
+    -policy policy_anything -extensions oper_ca_sign \
+    -config ../../../cert/openssl.cnf \
     -out revoked_proxy_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
-echo -e "\n\nGenerate 'domain_proxy' certificate/key signed by revoked_proxy_ca"
+printf "\n\n"
+echo "Generate 'domain_proxy' certificate/key signed by revoked_proxy_ca"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts oper_req -config ../../../cert/openssl.cnf \
-    -out domain_proxy_cert_from_revoked_ca.csr -keyout domain_proxy_cert_from_revoked_ca.key \
+    -out domain_proxy_cert_from_revoked_ca.csr \
+    -keyout domain_proxy_cert_from_revoked_ca.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum Domain Proxy Certificate/CN=0123456789:0010 - Revoked"
-openssl ca -cert revoked_proxy_ca.cert -keyfile private/revoked_proxy_ca.key -in domain_proxy_cert_from_revoked_ca.csr \
+openssl ca -cert revoked_proxy_ca.cert -keyfile private/revoked_proxy_ca.key \
+    -in domain_proxy_cert_from_revoked_ca.csr \
     -out domain_proxy_cert_from_revoked_ca.cert -outdir ./root \
-    -policy policy_anything -extensions oper_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions oper_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Revoke the Domain Proxy CA Certificate.
-echo -e "\n\nRevoke intermediate CA (revoked_proxy_ca) who already signed domain proxy certificate."
-openssl ca -revoke revoked_proxy_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
-    -config ../../../cert/openssl.cnf
+printf "\n\n"
+echo "Revoke intermediate CA (revoked_proxy_ca) who already signed domain proxy certificate."
+openssl ca -revoke revoked_proxy_ca.cert -keyfile private/root_ca.key \
+    -cert root_ca.cert -config ../../../cert/openssl.cnf
 
-# Certificate for test case WINNF.FT.S.SSS.16 - Certificate signed by a revoked CA presented during registration
-echo -e "\n\nGenerate 'sas_ca' certificate/key to revoke intermediate CA."
+# Certificate for test case WINNF.FT.S.SSS.16 -
+# Certificate signed by a revoked CA presented during registration
+printf "\n\n"
+echo "Generate 'sas_ca' certificate/key to revoke intermediate CA."
 openssl req -new -newkey rsa:4096 -nodes \
     -reqexts sas_ca  -config ../../../cert/openssl.cnf \
     -out revoked_sas_ca.csr -keyout private/revoked_sas_ca.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=RSA SAS Provider CA0002/CN=WInnForum RSA SAS Provider CA - Revoked"
-openssl ca -cert root_ca.cert -keyfile private/root_ca.key -in revoked_sas_ca.csr \
-    -policy policy_anything -extensions sas_ca_sign -config ../../../cert/openssl.cnf \
+openssl ca -cert root_ca.cert -keyfile private/root_ca.key \
+    -in revoked_sas_ca.csr \
+    -policy policy_anything -extensions sas_ca_sign \
+    -config ../../../cert/openssl.cnf \
     -out revoked_sas_ca.cert -outdir ./root \
     -batch -notext -create_serial -utf8 -days 5475 -md sha384
 
 # Generate sas server certificate/key.
-echo -e "\n\nGenerate 'sas server' certificate/key signed by revoked_sas_ca"
+printf "\n\n"
+echo "Generate 'sas server' certificate/key signed by revoked_sas_ca"
 openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_req -config ../../../cert/openssl.cnf \
     -out sas_cert_from_revoked_ca.csr -keyout sas_cert_from_revoked_ca.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=localhost - Revoked"
-openssl ca -cert revoked_sas_ca.cert -keyfile private/revoked_sas_ca.key -in sas_cert_from_revoked_ca.csr \
+openssl ca -cert revoked_sas_ca.cert -keyfile private/revoked_sas_ca.key \
+    -in sas_cert_from_revoked_ca.csr \
     -out sas_cert_from_revoked_ca.cert -outdir ./root \
-    -policy policy_anything -extensions sas_req_sign -config ../../../cert/openssl.cnf \
+    -policy policy_anything -extensions sas_req_sign \
+    -config ../../../cert/openssl.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
 # Revoke the SAS CA Certificate.
-openssl ca -revoke revoked_sas_ca.cert -keyfile private/root_ca.key -cert root_ca.cert \
-    -config ../../../cert/openssl.cnf
+openssl ca -revoke revoked_sas_ca.cert -keyfile private/root_ca.key \
+    -cert root_ca.cert -config ../../../cert/openssl.cnf
 
 # Creating CRL for revoked CA xxS.16 test cases
-echo -e "\n\n Generate CRL for root_ca"
+printf "\n\n"
+echo "Generate CRL for root_ca"
 openssl ca -gencrl -keyfile private/root_ca.key -cert root_ca.cert \
-     -config ../../../cert/openssl.cnf  -crldays 365 \
-     -out crl/root_ca.crl
+    -config ../../../cert/openssl.cnf  -crldays 365 \
+    -out crl/root_ca.crl
 
-echo -e "\n\n Generate CRL for revoked_cbsd_ca"
-openssl ca -gencrl -keyfile private/revoked_cbsd_ca.key -cert revoked_cbsd_ca.cert \
-     -config ../../../cert/openssl.cnf -crldays 365 \
-     -out crl/revoked_cbsd_ca.crl
+printf "\n\n"
+echo "Generate CRL for revoked_cbsd_ca"
+openssl ca -gencrl -keyfile private/revoked_cbsd_ca.key \
+    -cert revoked_cbsd_ca.cert \
+    -config ../../../cert/openssl.cnf -crldays 365 \
+    -out crl/revoked_cbsd_ca.crl
 
-echo -e "\n\n Generate CRL for revoked_sas_ca"
-openssl ca -gencrl -keyfile private/revoked_sas_ca.key -cert revoked_sas_ca.cert \
-     -config ../../../cert/openssl.cnf -crldays 365 \
-     -out crl/revoked_sas_ca.crl
+printf "\n\n"
+echo "Generate CRL for revoked_sas_ca"
+openssl ca -gencrl -keyfile private/revoked_sas_ca.key \
+    -cert revoked_sas_ca.cert \
+    -config ../../../cert/openssl.cnf -crldays 365 \
+    -out crl/revoked_sas_ca.crl
 
-echo -e "\n\n Generate CRL for revoked_proxy_ca"
-openssl ca -gencrl -keyfile private/revoked_proxy_ca.key -cert revoked_proxy_ca.cert \
-     -config ../../../cert/openssl.cnf -crldays 365 \
-     -out crl/revoked_proxy_ca.crl
+printf "\n\n"
+echo "Generate CRL for revoked_proxy_ca"
+openssl ca -gencrl -keyfile private/revoked_proxy_ca.key \
+    -cert revoked_proxy_ca.cert \
+    -config ../../../cert/openssl.cnf -crldays 365 \
+    -out crl/revoked_proxy_ca.crl
 
 # Generate trusted CA bundle.
-echo -e "\n\nGenerate 'ca' bundle"
-cat cbsd_ca.cert proxy_ca.cert sas_ca.cert root_ca.cert cbsd-ecc_ca.cert sas-ecc_ca.cert root-ecc_ca.cert \
-    revoked_cbsd_ca.cert revoked_sas_ca.cert revoked_proxy_ca.cert > ca.cert
+printf "\n\n"
+echo "Generate 'ca' bundle"
+cat cbsd_ca.cert proxy_ca.cert sas_ca.cert root_ca.cert cbsd-ecc_ca.cert \
+    sas-ecc_ca.cert root-ecc_ca.cert revoked_cbsd_ca.cert \
+    revoked_sas_ca.cert revoked_proxy_ca.cert > ca.cert
 # Append the github cert, use to download test dump file.
-echo | openssl s_client  -servername raw.githubusercontent.com -connect raw.githubusercontent.com:443 -prexit < /dev/null 2>&1 | \
+echo | \
+    openssl s_client \
+        -servername raw.githubusercontent.com \
+        -connect raw.githubusercontent.com:443 \
+        -prexit < /dev/null 2>&1 | \
     sed -n -e '/BEGIN\ CERTIFICATE/,/END\ CERTIFICATE/ p' >> ca.cert
 
 # Create CA certificate chain containing the CRLs with revoked leaf certificates.
@@ -602,5 +766,3 @@ cat ca.cert crl/ca_sxs16.crl > ca_crl_chain_sxs16.cert
 
 # Cleanup: remove all files not directly used by the testcases or other scripts.
 rm *.csr
-
-

--- a/src/harness/certs/generate_sas_cert.sh
+++ b/src/harness/certs/generate_sas_cert.sh
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# If this appears in an error message, then you should use openssl_db instead.
+export OPENSSL_CNF_CA_DIR="_use_openssl_db_instead_"
+
+# Runs openssl using the database for a particular CA.
+# $1 should match an existing db/* directory.
+function openssl_db {
+  OPENSSL_CNF_CA_DIR="db/$1" openssl "${@:2}" \
+      -cert "$1.cert" -keyfile "private/$1.key"
+}
+
 # Make sure we have the CN.
 if [ -z "$1" ]
   then
@@ -49,8 +59,8 @@ openssl req -new -newkey rsa:2048 -nodes \
     -reqexts sas_req_san_ext -config san.cnf \
     -out sas_uut.csr -keyout sas_uut.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=$1"
-openssl ca -cert sas_ca.cert -keyfile private/sas_ca.key -in sas_uut.csr \
-    -out sas_uut.cert -outdir ./root \
+openssl_db sas_ca ca -in sas_uut.csr \
+    -out sas_uut.cert \
     -policy policy_anything -extensions sas_req_san_ext_sign -config san.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 
@@ -60,8 +70,8 @@ openssl req -new -nodes \
     -reqexts sas_req_san_ext -config san.cnf \
     -out sas_uut-ecc.csr -key sas_uut-ecc.key \
     -subj "/C=US/O=Wireless Innovation Forum/OU=WInnForum SAS Provider Certificate/CN=$1"
-openssl ca -cert sas-ecc_ca.cert -keyfile private/sas-ecc_ca.key -in sas_uut-ecc.csr \
-    -out sas_uut-ecc.cert -outdir ./root \
+openssl_db sas-ecc_ca ca -in sas_uut-ecc.csr \
+    -out sas_uut-ecc.cert \
     -policy policy_anything -extensions sas_req_san_ext_sign -config san.cnf \
     -batch -notext -create_serial -utf8 -days 1185 -md sha384
 

--- a/src/harness/certs/generate_sas_cert.sh
+++ b/src/harness/certs/generate_sas_cert.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
-# If this appears in an error message, then you should use openssl_db instead.
-export OPENSSL_CNF_CA_DIR="_use_openssl_db_instead_"
+. include_crldp_base.sh
+echo "Using CRL distribution points: $CRLDP_BASE<ca_name>.crl"
 
 # Runs openssl using the database for a particular CA.
 # $1 should match an existing db/* directory.
 function openssl_db {
-  OPENSSL_CNF_CA_DIR="db/$1" openssl "${@:2}" \
+  OPENSSL_CNF_CA_DIR="db/$1" OPENSSL_CNF_CRLDP="$CRLDP_BASE$1.crl" \
+      openssl "${@:2}" \
       -cert "$1.cert" -keyfile "private/$1.key"
 }
 

--- a/src/harness/certs/generate_short_lived_certs.sh
+++ b/src/harness/certs/generate_short_lived_certs.sh
@@ -1,12 +1,29 @@
 #!/bin/bash -e
 
-# Setup: build intermediate directories.
-mkdir -p root
-touch index.txt
-echo -n 'unique_subject = no' >> index.txt.attr
+declare -ra CA_NAMES=(
+  cbsd_ca
+  proxy_ca
+)
 
-function generate_cbsd_short_lived_certificate()
-{
+# Create index.txt (if it doesn't already exist) for each CA.
+for ca in "${CA_NAMES[@]}"; do
+  mkdir -p "db/$ca"
+  touch "db/$ca/index.txt"
+  echo -n "unique_subject = no" > "db/$ca/index.txt.attr"
+done
+
+# If this appears in an error message, then you should use openssl_db instead.
+export OPENSSL_CNF_CA_DIR="_use_openssl_db_instead_"
+
+# Runs openssl using the database for a particular CA.
+# $1 should match an entry from the CA_NAMES array.
+function openssl_db {
+  OPENSSL_CNF_CA_DIR="db/$1" openssl "${@:2}" \
+      -config ../../../cert/openssl.cnf \
+      -cert "$1.cert" -keyfile "private/$1.key"
+}
+
+function generate_cbsd_short_lived_certificate() {
   # Argument1: Name of the certificate to be generated.
   # Argument2: Time (in minutes).
 
@@ -23,9 +40,8 @@ function generate_cbsd_short_lived_certificate()
         -reqexts cbsd_req -config ../../../cert/openssl.cnf \
         -out $1.csr -keyout $1.key \
         -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=test_fcc_id_a:test_serial_number_a"
-    openssl ca -cert cbsd_ca.cert -keyfile private/cbsd_ca.key -in $1.csr \
-        -out $1.cert -outdir ./root \
-        -policy policy_anything -extensions cbsd_req_sign -config ../../../cert/openssl.cnf \
+    openssl_db cbsd_ca ca -in $1.csr -out $1.cert \
+        -policy policy_anything -extensions cbsd_req_sign \
         -batch -notext -create_serial -utf8 -days 1185 -md sha384 -enddate $enddate_value
         return 0
   fi
@@ -33,8 +49,7 @@ function generate_cbsd_short_lived_certificate()
   return -1
 }
 
-function generate_dp_short_lived_certificate()
-{
+function generate_dp_short_lived_certificate() {
   # Argument1: Name of the certificate to be generated.
   # Argument2: Time (in minutes).
 
@@ -51,9 +66,8 @@ function generate_dp_short_lived_certificate()
         -reqexts oper_req -config ../../../cert/openssl.cnf \
         -out $1.csr -keyout $1.key \
         -subj "/C=US/ST=District of Columbia/L=Washington/O=Wireless Innovation Forum/OU=www.wirelessinnovation.org/CN=0112233445:0011"
-    openssl ca -cert proxy_ca.cert -keyfile private/proxy_ca.key -in $1.csr \
-        -out $1.cert -outdir ./root \
-        -policy policy_anything -extensions oper_req_sign -config ../../../cert/openssl.cnf \
+    openssl_db proxy_ca ca -in $1.csr -out $1.cert \
+        -policy policy_anything -extensions oper_req_sign \
         -batch -notext -create_serial -utf8 -days 1185 -md sha384 -enddate $enddate_value
     return 0
   fi
@@ -70,5 +84,3 @@ else
   echo "Wrong option other than (CBSD, DomainProxy)."
   exit -1
 fi
-
-rm -rf root

--- a/src/harness/certs/include_crldp_base.sh
+++ b/src/harness/certs/include_crldp_base.sh
@@ -1,0 +1,1 @@
+CRLDP_BASE="http://localhost:9007/"

--- a/src/harness/testcases/README.md
+++ b/src/harness/testcases/README.md
@@ -6,13 +6,20 @@ The current test cases are based on the [WinnForum test specification](https://w
 
 ## Security Test Cases
 
-The SCS.11/16, SDS.11/16 and SSS.11/16 TCs just expect the handshake failure and do not validate the reason for failure.<br>
-The correct way to run the fake_sas for these test cases is
-<pre>
-<code>
-<b> $ python fake_sas.py --verify_crl --ca ca_crl_chain_sxs11/16.cert </b>
-</code>
-</pre>
+The following test cases expect handshake failures due to certificate revocation
+(though they don't validate the reason for the failure):
+
+- SCS_11
+- SCS_16
+- SDS_11
+- SDS_16
+- SSS_11
+- SSS_16
+
+They may be run against fake_sas by injecting the CRL files directly:
+
+    $ python fake_sas.py --crl_index certs/crl/crl_index_sxs11.txt
+    $ python fake_sas.py --crl_index certs/crl/crl_index_sxs16.txt
 
 As WinnF WG.2 and ITS approved to use CRL as the initial certificate blacklisting solution before OCSP is available, 
 came up with following agreements
@@ -38,20 +45,5 @@ CRL file is not implemented in fake_sas.
 To obtain the CRL file, the <b>simple CRL server</b> in <b>master</b> branch needs to be 
 executed and a CRL chain can be retrieved from this server.
 
-The steps are
-
-1. Run the ‘simple CRL server’
-<b> $ python simple_crl_server.py </b>
-2. Use the menu option to blacklist a certificate (client cert or DP cert or SAS cert).
-3. Use wget on the simple CRL server URL to get the CRL chain file.
-<b> wget http://localhost:9007/ca.crl </b>
-4. Concatenate the CA chain file and the CRL file to create a combined CA chain and CRL chain file.
-<b> cat certs/ca.cert ca.crl > certs/ca_crl_chain.cert </b>
-5. Run the fake_sas with the <b>--verify_crl</b> and <b>--ca ca_crl_chain.cert</b> option.
-
 The details of using the <b>simple CRL server</b> is documented under <b>harness/CRLServer-README.md file</b>. 
 The simple CRL server is also enhanced with simpler menu option and ability to blacklist intermediate CAs.
-
-However to make it bit more easier to run the SXS.11/16 test cases, a default CRL file containing the CA chain and 
-the CRL chain containing the blacklisted certificates for SXS.11/16 test cases is created. 
-So the fake_sas can be run with the ca file <b>ca_crl_chain_sxs11/16.cert</b> without running the <b>simple CRL server</b>.


### PR DESCRIPTION
I recommend looking at the commits individually, to separate the signal (CRL-related fixes) from the noise (formatting cleanups).

This pull request gives each CA its own database and RFC-compliant CRL file.

In terms of ITS using this code, there is one key functional difference:

- Before: There is a single CRL Distribution Point **URL**, stored in `simple_crl_server.py` and `openssl.cnf`.
  http://crl.example.com:1234/ca.crl
  
- After: There is a CRL Distribution Point **URL prefix**, stored in `simple_crl_server.py` and `include_crldp_base.sh`. Each CA generates its own suffix.

  `CRLDP_BASE = "http://crl.example.com:1234/"`
  ↓
  http://crl.example.com:1234/root_ca.crl
  http://crl.example.com:1234/cbsd_ca.crl
  http://crl.example.com:1234/sas_ca.crl
  [ etc. ]

---

**Use a distinct index.txt database for each CA.**

Prior to this change, all CAs stored their revoked certificates in the
same database.  Now, all openssl commands that depend on a database must
specify which CA to modify.

After running generate_fake_certs.sh, you can browse the db/ directory
to see certs (and revocations) belonging to each CA.

---

**Generate one CRL per CA, in DER format.**

Previously, we concatenated several PEM-formatted CRLs into a single
ca.crl file, but https://tools.ietf.org/html/rfc5280#section-4.2.1.13
specifies that each URI "MUST point to a single DER encoded CRL".

Changes include:

- The generate scripts emit .crl files in DER format, and pass
  CA-specific CRLDP values to openssl.

- fake_sas accepts a crl_index_*.txt file, containing a list of
  DER-encoded CRLs.  While the files are now in the correct format,
  the distribution method is trivial compared to a real SAS.

- simple_crl_server writes the CRLDP to a one-line include file instead
  of openssl.cnf, and serves multiple *.crl files over HTTP.

- openssl.cnf obtains CRLDPs from its environment, and provides default
  values for its environment variables (because the error triggered by a
  missing variable was pretty cryptic.)