### PR TITLE
Remove DPA filtering on Hawaii6

### DIFF
--- a/src/harness/reference_models/geo/zones.py
+++ b/src/harness/reference_models/geo/zones.py
@@ -237,7 +237,6 @@ def _ReadKmlZones(kml_path, root_id_zone='Placemark', ignore_if_parent=None,
       continue
 
     name = element.name.text
-    if name == 'Hawaii6': continue
     # Read the zone geometry
     geometry = None
     polygons = [_GetPolygon(poly)


### PR DESCRIPTION
This DPA was filtered out as a hack as it was invalid for a while.
Since then, it has been fixed by NIck (NTIA), but the hack never removed.