### PR TITLE
Use the right grant request & maxEirp in the interference calculation.

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_BPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_BPR_testcase.py
@@ -285,7 +285,7 @@ class BorderProtectionTestcase(sas_testcase.SasTestCase):
       logging.info('Closest point in the border: Lat is %f', closest_point_lat)
       logging.info('Closest point in the border: Long is %f', closest_point_lon)
       # requested_eirp (p)
-      p = config['grantRequests'][i]['operationParam']['maxEirp']
+      p = config['grantRequests'][index]['operationParam']['maxEirp']
       # Calculate PL
       cbsd_height = cbsd_information['installationParam']['height']
       cbsd_height_type = cbsd_information['installationParam']['heightType']


### PR DESCRIPTION

Use the right grant request (and corresponding maxEirp) in the interference calculation. The existing code uses the wrong index into the grant requests array and hence there is a mismatch between the EIRP used in the SAS calculation vs. the EIRP used in the test harness calculation.