### PR TITLE
Peer fccid injection for IPR testcases

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -179,6 +179,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
           'url':
               test_harness.getBaseUrl()
       })
+      self.InjectTestHarnessFccIds(test_harness_config['fullActivityDumpRecords'][0])
       test_harness.writeFadRecords(
           test_harness_config['fullActivityDumpRecords'])
       test_harnesses.append(test_harness)
@@ -462,6 +463,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
           'url':
               test_harness.getBaseUrl()
       })
+      self.InjectTestHarnessFccIds(test_harness_config['fullActivityDumpRecords'][0])
       test_harness.writeFadRecords(
           test_harness_config['fullActivityDumpRecords'])
       test_harnesses.append(test_harness)
@@ -933,6 +935,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
           'url':
               test_harness.getBaseUrl()
       })
+      self.InjectTestHarnessFccIds(test_harness_config['fullActivityDumpRecords'][0])
       test_harness.writeFadRecords(
           test_harness_config['fullActivityDumpRecords'])
       test_harnesses.append(test_harness)
@@ -1200,6 +1203,7 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
           'url':
               test_harness.getBaseUrl()
       })
+      self.InjectTestHarnessFccIds(test_harness_config['fullActivityDumpRecords'][0])
       test_harness.writeFadRecords(
           test_harness_config['fullActivityDumpRecords'])
       test_harnesses.append(test_harness)
@@ -1293,5 +1297,4 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
 
     if dpa_database_server:
       del dpa_database_server
-
-    
+   

--- a/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_IPR_testcase.py
@@ -179,7 +179,8 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
           'url':
               test_harness.getBaseUrl()
       })
-      self.InjectTestHarnessFccIds(test_harness_config['fullActivityDumpRecords'][0])
+      for fullActivityDumpRecord in test_harness_config['fullActivityDumpRecords']:
+          self.InjectTestHarnessFccIds(fullActivityDumpRecord)
       test_harness.writeFadRecords(
           test_harness_config['fullActivityDumpRecords'])
       test_harnesses.append(test_harness)
@@ -463,7 +464,8 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
           'url':
               test_harness.getBaseUrl()
       })
-      self.InjectTestHarnessFccIds(test_harness_config['fullActivityDumpRecords'][0])
+      for fullActivityDumpRecord in test_harness_config['fullActivityDumpRecords']:
+          self.InjectTestHarnessFccIds(fullActivityDumpRecord)
       test_harness.writeFadRecords(
           test_harness_config['fullActivityDumpRecords'])
       test_harnesses.append(test_harness)
@@ -935,7 +937,8 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
           'url':
               test_harness.getBaseUrl()
       })
-      self.InjectTestHarnessFccIds(test_harness_config['fullActivityDumpRecords'][0])
+      for fullActivityDumpRecord in test_harness_config['fullActivityDumpRecords']:
+          self.InjectTestHarnessFccIds(fullActivityDumpRecord)
       test_harness.writeFadRecords(
           test_harness_config['fullActivityDumpRecords'])
       test_harnesses.append(test_harness)
@@ -1203,7 +1206,8 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
           'url':
               test_harness.getBaseUrl()
       })
-      self.InjectTestHarnessFccIds(test_harness_config['fullActivityDumpRecords'][0])
+      for fullActivityDumpRecord in test_harness_config['fullActivityDumpRecords']:
+          self.InjectTestHarnessFccIds(fullActivityDumpRecord)
       test_harness.writeFadRecords(
           test_harness_config['fullActivityDumpRecords'])
       test_harnesses.append(test_harness)
@@ -1297,4 +1301,5 @@ class FederalIncumbentProtectionTestcase(sas_testcase.SasTestCase):
 
     if dpa_database_server:
       del dpa_database_server
-   
+
+ 


### PR DESCRIPTION
Added peer fccid injection for IPR testcases. This is related to Whitelist fccIds by injecting before FAD Issue #810