### PR TITLE
Fix Server Shutdown between Tests

### DIFF
--- a/src/harness/database.py
+++ b/src/harness/database.py
@@ -112,6 +112,7 @@ class DatabaseServer(threading.Thread):
     """This method is used to stop HTTPServer Socket."""
     self.stopped = True
     self.server.shutdown()
+    self.server.server_close()
     logging.info('Stopped Database Server:%s', self.name)
 
   def setFileToServe(self, file_url, file_path):

--- a/src/harness/database.py
+++ b/src/harness/database.py
@@ -108,6 +108,12 @@ class DatabaseServer(threading.Thread):
     logging.info('Shutting down Database Server:%s at %s', self.name,
                  self.address)
 
+  def shutdown(self):
+    """This method is used to stop HTTPServer Socket."""
+    self.stopped = True
+    self.server.shutdown()
+    logging.info('Stopped Database Server:%s', self.name)
+
   def setFileToServe(self, file_url, file_path):
     """Remove existing path mappings and set a single file url to path mapping.
 

--- a/src/harness/sas_test_harness.py
+++ b/src/harness/sas_test_harness.py
@@ -180,6 +180,7 @@ class SasTestHarnessServer(threading.Thread):
     """This method is used to stop HTTPServer Socket."""
     self.stopped = True
     self.server.shutdown()
+    self.server.server_close()
     logging.info('Stopped Test Harness Server:%s', self.name)
 
 

--- a/src/harness/sas_testcase.py
+++ b/src/harness/sas_testcase.py
@@ -14,6 +14,7 @@
 
 from datetime import datetime, timedelta
 import logging
+import threading
 import time
 import unittest
 import sas
@@ -506,4 +507,11 @@ class SasTestCase(unittest.TestCase):
     self.assertTrue(self._sas_admin.GetPpaCreationStatus()['withError'],
                     msg='Expected:There is an error in create PPA. But '
                         'PPA creation status indicates no error')
-						
+
+
+  def ShutdownServers(self):
+    logging.info('Stopping all running servers, if any')
+    for thread in threading.enumerate():
+      if 'shutdown' in dir(thread):
+        logging.info('Stopping %s' % thread.name)
+        thread.shutdown()

--- a/src/harness/testcases/WINNF_FT_S_EPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_EPR_testcase.py
@@ -15,8 +15,6 @@
 import json
 import os
 import sas
-import logging
-import threading
 import sas_testcase
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords, \
     generatePpaRecords
@@ -33,11 +31,7 @@ class EscProtectionTestcase(McpXprCommonTestcase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    logging.info('Stopping all running servers, if any')
-    for thread in threading.enumerate():
-      if 'shutdown' in dir(thread):
-        logging.info('Stopping %s' % thread.name)
-        thread.shutdown()
+    self.ShutdownServers()
 
   def generate_EPR_1_default_config(self, filename):
     """ Generates the WinnForum configuration for EPR.1. """

--- a/src/harness/testcases/WINNF_FT_S_EPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_EPR_testcase.py
@@ -15,6 +15,8 @@
 import json
 import os
 import sas
+import logging
+import threading
 import sas_testcase
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords, \
     generatePpaRecords
@@ -31,7 +33,11 @@ class EscProtectionTestcase(McpXprCommonTestcase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    pass
+    logging.info('Stopping all running servers, if any')
+    for thread in threading.enumerate():
+      if 'shutdown' in dir(thread):
+        logging.info('Stopping %s' % thread.name)
+        thread.shutdown()
 
   def generate_EPR_1_default_config(self, filename):
     """ Generates the WinnForum configuration for EPR.1. """

--- a/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
@@ -17,7 +17,6 @@ import copy
 import hashlib
 import json
 import os
-import threading
 import common_strings
 import sas
 import sas_testcase
@@ -39,11 +38,7 @@ class FullActivityDumpTestcase(sas_testcase.SasTestCase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    logging.info('Stopping all running servers, if any')
-    for thread in threading.enumerate():
-      if 'shutdown' in dir(thread):
-        logging.info('Stopping %s' % thread.name)
-        thread.shutdown()
+    self.ShutdownServers()
 
   def assertEqualToDeviceOrPreloadedConditionalParam(self, attr_name, registration_request,\
                                                      preloaded_conditionals, record):

--- a/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
@@ -17,6 +17,7 @@ import copy
 import hashlib
 import json
 import os
+import threading
 import common_strings
 import sas
 import sas_testcase
@@ -38,7 +39,11 @@ class FullActivityDumpTestcase(sas_testcase.SasTestCase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    pass
+    logging.info('Stopping all running servers, if any')
+    for thread in threading.enumerate():
+      if 'shutdown' in dir(thread):
+        logging.info('Stopping %s' % thread.name)
+        thread.shutdown()
 
   def assertEqualToDeviceOrPreloadedConditionalParam(self, attr_name, registration_request,\
                                                      preloaded_conditionals, record):

--- a/src/harness/testcases/WINNF_FT_S_FDB_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FDB_testcase.py
@@ -17,7 +17,6 @@ import json
 import logging
 import os
 import sas
-import threading
 import sas_testcase
 from database import DatabaseServer
 from datetime import date, datetime, time, timedelta
@@ -45,11 +44,7 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    logging.info('Stopping all running servers, if any')
-    for thread in threading.enumerate():
-      if 'shutdown' in dir(thread):
-        logging.info('Stopping %s' % thread.name)
-        thread.shutdown()
+    self.ShutdownServers()
 
   def generate_FDB_1_default_config(self, filename):
     """Generates the WinnForum configuration for FDB.1"""

--- a/src/harness/testcases/WINNF_FT_S_FDB_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FDB_testcase.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import sas
+import threading
 import sas_testcase
 from database import DatabaseServer
 from datetime import date, datetime, time, timedelta
@@ -44,7 +45,11 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    pass
+    logging.info('Stopping all running servers, if any')
+    for thread in threading.enumerate():
+      if 'shutdown' in dir(thread):
+        logging.info('Stopping %s' % thread.name)
+        thread.shutdown()
 
   def generate_FDB_1_default_config(self, filename):
     """Generates the WinnForum configuration for FDB.1"""

--- a/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
@@ -16,8 +16,6 @@
 import json
 import os
 import sas
-import logging
-import threading
 import sas_testcase
 from sas_test_harness import generateCbsdRecords
 from util import winnforum_testcase, writeConfig, loadConfig, configurable_testcase,\
@@ -32,11 +30,7 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    logging.info('Stopping all running servers, if any')
-    for thread in threading.enumerate():
-      if 'shutdown' in dir(thread):
-        logging.info('Stopping %s' % thread.name)
-        thread.shutdown()
+    self.ShutdownServers()
 
   def generate_FPR_1_default_config(self, filename):
     """ Generates the WinnForum configuration for FPR.1. """

--- a/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FPR_testcase.py
@@ -16,6 +16,8 @@
 import json
 import os
 import sas
+import logging
+import threading
 import sas_testcase
 from sas_test_harness import generateCbsdRecords
 from util import winnforum_testcase, writeConfig, loadConfig, configurable_testcase,\
@@ -30,7 +32,11 @@ class FSSProtectionTestcase(McpXprCommonTestcase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    pass
+    logging.info('Stopping all running servers, if any')
+    for thread in threading.enumerate():
+      if 'shutdown' in dir(thread):
+        logging.info('Stopping %s' % thread.name)
+        thread.shutdown()
 
   def generate_FPR_1_default_config(self, filename):
     """ Generates the WinnForum configuration for FPR.1. """

--- a/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
@@ -15,8 +15,6 @@
 import json
 import os
 import sas
-import threading
-import logging
 import sas_testcase
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords, \
     generatePpaRecords
@@ -33,11 +31,7 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    logging.info('Stopping all running servers, if any')
-    for thread in threading.enumerate():
-      if 'shutdown' in dir(thread):
-        logging.info('Stopping %s' % thread.name)
-        thread.shutdown()
+    self.ShutdownServers()
 
   def generate_GPR_1_default_config(self, filename):
     """ Generates the WinnForum configuration for GPR.1. """

--- a/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_GPR_testcase.py
@@ -15,6 +15,8 @@
 import json
 import os
 import sas
+import threading
+import logging
 import sas_testcase
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords, \
     generatePpaRecords
@@ -31,7 +33,11 @@ class GwpzProtectionTestcase(McpXprCommonTestcase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    pass
+    logging.info('Stopping all running servers, if any')
+    for thread in threading.enumerate():
+      if 'shutdown' in dir(thread):
+        logging.info('Stopping %s' % thread.name)
+        thread.shutdown()
 
   def generate_GPR_1_default_config(self, filename):
     """ Generates the WinnForum configuration for GPR.1. """

--- a/src/harness/testcases/WINNF_FT_S_GRA_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_GRA_testcase.py
@@ -48,7 +48,6 @@ import os
 import time
 import sas
 import sas_testcase
-import threading
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords
 from util import winnforum_testcase, getRandomLatLongInPolygon, \
   makePpaAndPalRecordsConsistent, configurable_testcase, writeConfig, \
@@ -62,11 +61,7 @@ class GrantTestcase(sas_testcase.SasTestCase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    logging.info('Stopping all running servers, if any')
-    for thread in threading.enumerate():
-      if 'shutdown' in dir(thread):
-        logging.info('Stopping %s' % thread.name)
-        thread.shutdown()
+    self.ShutdownServers()
 
   @winnforum_testcase
   def test_WINNF_FT_S_GRA_1(self):

--- a/src/harness/testcases/WINNF_FT_S_GRA_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_GRA_testcase.py
@@ -48,6 +48,7 @@ import os
 import time
 import sas
 import sas_testcase
+import threading
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords
 from util import winnforum_testcase, getRandomLatLongInPolygon, \
   makePpaAndPalRecordsConsistent, configurable_testcase, writeConfig, \
@@ -61,7 +62,11 @@ class GrantTestcase(sas_testcase.SasTestCase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    pass
+    logging.info('Stopping all running servers, if any')
+    for thread in threading.enumerate():
+      if 'shutdown' in dir(thread):
+        logging.info('Stopping %s' % thread.name)
+        thread.shutdown()
 
   @winnforum_testcase
   def test_WINNF_FT_S_GRA_1(self):

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -17,7 +17,6 @@ import logging
 import json
 import os
 import sas
-import threading
 import sas_testcase
 import time
 
@@ -44,11 +43,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    logging.info('Stopping all running servers, if any')
-    for thread in threading.enumerate():
-      if 'shutdown' in dir(thread):
-        logging.info('Stopping %s' % thread.name)
-        thread.shutdown()
+    self.ShutdownServers()
 
   def frequencyInBand(self, low_frequency, high_frequency):
     """Returns True iff the given range overlaps with the 3550-3650MHz range."""

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -17,6 +17,7 @@ import logging
 import json
 import os
 import sas
+import threading
 import sas_testcase
 import time
 
@@ -43,7 +44,11 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    pass
+    logging.info('Stopping all running servers, if any')
+    for thread in threading.enumerate():
+      if 'shutdown' in dir(thread):
+        logging.info('Stopping %s' % thread.name)
+        thread.shutdown()
 
   def frequencyInBand(self, low_frequency, high_frequency):
     """Returns True iff the given range overlaps with the 3550-3650MHz range."""

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -20,6 +20,7 @@ import os
 from reference_models.common import mpool
 from functools import partial
 import logging
+import threading
 import sas
 import sas_testcase
 import test_harness_objects
@@ -822,7 +823,11 @@ class MultiConstraintProtectionTestcase(McpXprCommonTestcase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    pass
+    logging.info('Stopping all running servers, if any')
+    for thread in threading.enumerate():
+      if 'shutdown' in dir(thread):
+        logging.info('Stopping %s' % thread.name)
+        thread.shutdown()
 
   def generate_MCP_1_default_config(self, filename):
     """ Generates the WinnForum configuration for MCP.1. """

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -20,7 +20,6 @@ import os
 from reference_models.common import mpool
 from functools import partial
 import logging
-import threading
 import sas
 import sas_testcase
 import test_harness_objects
@@ -823,11 +822,7 @@ class MultiConstraintProtectionTestcase(McpXprCommonTestcase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    logging.info('Stopping all running servers, if any')
-    for thread in threading.enumerate():
-      if 'shutdown' in dir(thread):
-        logging.info('Stopping %s' % thread.name)
-        thread.shutdown()
+    self.ShutdownServers()
 
   def generate_MCP_1_default_config(self, filename):
     """ Generates the WinnForum configuration for MCP.1. """

--- a/src/harness/testcases/WINNF_FT_S_MES_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MES_testcase.py
@@ -28,6 +28,7 @@ class MeasurementTestcase(unittest.TestCase):
 
   def tearDown(self):
     pass
+
   @winnforum_testcase
   def test_WINNF_FT_S_MES_1(self):
     """The sas under test to request measurement reporting

--- a/src/harness/testcases/WINNF_FT_S_PPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_PPR_testcase.py
@@ -14,6 +14,8 @@
 
 import json
 import os
+import threading
+import logging
 import sas
 import sas_testcase
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords, \
@@ -30,7 +32,11 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    pass
+    logging.info('Stopping all running servers, if any')
+    for thread in threading.enumerate():
+      if 'shutdown' in dir(thread):
+        logging.info('Stopping %s' % thread.name)
+        thread.shutdown()
 
   def generate_PPR_1_default_config(self, filename):
     """ Generates the WinnForum configuration for PPR.1. """

--- a/src/harness/testcases/WINNF_FT_S_PPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_PPR_testcase.py
@@ -14,8 +14,6 @@
 
 import json
 import os
-import threading
-import logging
 import sas
 import sas_testcase
 from sas_test_harness import SasTestHarnessServer, generateCbsdRecords, \
@@ -32,11 +30,7 @@ class PpaProtectionTestcase(McpXprCommonTestcase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    logging.info('Stopping all running servers, if any')
-    for thread in threading.enumerate():
-      if 'shutdown' in dir(thread):
-        logging.info('Stopping %s' % thread.name)
-        thread.shutdown()
+    self.ShutdownServers()
 
   def generate_PPR_1_default_config(self, filename):
     """ Generates the WinnForum configuration for PPR.1. """

--- a/src/harness/testcases/WINNF_FT_S_WDB_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_WDB_testcase.py
@@ -18,7 +18,6 @@ import logging
 import os
 import sas
 import sas_testcase
-import threading
 from database import DatabaseServer
 from util import configurable_testcase, writeConfig, loadConfig,\
   convertRequestToRequestWithCpiSignature, makePalRecordsConsistent, \
@@ -33,11 +32,7 @@ class WinnforumDatabaseUpdateTestcase(sas_testcase.SasTestCase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    logging.info('Stopping all running servers, if any')
-    for thread in threading.enumerate():
-      if 'shutdown' in dir(thread):
-        logging.info('Stopping %s' % thread.name)
-        thread.shutdown()
+    self.ShutdownServers()
 
   def generate_WDB_1_default_config(self, filename):
     """Generates the WinnForum configuration for WDB.1"""

--- a/src/harness/testcases/WINNF_FT_S_WDB_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_WDB_testcase.py
@@ -18,6 +18,7 @@ import logging
 import os
 import sas
 import sas_testcase
+import threading
 from database import DatabaseServer
 from util import configurable_testcase, writeConfig, loadConfig,\
   convertRequestToRequestWithCpiSignature, makePalRecordsConsistent, \
@@ -32,7 +33,11 @@ class WinnforumDatabaseUpdateTestcase(sas_testcase.SasTestCase):
     self._sas_admin.Reset()
 
   def tearDown(self):
-    pass
+    logging.info('Stopping all running servers, if any')
+    for thread in threading.enumerate():
+      if 'shutdown' in dir(thread):
+        logging.info('Stopping %s' % thread.name)
+        thread.shutdown()
 
   def generate_WDB_1_default_config(self, filename):
     """Generates the WinnForum configuration for WDB.1"""


### PR DESCRIPTION
Added Server Shutdown as a part of Teardown. While running tests in Bulk Ports get exhausted, this fix will stop the servers if they are running in between tests.