### PR TITLE
Adding 501 as a valid response code to 2nd CBSD in first check for FDB4 default config

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_FDB_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FDB_testcase.py
@@ -766,7 +766,7 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
             [grant_g1_a, grant_g1_b],
             [grant_g2_a, grant_g2_b]],
         'expectedResponseCodes': [
-            [(0, ), (0,)],
+            [(0, ), (0,501)],
             [(501, ), (501, )]],
         'conditionalRegistrationData': conditionals,
         'fssDatabaseConfig': fss_database_config


### PR DESCRIPTION
update FDB4 default config so the second CBSD on the first check also allows a response code of 501