### PR TITLE
Marking Grant Object as Not Authorized if it is terminated

### DIFF
--- a/src/harness/test_harness_objects.py
+++ b/src/harness/test_harness_objects.py
@@ -250,6 +250,7 @@ class DomainProxy(object):
       grant_object.authorized_in_last_heartbeat = True
     elif heartbeat_response_code == ResponseCodes.TERMINATED_GRANT.value:
       grant_object.is_terminated = True
+      grant_object.authorized_in_last_heartbeat = False
     elif heartbeat_response_code == ResponseCodes.SUSPENDED_GRANT.value:
       grant_object.authorized_in_last_heartbeat = False
     else:


### PR DESCRIPTION
getAuthorizedGrants and hasAuthorizedGrant might cause an issue(Still give or create the Grants which are not Authorized) if the Grant is Terminated instead of Suspended. Updating the authorized_in_last_heartbeat flag might solve the issue.