### PR TITLE
Renew grants with every heartbeat in functional tests

### DIFF
--- a/src/harness/test_harness_objects.py
+++ b/src/harness/test_harness_objects.py
@@ -50,7 +50,8 @@ class Grant(object):
     heartbeat_request = {
         'grantId': self.grant_id,
         'cbsdId': self.grant_request['cbsdId'],
-        'operationState': 'GRANTED'
+        'operationState': 'GRANTED',
+        'grantRenew': True
       }
     return heartbeat_request
 


### PR DESCRIPTION
We agreed long ago in test dev that we would set grantRenew=True in each heartbeat request made during the functional test cases, thus allowing the SAS Admin to set a relatively short grant duration (important for reducing the runtime of HBT.6) without unintended consequences (e.g. the grant expiring in the middle of MCP.1). This PR adds this functionality, which was inadvertently omitted.