### PR TITLE
Add TCP keepalive to all test harness requests

### DIFF
--- a/src/harness/request_handler.py
+++ b/src/harness/request_handler.py
@@ -119,6 +119,7 @@ def _Request(url, request, config, is_post_method):
   conn.setopt(conn.CAINFO, config.ca_cert)
   conn.setopt(conn.HTTPHEADER, header)
   conn.setopt(conn.SSL_CIPHER_LIST, ':'.join(config.ciphers))
+  conn.setopt(conn.TCP_KEEPALIVE, 1)
   request = json.dumps(request) if request else ''
   if is_post_method:
     conn.setopt(conn.POST, True)


### PR DESCRIPTION
As suggested by Sony, this change prevents the connection from dropping which would cause a test failure.