### PR TITLE
EHata: Cleanup of the float -> double switch.

### DIFF
--- a/src/harness/reference_models/propagation/ehata/its/ExtendedHata.cpp
+++ b/src/harness/reference_models/propagation/ehata/its/ExtendedHata.cpp
@@ -65,8 +65,8 @@ void printInterValues(InterValues *interValues)
 *   Outputs:
 *       plb : path loss, in dB
 */
-void ExtendedHata(float pfl[], float f__mhz, float h_b__meter, float h_m__meter,
-    int enviro_code, float *plb)
+void ExtendedHata(double pfl[], double f__mhz, double h_b__meter, double h_m__meter,
+    int enviro_code, double *plb)
 {
     InterValues interValues;
     ExtendedHata_DBG(pfl, f__mhz, h_b__meter, h_m__meter, enviro_code, plb, &interValues);
@@ -87,14 +87,14 @@ void ExtendedHata(float pfl[], float f__mhz, float h_b__meter, float h_m__meter,
 *       plb : path loss, in dB
 *       interValues : data structure containing intermediate calculated values
 */
-void ExtendedHata_DBG(float pfl[], float f__mhz, float h_b__meter, float h_m__meter,
-    int enviro_code, float *plb, InterValues *interValues)
+void ExtendedHata_DBG(double pfl[], double f__mhz, double h_b__meter, double h_m__meter,
+    int enviro_code, double *plb, InterValues *interValues)
 {
     int np = int(pfl[0]);
 
     PreprocessTerrainPath(pfl, h_b__meter, h_m__meter, interValues);
 
-    float h_m_gnd__meter, d1_hzn__km, d2_hzn__km;
+    double h_m_gnd__meter, d1_hzn__km, d2_hzn__km;
 
     h_m_gnd__meter = pfl[2];
     interValues->h_m_eff__meter = h_m__meter + pfl[2] - interValues->h_avg__meter[0];
@@ -122,7 +122,7 @@ void ExtendedHata_DBG(float pfl[], float f__mhz, float h_b__meter, float h_m__me
 
     // ******* End WinnForum change *******
 
-    float plb_median__db;
+    double plb_median__db;
     MedianBasicPropLoss(f__mhz, interValues->h_b_eff__meter, interValues->h_m_eff__meter, interValues->d__km, enviro_code, &plb_median__db, interValues);
 
     // apply correction factors based on path

--- a/src/harness/reference_models/propagation/ehata/its/FindHorizons.cpp
+++ b/src/harness/reference_models/propagation/ehata/its/FindHorizons.cpp
@@ -1,18 +1,18 @@
 #include "ehata.h"
 
-void FindHorizons(float *pfl, float gme, float d__meter, float h_1__meter,
-    float h_2__meter, float *d_hzn__meter)
+void FindHorizons(double *pfl, double gme, double d__meter, double h_1__meter,
+    double h_2__meter, double *d_hzn__meter)
 {
-    float theta[2];
+    double theta[2];
 
     bool wq;
 
     int np = pfl[0];
-    float xi = pfl[1];
-    float za = pfl[2] + h_1__meter;
-    float zb = pfl[np + 2] + h_2__meter;
-    float qc = 0.5 * gme;
-    float q = qc * d__meter;
+    double xi = pfl[1];
+    double za = pfl[2] + h_1__meter;
+    double zb = pfl[np + 2] + h_2__meter;
+    double qc = 0.5 * gme;
+    double q = qc * d__meter;
     theta[1] = (zb - za) / d__meter;
     theta[0] = theta[1] - q;
     theta[1] = -theta[1] - q;
@@ -22,8 +22,8 @@ void FindHorizons(float *pfl, float gme, float d__meter, float h_1__meter,
     if (np < 2)
         return;
 
-    float sa = 0;
-    float sb = d__meter;
+    double sa = 0;
+    double sb = d__meter;
     wq = true;
     for (int i = 2; i <= np; i++)
     {

--- a/src/harness/reference_models/propagation/ehata/its/FindQuantile.cpp
+++ b/src/harness/reference_models/propagation/ehata/its/FindQuantile.cpp
@@ -1,8 +1,8 @@
 #include "ehata.h"
 
-float FindQuantile(const int &nn, float *a, const int &ir)
+double FindQuantile(const int &nn, double *a, const int &ir)
 {
-    float q, r;
+    double q, r;
     int m, n, i, j, j1, i0, k;
     bool done = false;
     bool goto10 = true;

--- a/src/harness/reference_models/propagation/ehata/its/FineRollingHillyTerrainCorectionFactor.cpp
+++ b/src/harness/reference_models/propagation/ehata/its/FineRollingHillyTerrainCorectionFactor.cpp
@@ -10,16 +10,16 @@
 *       interValues->deltah__meter : terrain irregularity parameter
 *       h_m_gnd__meter : mobile ground height, in meters
 *   Return:
-*       [float] : correction factor
+*       [double] : correction factor
 */
-float FineRollingHillyTerrainCorectionFactor(InterValues *interValues, float h_m_gnd__meter)
+double FineRollingHillyTerrainCorectionFactor(InterValues *interValues, double h_m_gnd__meter)
 {
-    float a = -11.728795;
-    float b = 15.544272;
-    float c = -1.8154766;
+    double a = -11.728795;
+    double b = 15.544272;
+    double c = -1.8154766;
 
-    float deltah_use;
-    float K_h;
+    double deltah_use;
+    double K_h;
 
     // deltaH must be at least 10 meters
     if (interValues->deltah__meter < 10.0)

--- a/src/harness/reference_models/propagation/ehata/its/GeneralSlopeCorrectionFactor.cpp
+++ b/src/harness/reference_models/propagation/ehata/its/GeneralSlopeCorrectionFactor.cpp
@@ -7,15 +7,15 @@
 *       theta_m__mrad : mobile terrain slope, in millirads
 *       d__km : path distance, in kilometers
 *   Return:
-*       [float] : correction factor
+*       [double] : correction factor
 */
-float GeneralSlopeCorrectionFactor(float theta_m__mrad, float d__km)
+double GeneralSlopeCorrectionFactor(double theta_m__mrad, double d__km)
 {
-    float emm1 = 0.25;
-    float emm2 = 0.8;
-    float emp1 = 0.125;
-    float emp2 = 0.35;
-    float emp3 = 0.6;
+    double emm1 = 0.25;
+    double emm2 = 0.8;
+    double emp1 = 0.125;
+    double emp2 = 0.35;
+    double emp3 = 0.6;
 
     // computing values from the curves on Fig 34 in Okumura
     if (theta_m__mrad <= 0.0)

--- a/src/harness/reference_models/propagation/ehata/its/IsolatedRidgeCorrectionFactor.cpp
+++ b/src/harness/reference_models/propagation/ehata/its/IsolatedRidgeCorrectionFactor.cpp
@@ -9,21 +9,21 @@
 *       d2_hzn__km : horizon distance, in kilometers
 *       h_edge__meter : intermediate value
 *   Return:
-*       [float] : correction factor
+*       [double] : correction factor
 */
-float IsolatedRidgeCorrectionFactor(float d1_hzn__km, float d2_hzn__km, float h_edge__meter)
+double IsolatedRidgeCorrectionFactor(double d1_hzn__km, double d2_hzn__km, double h_edge__meter)
 {
-    float d_1__km[3] = { 15.0, 30.0, 60.0 };
-    float d_2__km[9] = { 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
+    double d_1__km[3] = { 15.0, 30.0, 60.0 };
+    double d_2__km[9] = { 0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0 };
     
     // points from Figure 31, Okumura
-    float curve_data[3][9] = 
+    double curve_data[3][9] = 
             { {  4.0, -13.0, -17.5, -17.5, -15.0, -12.5, -10.0, -8.0, -6.0 },   // C curve : d1 <= 15 km
               { 12.0,  -8.5, -13.0, -12.0, -10.0,  -8.0,  -6.5, -5.0, -4.0 },   // B curve : d1 <= 30 km
               { 20.0,  -4.0,  -6.5,  -6.0,  -4.5,  -3.5,  -2.5, -2.0, -1.0 } }; // A curve : d1 <= 60 km
 
     // normalized ridge height factor
-    float alpha = sqrt(h_edge__meter / 200.0); // Eq 1, Okumura, alpha = 0.07 * sqrt(h)
+    double alpha = sqrt(h_edge__meter / 200.0); // Eq 1, Okumura, alpha = 0.07 * sqrt(h)
 
     int id1 = 0;
     if (d1_hzn__km >= d_1__km[1])
@@ -33,8 +33,8 @@ float IsolatedRidgeCorrectionFactor(float d1_hzn__km, float d2_hzn__km, float h_
     while (id2 < 7 && d2_hzn__km > d_2__km[id2 + 1])
         id2 = id2 + 1;
 
-    float c1 = curve_data[id1][id2] + (curve_data[id1][id2 + 1] - curve_data[id1][id2]) * (d2_hzn__km - d_2__km[id2]) / (d_2__km[id2 + 1] - d_2__km[id2]);
-    float c2 = curve_data[id1 + 1][id2] + (curve_data[id1 + 1][id2 + 1] - curve_data[id1 + 1][id2]) * (d2_hzn__km - d_2__km[id2]) / (d_2__km[id2 + 1] - d_2__km[id2]);
+    double c1 = curve_data[id1][id2] + (curve_data[id1][id2 + 1] - curve_data[id1][id2]) * (d2_hzn__km - d_2__km[id2]) / (d_2__km[id2 + 1] - d_2__km[id2]);
+    double c2 = curve_data[id1 + 1][id2] + (curve_data[id1 + 1][id2 + 1] - curve_data[id1 + 1][id2]) * (d2_hzn__km - d_2__km[id2]) / (d_2__km[id2 + 1] - d_2__km[id2]);
 
     return alpha * (c1 + (c2 - c1) * (d1_hzn__km - d_1__km[id1]) / (d_1__km[id1 + 1] - d_1__km[id1]));
 }

--- a/src/harness/reference_models/propagation/ehata/its/LeastSquares.cpp
+++ b/src/harness/reference_models/propagation/ehata/its/LeastSquares.cpp
@@ -9,13 +9,13 @@
 *                - pfl_segment[1] = step size, in meters
 *                - pfl_segment[i] = elevation above mean sea level, in meters
 */
-void LeastSquares(float *pfl_segment, float x1, float x2, float *z0, float *zn)
+void LeastSquares(double *pfl_segment, double x1, double x2, double *z0, double *zn)
 {
-    float xn = int(pfl_segment[0]);
-    float xi = pfl_segment[1];
+    double xn = int(pfl_segment[0]);
+    double xi = pfl_segment[1];
 
-    float xa = int(MAX(x1 / xi, 0.0));
-    float xb = xn - int(MAX(xn - x2 / xi, 0.0));
+    double xa = int(MAX(x1 / xi, 0.0));
+    double xb = xn - int(MAX(xn - x2 / xi, 0.0));
 
     if (xb <= xa)
     {
@@ -27,10 +27,10 @@ void LeastSquares(float *pfl_segment, float x1, float x2, float *z0, float *zn)
     int jb = xb;
     int n = jb - ja;
     xa = xb - xa;
-    float x = -0.5 * xa;
+    double x = -0.5 * xa;
     xb = xb + x;
-    float a = 0.5 * (pfl_segment[ja + 2] + pfl_segment[jb + 2]);
-    float b = 0.5 * (pfl_segment[ja + 2] - pfl_segment[jb + 2]) * x;
+    double a = 0.5 * (pfl_segment[ja + 2] + pfl_segment[jb + 2]);
+    double b = 0.5 * (pfl_segment[ja + 2] - pfl_segment[jb + 2]) * x;
     for (int i = 2; i <= n; i++)
     {
         ja = ja + 1;

--- a/src/harness/reference_models/propagation/ehata/its/MedianBasicPropLoss.cpp
+++ b/src/harness/reference_models/propagation/ehata/its/MedianBasicPropLoss.cpp
@@ -1,7 +1,7 @@
 #include "math.h"
 #include "ehata.h"
 
-void MedianBasicPropLoss(float f__mhz, float h_b__meter, float h_m__meter, float d__km, int enviro_code, float* plb_med__db, InterValues *interValues)
+void MedianBasicPropLoss(double f__mhz, double h_b__meter, double h_m__meter, double d__km, int enviro_code, double* plb_med__db, InterValues *interValues)
 {
     double perm = 4.0e-7 * PI;
     double eps = 8.854e-12;

--- a/src/harness/reference_models/propagation/ehata/its/MedianRollingHillyTerrainCorrectionFactor.cpp
+++ b/src/harness/reference_models/propagation/ehata/its/MedianRollingHillyTerrainCorrectionFactor.cpp
@@ -6,15 +6,15 @@
 *   Inputs:
 *       delta_h__meter : terrain irregularity factor
 *   Return:
-*       [float] : correction factor
+*       [double] : correction factor
 */
-float MedianRollingHillyTerrainCorrectionFactor(float deltah__meter)
+double MedianRollingHillyTerrainCorrectionFactor(double deltah__meter)
 {
-    float a = -1.5072013;
-    float b = 8.458676;
-    float c = -6.102538;
+    double a = -1.5072013;
+    double b = 8.458676;
+    double c = -6.102538;
 
-    float deltah_use;
+    double deltah_use;
 
     if (deltah__meter < 15.0)
         deltah_use = 15.0;

--- a/src/harness/reference_models/propagation/ehata/its/MixedPathCorrectionFactor.cpp
+++ b/src/harness/reference_models/propagation/ehata/its/MixedPathCorrectionFactor.cpp
@@ -14,19 +14,19 @@
 *       interValues->trace_code : debug trace flag to document code
 *               execution path for tracing and testing purposes
 *   Return:
-*       [float] : correction factor
+*       [double] : correction factor
 */
-float MixedPathCorrectionFactor(float d__km, InterValues *interValues)
+double MixedPathCorrectionFactor(double d__km, InterValues *interValues)
 {
-    float slope_30[2];
-    float slope_60[2];
+    double slope_30[2];
+    double slope_60[2];
 
-    float beta_30[10]    =   { 0.0, 0.15, 0.35, 0.45, 0.6, 0.65, 0.725, 0.775, 0.85,  1.0 };
-    float corr_30[2][10] = { { 0.0, 1.0,  3.0,  4.0,  6.0, 7.0,  8.0,   9.0,  10.0,  11.0 },
+    double beta_30[10]    =   { 0.0, 0.15, 0.35, 0.45, 0.6, 0.65, 0.725, 0.775, 0.85,  1.0 };
+    double corr_30[2][10] = { { 0.0, 1.0,  3.0,  4.0,  6.0, 7.0,  8.0,   9.0,  10.0,  11.0 },
                              { 0.0, 4.0,  5.5,  7.0,  8.5, 9.0,  9.5,   9.8,  10.25, 11.0 } };
 
-    float beta_60[10]    =   { 0.0, 0.15, 0.3,  0.4,  0.5,  0.6,   0.725,  0.85,  0.9,   1.0 };
-    float corr_60[2][10] = { { 0.0, 2.0,  4.0,  5.5,  7.0,  9.0,  11.0,   13.0,  14.0,  15.0 },
+    double beta_60[10]    =   { 0.0, 0.15, 0.3,  0.4,  0.5,  0.6,   0.725,  0.85,  0.9,   1.0 };
+    double corr_60[2][10] = { { 0.0, 2.0,  4.0,  5.5,  7.0,  9.0,  11.0,   13.0,  14.0,  15.0 },
                              { 0.0, 4.25, 6.25, 9.2, 10.5, 11.75, 13.0,   14.0,  14.25, 15.0 } };
 
     if (interValues->beta == 0.0)
@@ -73,9 +73,9 @@ float MixedPathCorrectionFactor(float d__km, InterValues *interValues)
     }
     else
     {
-        float dist_fact = (d__km - 30.0) / 30.0;
-        float qmp_corr_30;
-        float qmp_corr_60;
+        double dist_fact = (d__km - 30.0) / 30.0;
+        double qmp_corr_30;
+        double qmp_corr_60;
 
         if (interValues->iend_ov_sea == 0 || interValues->iend_ov_sea == 1)
         {

--- a/src/harness/reference_models/propagation/ehata/its/PreprocessTerrainPath.cpp
+++ b/src/harness/reference_models/propagation/ehata/its/PreprocessTerrainPath.cpp
@@ -2,7 +2,7 @@
 #include "ehata.h"
 
 
-void PreprocessTerrainPath(float *pfl, float h_b__meter, float h_m__meter, InterValues *interValues)
+void PreprocessTerrainPath(double *pfl, double h_b__meter, double h_m__meter, InterValues *interValues)
 {
     FindAverageGroundHeight(pfl, interValues);
 
@@ -30,19 +30,19 @@ void PreprocessTerrainPath(float *pfl, float h_b__meter, float h_m__meter, Inter
 *       interValues->trace_code : Debug trace flag to document code
 *               execution path for tracing and testing purposes
 */
-void FindAverageGroundHeight(float *pfl, InterValues *interValues)
+void FindAverageGroundHeight(double *pfl, InterValues *interValues)
 {
     int np = int(pfl[0]);
     // ******* WinnForum change *******
     // Old code:
-    //float xi = pfl[1] * 0.001;      // step size of the profile points, in km
+    //double xi = pfl[1] * 0.001;      // step size of the profile points, in km
     // New code:
-    float xi = pfl[1] / 1000.;      // step size of the profile points, in km
+    double xi = pfl[1] / 1000.;      // step size of the profile points, in km
     // ******* End WinnForum change *******
-    float d__km = np * xi;
+    double d__km = np * xi;
 
     int i_start, i_end;
-    float sum = 0.0;
+    double sum = 0.0;
 
     if (d__km < 3.0)
     {
@@ -135,16 +135,16 @@ void FindAverageGroundHeight(float *pfl, InterValues *interValues)
 *       interValues->trace_code : debug trace flag to document code
 *               execution path for tracing and testing purposes
 */
-void ComputeTerrainStatistics(float *pfl, InterValues *interValues)
+void ComputeTerrainStatistics(double *pfl, InterValues *interValues)
 {
     int np = int(pfl[0]);
     // ******* WinnForum change *******
     // Old code:
-    //float xi = pfl[1] * 0.001;      // step size of the profile points, in km
-    //float d__km = np * xi;          // path distance, in km
+    //double xi = pfl[1] * 0.001;      // step size of the profile points, in km
+    //double d__km = np * xi;          // path distance, in km
     // New code:
-    float xi = pfl[1] / 1000.;      // step size of the profile points, in km    
-    float d__km = GetDistanceInMeters(pfl) / 1000.;
+    double xi = pfl[1] / 1000.;      // step size of the profile points, in km    
+    double d__km = GetDistanceInMeters(pfl) / 1000.;
     // ******* End WinnForum change *******
 
     int i_start, i_end;
@@ -171,9 +171,9 @@ void ComputeTerrainStatistics(float *pfl, InterValues *interValues)
     // ******* WinnForum change *******
     // The following code may crash the application if using a step <= 25m
     // Old code:
-    //float pfl_segment[400];
+    //double pfl_segment[400];
     // New code:
-    float *pfl_segment = new float[i_end - i_start + 2];
+    double *pfl_segment = new double[i_end - i_start + 2];
     // ******* End WinnForum change *******
     
     for (int i = i_start; i <= i_end; i++)
@@ -192,7 +192,7 @@ void ComputeTerrainStatistics(float *pfl, InterValues *interValues)
     //  for the terrain irrgularity is computed" [TR-15-517]
     if (d__km < 10.0)
     {
-        float factor = (1.0 - 0.8*exp(-0.2)) / (1.0 - 0.8*exp(-0.02 * d__km));
+        double factor = (1.0 - 0.8*exp(-0.2)) / (1.0 - 0.8*exp(-0.02 * d__km));
         interValues->pfl10__meter = interValues->pfl10__meter * factor;
         interValues->pfl50__meter = interValues->pfl50__meter * factor;
         interValues->pfl90__meter = interValues->pfl90__meter * factor;
@@ -217,31 +217,31 @@ void ComputeTerrainStatistics(float *pfl, InterValues *interValues)
 *       interValues->trace_code : debug trace flag to document code
 *               execution path for tracing and testing purposes
 */
-void MobileTerrainSlope(float *pfl, InterValues *interValues)
+void MobileTerrainSlope(double *pfl, InterValues *interValues)
 {
     // ******* WinnForum change *******
     // Old code:
     //int np = int(pfl[0]);           // number of points
-    //float xi = pfl[1];              // step size of the profile points, in meter
-    //float d__meter = np * xi;
+    //double xi = pfl[1];              // step size of the profile points, in meter
+    //double d__meter = np * xi;
     // New code:
-    float xi = pfl[1];              // step size of the profile points, in meter
-    float d__meter = GetDistanceInMeters(pfl);
+    double xi = pfl[1];              // step size of the profile points, in meter
+    double d__meter = GetDistanceInMeters(pfl);
     // ******* End WinnForum change *******
 
     // find the mean slope of the terrain in the vicinity of the mobile station
     interValues->slope_max = -1.0e+31;
     interValues->slope_min = 1.0e+31;
-    float slope_five = 0.0;
-    float slope;
+    double slope_five = 0.0;
+    double slope;
     
-    float x1, x2;
+    double x1, x2;
     // ******* WinnForum change *******
     // The following code may crash the application if using a step <= 25m
     // Old code:
-    //float pfl_segment[400] = { 0 };
+    //double pfl_segment[400] = { 0 };
     // New code:
-    float *pfl_segment = new float[int(10000/xi) + 4]();
+    double *pfl_segment = new double[int(10000/xi) + 4]();
     // ******* End WinnForum change *******
 
     x1 = 0.0;
@@ -254,7 +254,7 @@ void MobileTerrainSlope(float *pfl, InterValues *interValues)
         for (int i = 0; i < npts + 1; i++) 
             pfl_segment[i + 2] = pfl[i + 2];
 
-        float z1 = 0, z2 = 0;
+        double z1 = 0, z2 = 0;
         LeastSquares(pfl_segment, x1, x2, &z1, &z2);
 
         // flip the sign to match the Okumura et al.convention
@@ -306,7 +306,7 @@ void MobileTerrainSlope(float *pfl, InterValues *interValues)
 *                0  : high end
 *               -1  : equal amounts on both ends
 */
-void AnalyzeSeaPath(float* pfl, InterValues *interValues)
+void AnalyzeSeaPath(double* pfl, InterValues *interValues)
 {
     int np = int(pfl[0]);
 
@@ -329,7 +329,7 @@ void AnalyzeSeaPath(float* pfl, InterValues *interValues)
         }
     }
 
-    interValues->beta = float(sea_cnt) / float(np + 1);
+    interValues->beta = double(sea_cnt) / double(np + 1);
 
     if (low_cnt > high_cnt)
         interValues->iend_ov_sea = 1;
@@ -347,11 +347,11 @@ void AnalyzeSeaPath(float* pfl, InterValues *interValues)
 *                - pfl[1] = step size, in meters
 *                - pfl[i] = elevation above mean sea level, in meters
 *   Return:
-*       [float] : average terrain height, in meters
+*       [double] : average terrain height, in meters
 */
-float AverageTerrainHeight(float *pfl)
+double AverageTerrainHeight(double *pfl)
 {
-    float h_gnd__meter = 0.0;
+    double h_gnd__meter = 0.0;
     int np = (int)pfl[0];
 
     for (int i = 1; i <= np + 1; i++)
@@ -379,34 +379,34 @@ float AverageTerrainHeight(float *pfl)
 *       interValues->trace_code : debug trace flag to document code
 *               execution path for tracing and testing purposes
 */
-void SingleHorizonTest(float *pfl, float h_m__meter, float h_b__meter, InterValues *interValues)
+void SingleHorizonTest(double *pfl, double h_m__meter, double h_b__meter, InterValues *interValues)
 {
     int np = int(pfl[0]);           // number of points
     // ******* WinnForum change *******
     // Old code:
-    //float xi = pfl[1];              // step size of the profile points, in meter
-    //float d__meter = np * xi;
+    //double xi = pfl[1];              // step size of the profile points, in meter
+    //double d__meter = np * xi;
     // New code:
-    float d__meter = GetDistanceInMeters(pfl);
+    double d__meter = GetDistanceInMeters(pfl);
     // ******* End WinnForum change *******
 
-    float h_gnd__meter = AverageTerrainHeight(pfl);
+    double h_gnd__meter = AverageTerrainHeight(pfl);
 
-    float en0 = 301.0f;
-    float ens = 0;
+    double en0 = 301.0f;
+    double ens = 0;
     if (h_gnd__meter == 0)
         ens = en0;
     else
         ens = en0 * exp(-h_gnd__meter / 9460);
-    float gma = 157e-9f;
-    float gme = gma * (1 - 0.04665 * exp(ens / 179.3));
+    double gma = 157e-9f;
+    double gme = gma * (1 - 0.04665 * exp(ens / 179.3));
 
     FindHorizons(pfl, gme, d__meter, h_m__meter, h_b__meter, interValues->d_hzn__meter);
 
-    //float a = interValues->d_hzn__meter[0];
-    //float b = interValues->d_hzn__meter[1];
-    float d_diff__meter = d__meter - interValues->d_hzn__meter[0] - interValues->d_hzn__meter[1];
-    float q = MAX(d_diff__meter - 0.5*pfl[1], 0) - MAX(-d_diff__meter - 0.5*pfl[1], 0);
+    //double a = interValues->d_hzn__meter[0];
+    //double b = interValues->d_hzn__meter[1];
+    double d_diff__meter = d__meter - interValues->d_hzn__meter[0] - interValues->d_hzn__meter[1];
+    double q = MAX(d_diff__meter - 0.5*pfl[1], 0) - MAX(-d_diff__meter - 0.5*pfl[1], 0);
     if (q != 0.0)
     {
         interValues->single_horizon = false;
@@ -417,7 +417,7 @@ void SingleHorizonTest(float *pfl, float h_m__meter, float h_b__meter, InterValu
         interValues->single_horizon = true;
         int iedge = interValues->d_hzn__meter[0] / pfl[1];
 
-        float za, zb;
+        double za, zb;
         za = h_b__meter + pfl[np + 2];
         zb = h_m__meter + pfl[2];
         interValues->hedge_tilda = pfl[iedge + 2] - (za*interValues->d_hzn__meter[1] + zb*interValues->d_hzn__meter[0]) / d__meter + 0.5*gme*interValues->d_hzn__meter[0] * interValues->d_hzn__meter[1];

--- a/src/harness/reference_models/propagation/ehata/its/ehata.h
+++ b/src/harness/reference_models/propagation/ehata/its/ehata.h
@@ -12,23 +12,6 @@
 #define MIN(x, y) (((x) < (y)) ? (x) : (y))
 
 // ******* WinnForum extension *******
-// Change all inputs and intermediate value from float to double
-// The reason for that are:
-// - to make the interface more in line with the ITM model
-// - to suppress all mismatch between different implementations:
-//   By using float, every implementation will lead to slightly different
-//   results depending on the compiler and manual code optimisation done.
-//
-//   Because the propagation model is strongly non linear, this typically
-//   leads to variation which can exceed a fraction of a dB or more.
-//   By using double, this issue is strongly alleviated (with the appropriate
-//   compiler flag to force exactness of double calculation, for example the
-//   -fno-unsafe-math-optimizations in gcc or the /fp:precise (default) in
-//   Microsoft compiler).
-//
-// Note: Hacky but works perfect if ehata.h last #include in the C++ files.
-#define float double
-
 // Activate the Winnforum extensions
 extern bool _WinnForum_Extensions; // default is ON
 void SetWinnForumExtensions(bool on);
@@ -42,38 +25,38 @@ void SetWinnForumExtensions(bool on);
 //  One solution is to reset the distance used in calculation to proper integer
 //  values when detected as very close to an integer value.
 //  This function does exactly that.
-float GetDistanceInMeters(float pfl[]);
+double GetDistanceInMeters(double pfl[]);
 
 // ******* End WinnForum extension *******
 
 struct InterValues
 {
-    float d_bp__km;
-    float att_1km;
-    float att_100km;
+    double d_bp__km;
+    double att_1km;
+    double att_100km;
 
-    float h_b_eff__meter;
-    float h_m_eff__meter;
+    double h_b_eff__meter;
+    double h_m_eff__meter;
 
     // Terrain Stats
-    float pfl10__meter;
-    float pfl50__meter;
-    float pfl90__meter;
-    float deltah__meter;
+    double pfl10__meter;
+    double pfl50__meter;
+    double pfl90__meter;
+    double deltah__meter;
 
     // Path Geometry
-    float d__km;
-    float d_hzn__meter[2];
-    float h_avg__meter[2];
-    float theta_m__mrad;
-    float beta;
+    double d__km;
+    double d_hzn__meter[2];
+    double h_avg__meter[2];
+    double theta_m__mrad;
+    double beta;
     int iend_ov_sea;
-    float hedge_tilda;
+    double hedge_tilda;
     bool single_horizon;
 
     // Misc
-    float slope_max;
-    float slope_min;
+    double slope_max;
+    double slope_min;
 
     int trace_code;
 };
@@ -81,26 +64,26 @@ struct InterValues
 #define PI 3.14159265358979323846
 
 // public
-DLLEXPORT void ExtendedHata(float pfl[], float f__mhz, float h_b__meter, float h_m__meter, int environment, float *plb);
-DLLEXPORT void ExtendedHata_DBG(float pfl[], float f__mhz, float h_b__meter, float h_m__meter, int environment, float *plb, InterValues *interValues);
+DLLEXPORT void ExtendedHata(double pfl[], double f__mhz, double h_b__meter, double h_m__meter, int environment, double *plb);
+DLLEXPORT void ExtendedHata_DBG(double pfl[], double f__mhz, double h_b__meter, double h_m__meter, int environment, double *plb, InterValues *interValues);
 
 // private
-void FindAverageGroundHeight(float *pfl, InterValues *interValues);
-void MobileTerrainSlope(float *pfl, InterValues *interValues);
-void LeastSquares(float *pfl_segment, float x1, float x2, float *z0, float *zn);
-void AnalyzeSeaPath(float* pfl, InterValues *interValues);
-void FindHorizons(float *pfl, float gme, float d__meter, float h_1__meter, float h_2__meter, float *d_hzn__meter);
-void SingleHorizonTest(float *pfl, float h_m__meter, float h_b__meter, InterValues *interValues);
-void ComputeTerrainStatistics(float *pfl, InterValues *interValues);
-float FindQuantile(const int &nn, float *apfl, const int &ir);
-void PreprocessTerrainPath(float *pfl, float h_b__meter, float h_m__meter, InterValues *interValues);
-float AverageTerrainHeight(float *pfl);
-float GeneralSlopeCorrectionFactor(float theta_m__mrad, float d__km);
-float FineRollingHillyTerrainCorectionFactor(InterValues *interValues, float h_m_gnd__meter);
-float MixedPathCorrectionFactor(float d__km, InterValues *interValues);
-float MedianRollingHillyTerrainCorrectionFactor(float deltah);
-void MedianBasicPropLoss(float f__mhz, float h_b__meter, float h_m__meter, float d__km, int environment, float* plb_med__db, InterValues *interValues);
-float IsolatedRidgeCorrectionFactor(float d1_hzn__km, float d2_hzn__km, float h_edge__meter);
+void FindAverageGroundHeight(double *pfl, InterValues *interValues);
+void MobileTerrainSlope(double *pfl, InterValues *interValues);
+void LeastSquares(double *pfl_segment, double x1, double x2, double *z0, double *zn);
+void AnalyzeSeaPath(double* pfl, InterValues *interValues);
+void FindHorizons(double *pfl, double gme, double d__meter, double h_1__meter, double h_2__meter, double *d_hzn__meter);
+void SingleHorizonTest(double *pfl, double h_m__meter, double h_b__meter, InterValues *interValues);
+void ComputeTerrainStatistics(double *pfl, InterValues *interValues);
+double FindQuantile(const int &nn, double *apfl, const int &ir);
+void PreprocessTerrainPath(double *pfl, double h_b__meter, double h_m__meter, InterValues *interValues);
+double AverageTerrainHeight(double *pfl);
+double GeneralSlopeCorrectionFactor(double theta_m__mrad, double d__km);
+double FineRollingHillyTerrainCorectionFactor(InterValues *interValues, double h_m_gnd__meter);
+double MixedPathCorrectionFactor(double d__km, InterValues *interValues);
+double MedianRollingHillyTerrainCorrectionFactor(double deltah);
+void MedianBasicPropLoss(double f__mhz, double h_b__meter, double h_m__meter, double d__km, int environment, double* plb_med__db, InterValues *interValues);
+double IsolatedRidgeCorrectionFactor(double d1_hzn__km, double d2_hzn__km, double h_edge__meter);
 
 // Trace Constants
 #define TRACE__METHOD_00    0x00000001;


### PR DESCRIPTION
Previously to avoid having the code base differing too much from
the original ITS reference implementation, we defined a global
  #define float double
in the ehata.h header file.
Obviously this is very hack and can fail depending on the order of
inclusion of ehata.h, or if t is forgotten in one of the cpp file.

The proper way is now implemented by directly changing all `float`
occurence with `double`.
This is in line with the change made by ITS on their reference
implementation at:
https://github.com/NTIA/ehata/commit/df2b5802f1444b77ffadf4a4301c5b2fd7be691c