### PR TITLE
DPA interf check: Add support for 'Best-of-N' reference move list.

### DIFF
--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -261,9 +261,6 @@ class Dpa(object):
         will be the best of those, ie the smallest one. If number is negative,
         intersection between the move list is performed instead.
     """
-    # TODO: add eventually the NTIA proposal which computes the intersection move list.
-    #       it is more involved as it requires more single move list calculation, but
-    #       likely produces a more stable 'composite' move list.
     logging.info('DPA Compute movelist `%s`- channels %s thresh %s bw %s height %s '
                  'iter %s azi_range %s nbor_dists %s best_of_n %s',
                  self.name, self._channels, self.threshold, self.beamwidth,

--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -264,10 +264,10 @@ class Dpa(object):
     #       it is more involved as it requires more single move list calculation, but
     #       likely produces a more stable 'composite' move list.
     logging.info('DPA Compute movelist `%s`- channels %s thresh %s bw %s height %s '
-                 'iter %s azi_range %s nbor_dists %s',
+                 'iter %s azi_range %s nbor_dists %s best_of_n %s',
                  self.name, self._channels, self.threshold, self.beamwidth,
                  self.radar_height, Dpa.num_iteration,
-                 self.azimuth_range, self.neighbor_distances)
+                 self.azimuth_range, self.neighbor_distances, best_of_n)
     logging.debug('  protected points: %s', self.protected_points)
     self.ResetLists()
     for chan_idx, (low_freq, high_freq) in enumerate(self._channels):

--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -258,7 +258,8 @@ class Dpa(object):
 
     Args:
       best_of_n: The number of move list internally computed. The final one
-        will be the best of those, ie the smallest one.
+        will be the best of those, ie the smallest one. If number is negative,
+        intersection between the move list is performed instead.
     """
     # TODO: add eventually the NTIA proposal which computes the intersection move list.
     #       it is more involved as it requires more single move list calculation, but
@@ -270,14 +271,19 @@ class Dpa(object):
                  self.azimuth_range, self.neighbor_distances, best_of_n)
     logging.debug('  protected points: %s', self.protected_points)
     self.ResetLists()
+    num_calc_list = abs(best_of_n)
     for chan_idx, (low_freq, high_freq) in enumerate(self._channels):
       move_list, nbor_list = self._ComputeSingleMoveList(low_freq, high_freq)
-      if best_of_n > 1:
-        for run in xrange(best_of_n - 1):
+      if num_calc_list > 1:
+        for run in xrange(num_calc_list - 1):
           alt_move_list, alt_nbor_list = self._ComputeSingleMoveList(low_freq, high_freq)
-          if len(alt_move_list) < len(move_list):
-            move_list = alt_move_list
-            nbor_list = alt_nbor_list
+          if best_of_n > 0:
+            if len(alt_move_list) < len(move_list):
+              move_list = alt_move_list
+              nbor_list = alt_nbor_list
+          else:
+            move_list.intersection_update(alt_move_list)
+            nbor_list.intersection_update(alt_nbor_list)
       self.move_lists[chan_idx] = move_list
       self.nbor_lists[chan_idx] = nbor_list
 

--- a/src/harness/reference_models/dpa/dpa_mgr_example.py
+++ b/src/harness/reference_models/dpa/dpa_mgr_example.py
@@ -125,6 +125,8 @@ if __name__ == '__main__':
                                     margin_db=margin_db)
   print 'Move list output: ' + str(dpa_uut.GetMoveListMask(channel))
   print 'Check Interference @%.2fdB margin: %s' % (margin_db, 'OK' if check else 'FAIL')
+  # Coverage test of the 'best of N' movelist method
+  dpa_uut.ComputeMoveLists(best_of_n=3)
 
   # Simulate a single SAS UUT (no peer SAS)
   print '-- Single UUT model --'
@@ -140,7 +142,6 @@ if __name__ == '__main__':
   print 'Check Interference @%.2fdB margin: %s' % (margin_db, 'OK' if check else 'FAIL')
 
   # Simulate a single SAS UUT (no peer SAS) CheckInterference ().
-  # import ipdb; ipdb.set_trace()
   print '-- Single UUT model - No Compute Move List --'
   dpa_suut = dpa_mgr.Dpa(protection_points,
                          name='alt(East1)',

--- a/src/harness/reference_models/dpa/dpa_mgr_example.py
+++ b/src/harness/reference_models/dpa/dpa_mgr_example.py
@@ -127,6 +127,7 @@ if __name__ == '__main__':
   print 'Check Interference @%.2fdB margin: %s' % (margin_db, 'OK' if check else 'FAIL')
   # Coverage test of the 'best of N' movelist method
   dpa_uut.ComputeMoveLists(best_of_n=3)
+  dpa_uut.ComputeMoveLists(best_of_n=-3)
 
   # Simulate a single SAS UUT (no peer SAS)
   print '-- Single UUT model --'

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -1091,7 +1091,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         },
         'points_builder':
             'default (25, 10, 10, 10)',  # Not actually used since this is a single-point DPA.
-        'movelistMargin': 10,
+        'movelistMargin': 10
     }
 
     config = {

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -119,6 +119,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         },
         'points_builder': 'default (25, 10, 10, 10)',
         'movelistMargin': 10
+        'bestOfN': -3
     }
 
     config = {
@@ -260,10 +261,8 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
       high_freq_mhz = dpa_config['frequencyRange']['highFrequency'] / ONE_MHZ
       dpa.ResetFreqRange([(low_freq_mhz, high_freq_mhz)])
       dpa.SetGrantsFromFad(sas_uut_fad, test_harness_fads)
-      if 'bestOfN' in dpa_config:
-        dpa.ComputeMoveLists(dpa_config['bestOfN'])
-      else:
-        dpa.ComputeMoveLists()
+      dpa.ComputeMoveLists(dpa_config.get('bestOfN', 1))
+
       # Check grants do not exceed each DPAs interference threshold.
       self.assertTrue(dpa.CheckInterference(
           sas_uut_active_grants=grant_info,
@@ -515,10 +514,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
       high_freq_mhz = dpa_config['frequencyRange']['highFrequency'] / ONE_MHZ
       dpa.ResetFreqRange([(low_freq_mhz, high_freq_mhz)])
       dpa.SetGrantsFromFad(sas_uut_fad, test_harness_fads)
-      if 'bestOfN' in dpa_config:
-        dpa.ComputeMoveLists(dpa_config['bestOfN'])
-      else:
-        dpa.ComputeMoveLists()
+      dpa.ComputeMoveLists(dpa_config.get('bestOfN', 1))
       all_dpas.append(dpa)
 
     # Activate each DPA in sequence and check the move list interference is
@@ -975,10 +971,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
     for dpa_config in config['dpas']:
       dpa = dpa_mgr.BuildDpa(dpa_config['dpaId'], dpa_config['points_builder'])
       dpa.SetGrantsFromFad(sas_uut_fad, test_harness_fads)
-      if 'bestOfN' in dpa_config:
-        dpa.ComputeMoveLists(dpa_config['bestOfN'])
-      else:
-        dpa.ComputeMoveLists()
+      dpa.ComputeMoveLists(dpa_config.get('bestOfN', 1))
       all_dpas.append(dpa)
 
     # Connectivity between ESCs and SAS UUT is broken.
@@ -1287,10 +1280,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
     high_freq_mhz = dpa_config['frequencyRange']['highFrequency'] / ONE_MHZ
     dpa.ResetFreqRange([(low_freq_mhz, high_freq_mhz)])
     dpa.SetGrantsFromFad(sas_uut_fad, test_harness_fads)
-    if 'bestOfN' in dpa_config:
-      dpa.ComputeMoveLists(dpa_config['bestOfN'])
-    else:
-      dpa.ComputeMoveLists()
+    dpa.ComputeMoveLists(dpa_config.get('bestOfN', 1))
     # Check grants do not exceed each DPAs interference threshold.
     self.assertTrue(
         dpa.CheckInterference(

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -119,7 +119,6 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         },
         'points_builder': 'default (25, 10, 10, 10)',
         'movelistMargin': 10
-        'bestOfN': -3
     }
 
     config = {
@@ -1093,7 +1092,6 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         'points_builder':
             'default (25, 10, 10, 10)',  # Not actually used since this is a single-point DPA.
         'movelistMargin': 10,
-        'bestOfN': 3
     }
 
     config = {

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -260,7 +260,10 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
       high_freq_mhz = dpa_config['frequencyRange']['highFrequency'] / ONE_MHZ
       dpa.ResetFreqRange([(low_freq_mhz, high_freq_mhz)])
       dpa.SetGrantsFromFad(sas_uut_fad, test_harness_fads)
-      dpa.ComputeMoveLists()
+      if 'bestOfN' in dpa_config:
+        dpa.ComputeMoveLists(dpa_config['bestOfN'])
+      else:
+        dpa.ComputeMoveLists()
       # Check grants do not exceed each DPAs interference threshold.
       self.assertTrue(dpa.CheckInterference(
           sas_uut_active_grants=grant_info,
@@ -512,7 +515,10 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
       high_freq_mhz = dpa_config['frequencyRange']['highFrequency'] / ONE_MHZ
       dpa.ResetFreqRange([(low_freq_mhz, high_freq_mhz)])
       dpa.SetGrantsFromFad(sas_uut_fad, test_harness_fads)
-      dpa.ComputeMoveLists()
+      if 'bestOfN' in dpa_config:
+        dpa.ComputeMoveLists(dpa_config['bestOfN'])
+      else:
+        dpa.ComputeMoveLists()
       all_dpas.append(dpa)
 
     # Activate each DPA in sequence and check the move list interference is
@@ -969,7 +975,10 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
     for dpa_config in config['dpas']:
       dpa = dpa_mgr.BuildDpa(dpa_config['dpaId'], dpa_config['points_builder'])
       dpa.SetGrantsFromFad(sas_uut_fad, test_harness_fads)
-      dpa.ComputeMoveLists()
+      if 'bestOfN' in dpa_config:
+        dpa.ComputeMoveLists(dpa_config['bestOfN'])
+      else:
+        dpa.ComputeMoveLists()
       all_dpas.append(dpa)
 
     # Connectivity between ESCs and SAS UUT is broken.
@@ -1090,7 +1099,8 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
         },
         'points_builder':
             'default (25, 10, 10, 10)',  # Not actually used since this is a single-point DPA.
-        'movelistMargin': 10
+        'movelistMargin': 10,
+        'bestOfN': 3
     }
 
     config = {
@@ -1277,7 +1287,10 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
     high_freq_mhz = dpa_config['frequencyRange']['highFrequency'] / ONE_MHZ
     dpa.ResetFreqRange([(low_freq_mhz, high_freq_mhz)])
     dpa.SetGrantsFromFad(sas_uut_fad, test_harness_fads)
-    dpa.ComputeMoveLists()
+    if 'bestOfN' in dpa_config:
+      dpa.ComputeMoveLists(dpa_config['bestOfN'])
+    else:
+      dpa.ComputeMoveLists()
     # Check grants do not exceed each DPAs interference threshold.
     self.assertTrue(
         dpa.CheckInterference(
@@ -1293,5 +1306,3 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
 
     if dpa_database_server:
       del dpa_database_server
-
-    

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -414,7 +414,10 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
       if self.num_peer_sases:
         logging.info('Calculating  move list for DPA: %s', active_dpa)
         dpa.SetGrantsFromFad(self.sas_uut_fad, self.test_harness_fads)
-        dpa.ComputeMoveLists()
+        if 'bestOfN' in dpa_config:
+          dpa.ComputeMoveLists(dpa_config['bestOfN'])
+        else:
+          dpa.ComputeMoveLists()
 
       dpa_combined_id = '%s,%s,%s' % (
           active_dpa['dpaId'], active_dpa['frequencyRange']['lowFrequency'],

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -414,10 +414,7 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
       if self.num_peer_sases:
         logging.info('Calculating  move list for DPA: %s', active_dpa)
         dpa.SetGrantsFromFad(self.sas_uut_fad, self.test_harness_fads)
-        if 'bestOfN' in dpa_config:
-          dpa.ComputeMoveLists(dpa_config['bestOfN'])
-        else:
-          dpa.ComputeMoveLists()
+        dpa.ComputeMoveLists(dpa_config.get('bestOfN', 1))
 
       dpa_combined_id = '%s,%s,%s' % (
           active_dpa['dpaId'], active_dpa['frequencyRange']['lowFrequency'],


### PR DESCRIPTION
By default OFF. 
The computeMoveList can now optionally compute several
move list and take the best, best being either:
 -  the smallest one, ie the one with biggest keep list, and so producing the largest interference
hopefully.
 - the intersection one, ie the intersection of N move list

This change is fully integrated with the test harness (IPR/MCP tests)
via an optional config parameter 'bestOfN': positive value will use the smallest method and negative value withl use the intersection method.

Note that this proposal slow down the reference model by factor N.
The idea is to avoid "outliers" by using a small N, even something as small as 2 to 5.

### Explanation:
All previous DPA margin studies are demonstrating the checkInterference issue 
by comparing the SAS UUT creating a "best" move list (not a crazy assumption for an
efficient SAS), to the "worst case" move list reference model across many runs.
This can happen in practice in a random fashion. But if we repeat the
move list calculation a few time and take the smallest one, the chance
for it to happen is much lower. For example if we want to avoid the 10%
worst move list:
 - nominally we have 1 chance over 10 to fall in this scenario
 - by choosing the best of 3, the probability fall to 1 over 1000.

The intersection method is somewhat  is related to Michael Souryal "move list intersection" proposal which involves more move list calculation and the intersection of the XX% middle ones (in terms of move list length). 