### PR TITLE
Fix mem Leak on ITM

### DIFF
--- a/src/harness/reference_models/propagation/itm/itm_its_py.cpp
+++ b/src/harness/reference_models/propagation/itm/itm_its_py.cpp
@@ -158,8 +158,9 @@ static PyObject* itm_point_to_point_rels(PyObject* self, PyObject* args) {
     PyList_SET_ITEM(loss_obj, k, Py_BuildValue("d", db_losses[k]));
   }
   delete[] db_losses;
-
-  return Py_BuildValue("Oddsi", loss_obj, ver0, ver1, strmode, errnum);
+  // Note: use N instead of O here to avoid increment of ref count of loss_obj.
+  // Otherwise would have a mem leak, since it would never be released.
+  return Py_BuildValue("Nddsi", loss_obj, ver0, ver1, strmode, errnum);
 }
 
 static PyMethodDef ITMMethods[] = {


### PR DESCRIPTION
Affects the calculations with array or reliabilities (like DPA),
and average computed value.

The mem leak is expected to be about 16kB for a DPA CBSD-Point link,
and 800 bytes for a CBSD-point link in other protection type.
It is thus quite bug for DPA and affect negatively any test of the test harness