### PR TITLE
pre-IAP filtering and iap shall be performed even when there is no peer SASs

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -391,13 +391,12 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
     logging.info('Step 10: Triggering CPAS.')
     self.cpas = self.cpas_executor.submit(self.TriggerDailyActivitiesImmediatelyAndWaitUntilComplete)
 
-    if self.num_peer_sases:
-      # Step 11: Invoke IAP reference model
-      logging.info('Step 11: Performing pre-IAP filtering.')
-      pre_iap_filtering.preIapReferenceModel(self.protected_entity_records,
-                                     self.sas_uut_fad, self.test_harness_fads)
-      logging.info('Step 11: Performing IAP.')
-      self.performIap()
+    # Step 11: Invoke IAP reference model
+    logging.info('Step 11: Performing pre-IAP filtering.')
+    pre_iap_filtering.preIapReferenceModel(self.protected_entity_records,
+                                   self.sas_uut_fad, self.test_harness_fads)
+    logging.info('Step 11: Performing IAP.')
+    self.performIap()
 
     # Step 12: Invoke DPA ML reference model for currently-active and
     # will-be-active DPAs.


### PR DESCRIPTION
In the current MCP codes, for step 11, pre-IAP filtering and IAP will only be performed when there is at least one peer SAS. If no peer SAS, the functions will be skipped. This will fail all the single SAS incumbent protection test cases such as EPR.1, PPR.1 and so on. This fix is to remove the number of peer SAS check to allow the functions be called in all cases including single SAS case.