### PR TITLE
Make base_url a parameter to assertTlsHandshakeFailure().

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_SCS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SCS_testcase.py
@@ -180,7 +180,9 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     """
     config = loadConfig(config_filename)
     try:
-      self.assertTlsHandshakeFailure(client_cert=config['clientCert'],
+      # This uses the same base_url as Registration().
+      self.assertTlsHandshakeFailure(self._sas.cbsd_sas_active_base_url,
+                                     client_cert=config['clientCert'],
                                      client_key=config['clientKey'])
     except AssertionError as e:
       self.SasReset()
@@ -283,7 +285,10 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     # Load the keys/certs and check that TLS handshake is valid
     device_a_cert = config['clientCert']
     device_a_key = config['clientKey']
-    self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'], device_a_cert, device_a_key)
+    # This uses the same base_url as Registration().
+    self.assertTlsHandshakeSucceed(self._sas.cbsd_sas_active_base_url,
+                                   ['AES128-GCM-SHA256'],
+                                   device_a_cert, device_a_key)
    
     # Load device and inject fccId and userId
     device_a = json.load(open(os.path.join('testcases', 'testdata', 'device_a.json')))
@@ -341,8 +346,10 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     device_cert = getCertFilename(device_cert_name + ".cert")
     device_key = getCertFilename(device_cert_name + ".key")
 
-    # Successful TLS Handshake
-    self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'],
+    # Successful TLS Handshake.
+    # This uses the same base_url as Registration().
+    self.assertTlsHandshakeSucceed(self._sas.cbsd_sas_active_base_url,
+                                   ['AES128-GCM-SHA256'],
                                    device_cert, device_key)
     logging.info("TLS Handshake Succeeded")
 
@@ -388,9 +395,11 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     device_cert = getCertFilename(device_cert_name + ".cert")
     device_key = getCertFilename(device_cert_name + ".key")
 
-    # Successful TLS Handshake
-    self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'], device_cert,
-                                   device_key)
+    # Successful TLS Handshake.
+    # This uses the same base_url as Registration().
+    self.assertTlsHandshakeSucceed(self._sas.cbsd_sas_active_base_url,
+                                   ['AES128-GCM-SHA256'],
+                                   device_cert, device_key)
     logging.info("TLS Handshake Succeeded")
 
     # Load the device_a file
@@ -439,7 +448,9 @@ class SasCbsdSecurityTestcase(security_testcase.SecurityTestCase):
     device_key = getCertFilename(device_cert_name + ".key")
 
     # Successful TLS Handshake.
-    self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'],
+    # This uses the same base_url as Registration().
+    self.assertTlsHandshakeSucceed(self._sas.cbsd_sas_active_base_url,
+                                   ['AES128-GCM-SHA256'],
                                    device_cert, device_key)
     logging.info("TLS Handshake Succeeded")
 

--- a/src/harness/testcases/WINNF_FT_S_SDS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SDS_testcase.py
@@ -180,7 +180,9 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     """
     config = loadConfig(config_filename)
     try:
-      self.assertTlsHandshakeFailure(client_cert=config['domainProxyCert'],
+      # This uses the same base_url as Registration().
+      self.assertTlsHandshakeFailure(self._sas.cbsd_sas_active_base_url,
+                                     client_cert=config['domainProxyCert'],
                                      client_key=config['domainProxyKey'])
     except AssertionError as e:
       self.SasReset()
@@ -278,7 +280,10 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     # Load the keys/certs and check that TLS handshake is valid
     device_a_cert = config['domainProxyCert']
     device_a_key = config['domainProxyKey']
-    self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'], device_a_cert, device_a_key)
+    # This uses the same base_url as Registration().
+    self.assertTlsHandshakeSucceed(self._sas.cbsd_sas_active_base_url,
+                                   ['AES128-GCM-SHA256'],
+                                   device_a_cert, device_a_key)
 
     # Load device and inject fccId and userId
     device_a = json.load(open(os.path.join('testcases', 'testdata', 'device_a.json')))
@@ -338,7 +343,9 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     domain_proxy_key = getCertFilename(device_cert_name + ".key")
 
     # Successful TLS Handshake.
-    self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'],
+    # This uses the same base_url as Registration().
+    self.assertTlsHandshakeSucceed(self._sas.cbsd_sas_active_base_url,
+                                   ['AES128-GCM-SHA256'],
                                    domain_proxy_cert, domain_proxy_key)
     logging.info("TLS Handshake Succeeded")
 
@@ -384,8 +391,10 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     domain_proxy_key = getCertFilename(device_cert_name + ".key")
 
     # Successful TLS Handshake.
-    self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'], domain_proxy_cert,
-                                   domain_proxy_key)
+    # This uses the same base_url as Registration().
+    self.assertTlsHandshakeSucceed(self._sas.cbsd_sas_active_base_url,
+                                   ['AES128-GCM-SHA256'],
+                                   domain_proxy_cert, domain_proxy_key)
     logging.info("TLS Handshake Succeeded")
 
     # Load the device_a file
@@ -433,8 +442,10 @@ class SasDomainProxySecurityTestcase(security_testcase.SecurityTestCase):
     domain_proxy_key = getCertFilename(device_cert_name + ".key")
 
     # Successful TLS Handshake.
-    self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'],domain_proxy_cert,
-                                   domain_proxy_key)
+    # This uses the same base_url as Registration().
+    self.assertTlsHandshakeSucceed(self._sas.cbsd_sas_active_base_url,
+                                   ['AES128-GCM-SHA256'],
+                                   domain_proxy_cert, domain_proxy_key)
     logging.info("TLS Handshake Succeeded")
 
     # Load the device_a file.

--- a/src/harness/testcases/WINNF_FT_S_SSS_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_SSS_testcase.py
@@ -212,7 +212,9 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     self._sas_admin.InjectPeerSas({'certificateHash': certificate_hash,\
                                      'url': SAS_TEST_HARNESS_URL})
     try:
-      self.assertTlsHandshakeFailure(client_cert=config['sasCert'],
+      # This uses the same base_url as GetFullActivityDump().
+      self.assertTlsHandshakeFailure(self._sas.sas_sas_active_base_url,
+                                     client_cert=config['sasCert'],
                                      client_key=config['sasKey'])
     except AssertionError:
       trigger_succeed = False
@@ -366,7 +368,10 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
     certificate_hash = getCertificateFingerprint(config['sasCert'])
     self._sas_admin.InjectPeerSas({'certificateHash': certificate_hash,\
                                      'url': SAS_TEST_HARNESS_URL })
-    self.assertTlsHandshakeSucceed(self._sas_admin._base_url, ['AES128-GCM-SHA256'], config['sasCert'], config['sasKey'])
+    # This uses the same base_url as GetFullActivityDump().
+    self.assertTlsHandshakeSucceed(self._sas.sas_sas_active_base_url,
+                                   ['AES128-GCM-SHA256'],
+                                   config['sasCert'], config['sasKey'])
     trigger_succeed = False
     # Initiate Full Activity Dump
     try:
@@ -477,7 +482,9 @@ class SasToSasSecurityTestcase(security_testcase.SecurityTestCase):
 
     # Attempting FAD record download with different invalid cert,key pair
     try:
-      self.assertTlsHandshakeFailure(client_cert=config['invalidCertKeyPair']['cert'],
+      # This uses the same base_url as GetFullActivityDump().
+      self.assertTlsHandshakeFailure(self._sas.sas_sas_active_base_url,
+                                     client_cert=config['invalidCertKeyPair']['cert'],
                                      client_key=config['invalidCertKeyPair']['key'])
     except AssertionError as e:
       try:


### PR DESCRIPTION
Call the assertTls*() functions with a base_url that matches a function
that the test is already using.

In practice, this means:
- SCS and SDS tests use cbsd_sas_active_base_url
- SSS tests use sas_sas_active_base_url

Fixes #803