### PR TITLE
Fixes the default config for IPR_5

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -744,7 +744,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
 
     frequency_range = grant_a['operationParam']['operationFrequencyRange']
     dpa_1 = {
-        'dpaId': 'East4',
+        'dpaId': 'East3',
         'frequencyRange': {
             'lowFrequency': frequency_range['lowFrequency'],
             'highFrequency': frequency_range['highFrequency']


### PR DESCRIPTION
The default config activates East4 which is approx. 2278 km from the CBSD and hence its grants are not affected. Changing the config to activate East3, which is approx. 65 km away so that the grant is on the move list and hence the transmitExpireTime is updated as expected.