### PR TITLE
Fix time zone issue in FDB.8

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_FDB_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FDB_testcase.py
@@ -1419,13 +1419,11 @@ class FederalGovernmentDatabaseUpdateTestcase(sas_testcase.SasTestCase):
     # Fetching current time in CPAS time zone
     current_time = datetime.now(timezone(CPAS_TIME_ZONE))
 
+    # Calculate the scheduled CPAS start time.
+    scheduled_cpas_start_time =  timezone(CPAS_TIME_ZONE).localize(datetime.combine(current_time.date(), time(CPAS_START_TIME)))
+
     # Checks if CPAS start time is over then wait till next day otherwise
     # wait till scheduled CPAS starts
-    scheduled_cpas_start_time = datetime.combine(current_time.date(), time(CPAS_START_TIME))
-
-    # Scheduled CPAS start time is made consistent with the CPAS_TIME_ZONE
-    scheduled_cpas_start_time = scheduled_cpas_start_time.replace(tzinfo=timezone(CPAS_TIME_ZONE))
-
     if scheduled_cpas_start_time < current_time:
       scheduled_cpas_start_time += timedelta(days=1)
 


### PR DESCRIPTION
With the existing code, `current_time` correctly uses PDT but `scheduled_cpas_start_time` and `scheduled_cpas_end_time` uses LMT, which ultimately causes the test harness to wait too long for CPAS to complete. This change corrects the timezone discrepancy.