### PR TITLE
Use of East3 in IPR.3 Instead of East4

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -581,7 +581,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
 
     frequency_range = grant_a['operationParam']['operationFrequencyRange']
     dpa_1 = {
-        'dpaId': 'East4',
+        'dpaId': 'East3',
         'frequencyRange': {
             'lowFrequency': frequency_range['lowFrequency'],
             'highFrequency': frequency_range['highFrequency']


### PR DESCRIPTION
Modify DPA which is in the Neighborhood of the CBSD.