### PR TITLE
DPA: improve logs for enabling post processing eval

### DIFF
--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -79,10 +79,7 @@ def Db2Lin(x):
   return 10**(x / 10.)
 
 def Lin2Db(x):
-  if not np.isscalar(x):
-    return 10 * np.log10(x.clip(min=1e-100))
-  return 10 * np.log10(max(x, 1e-100))
-
+  return 10 * np.log10(np.asarray(x).clip(min=1e-100))
 
 class DpaInterferenceResult(
     namedtuple('DpaInterferenceResult',

--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -62,6 +62,13 @@ DPA_DEFAULT_DISTANCES = (150, 200, 0, 25)
 # The channel bandwidth
 DPA_CHANNEL_BANDWIDTH = 10
 
+# The logging path
+def GetDpaLogDir():
+  dpa_log_dir = os.path.join(os.path.dirname(__file__),
+                             '..', '..', 'testcases', 'output')
+  if not os.path.exists(dpa_log_dir): os.makedirs(dpa_log_dir)
+  return dpa_log_dir
+
 # Help routine
 class _EmptyFad(object):
   """Helper class for representing an empty FAD."""
@@ -467,11 +474,6 @@ class Dpa(object):
                  hard_threshold if hard_threshold else
                  ('`MoveList`' if margin_method == 'std' else 'MoveList + Linear'),
                  self.beamwidth, num_iter, self.azimuth_range, self.neighbor_distances)
-    # Removed since redundant with printKeepList logs.
-    # logging.debug('DPA Check interf `%s` - KL_TH_MGR: %s KL_TH_OTHER: %s KL_UUT_MGR: %s',
-    #              self.name,
-    #              keep_list_th_managing_sas, keep_list_th_other_sas,
-    #              sas_uut_active_grants)
 
     checkPointInterf = functools.partial(
         _CalcTestPointInterfDiff,
@@ -531,8 +533,9 @@ class Dpa(object):
   def __PrintStatistics(self, results, dpa_name, channel, threshold, margin_mw=None):
     """Prints result statistics."""
     timestamp = datetime.now().strftime('%Y-%m-%d %H_%M_%S')
-    filename = '%s DPA=%s channel=%s threshold=%s.csv' % (timestamp, dpa_name,
-                                                          channel, threshold)
+    filename = os.path.join(GetDpaLogDir(),
+                            '%s DPA=%s channel=%s threshold=%s.csv' % (
+                                timestamp, dpa_name, channel, threshold))
     logging.info('Saving stats for DPA %s, channel %s to file: %s', dpa_name,
                  channel, filename)
     with open(filename, 'w') as f:
@@ -599,7 +602,8 @@ class Dpa(object):
           f.write(','.join(str(getattr(cbsd_grant_info, key)) for key in fields) + '\n')
 
     timestamp = datetime.now().strftime('%Y-%m-%d %H_%M_%S')
-    base_filename = '%s DPA=%s channel=%s' % (timestamp, dpa_name, channel)
+    base_filename = os.path.join(GetDpaLogDir(),
+                                 '%s DPA=%s channel=%s' % (timestamp, dpa_name, channel))
 
     # SAS test harnesses (peer SASes) full neighbor list
     filename = '%s (neighbor list).csv' % base_filename

--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -79,7 +79,12 @@ def Db2Lin(x):
   return 10**(x / 10.)
 
 def Lin2Db(x):
-  return 10 * np.log10(x.clip(min=1e-100))
+  y = 10 * np.log10(x)
+  if np.isscalar(y):
+    return y if y > -1000 else -1000
+  y[y<-1000] = -1000
+  return y
+
 
 
 class DpaInterferenceResult(

--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -79,7 +79,7 @@ def Db2Lin(x):
   return 10**(x / 10.)
 
 def Lin2Db(x):
-  return 10 * np.log10(x)
+  return 10 * np.log10(x.clip(min=1e-100))
 
 
 class DpaInterferenceResult(

--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -79,12 +79,9 @@ def Db2Lin(x):
   return 10**(x / 10.)
 
 def Lin2Db(x):
-  y = 10 * np.log10(x)
-  if np.isscalar(y):
-    return y if y > -1000 else -1000
-  y[y<-1000] = -1000
-  return y
-
+  if not np.isscalar(x):
+    return 10 * np.log10(x.clip(min=1e-100))
+  return 10 * np.log10(max(x, 1e-100))
 
 
 class DpaInterferenceResult(

--- a/src/harness/reference_models/dpa/move_list.py
+++ b/src/harness/reference_models/dpa/move_list.py
@@ -479,6 +479,44 @@ def moveListConstraint(protection_point, low_freq, high_freq,
   return (movelist_grants, neighbor_grants)
 
 
+def getDpaNeighborGrants(grants, protection_points,
+                         low_freq, high_freq, neighbor_distances):
+  """Gets the list of actual neighbor grants of a DPA, for a given channel.
+
+  This looks at the total keep list considering a bunch of protected points.
+
+  Args:
+    grants:  A list of CBSD |data.CbsdGrantInfo| active grants.
+    protection_points: A list of protection point locations defining the DPA, each one
+      having attributes 'latitude' and 'longitude'.
+    low_freq: The low frequency of protection constraint (Hz).
+    high_freq: The high frequency of protection constraint (Hz).
+    neighbor_distances: The neighborhood distances (km) as a sequence:
+      [cata_dist, catb_dist, cata_oob_dist, catb_oob_dist]
+
+  Returns:
+    A set of |CbsdGrantInfo| neighbor grants.
+  """
+  dpa_type = findDpaType(low_freq, high_freq)
+
+  neighbor_grants = set()
+  for point in protection_points:
+    # Assign values to the protection constraint
+    constraint = data.ProtectionConstraint(latitude=point.latitude,
+                                           longitude=point.longitude,
+                                           low_frequency=low_freq,
+                                           high_frequency=high_freq,
+                                           entity_type=data.ProtectedEntityType.DPA)
+
+    # Identify CBSD grants in the neighborhood of the protection constraint
+    nbors, _ = findGrantsInsideNeighborhood(grants, constraint,
+                                                  dpa_type,
+                                                  neighbor_distances)
+    neighbor_grants.update(nbors)
+
+  return neighbor_grants
+
+
 def calcAggregatedInterference(protection_point,
                                low_freq, high_freq,
                                grants,

--- a/src/harness/test_main.py
+++ b/src/harness/test_main.py
@@ -18,15 +18,23 @@ look here how the setup is performed.
 It is particularly important to correctly set the geo drivers
 and multiprocessing pool for best performance
 """
+import argparse
 import logging
 import os
 import sys
 import unittest
 
-
 from reference_models.common import mpool
 from reference_models.geo import drive
 
+#----------------------------------------
+# Setup the command line arguments
+parser = argparse.ArgumentParser(description='Test Main')
+# - Generic config.
+parser.add_argument('--log_level', type=str, default='info',
+                    help='Logging level: debug, info, warning or error')
+
+# Setup the logger
 logger = logging.getLogger()
 handler = logging.StreamHandler(sys.stdout)
 handler.setFormatter(
@@ -34,6 +42,13 @@ handler.setFormatter(
         '[%(levelname)s] %(asctime)s %(filename)s:%(lineno)d %(message)s'))
 logger.addHandler(handler)
 logger.setLevel(logging.INFO)
+
+_LOGGER_MAP = {
+    'debug': logging.DEBUG,
+    'info': logging.INFO,
+    'warning': logging.WARNING,
+    'error': logging.ERROR
+}
 
 # Multi-processing
 # Number of worker processes allocated for heavy duty calculation,
@@ -114,6 +129,10 @@ def GetGeoCacheSize(num_workers):
 
 
 if __name__ == '__main__':
+  # Process the commad line arguments.
+  options = parser.parse_args()
+  logging.getLogger().setLevel(_LOGGER_MAP[options.log_level.lower()])
+
   # Configure the multiprocessing worker pool.
   # Your options are:
   #   0: single process (default if not called)


### PR DESCRIPTION
Some logs were introduced in DPA CheckInterference for better post analysis of result in #830.

This PR improves this logging according to various report received since then:
 
 - output of CSV logs put into harness/testcases/output/
 - output the neighbor list in addition of the keep list, to allow full post processing analysis (for example redo random movelist with ref model and anlayse agg interference variation)
 - fix issues with SAS UUT keep list to be the keep list per channel and not all SAS active grants in whole US for all channels. This means we run the active grants through a neighbor filter, just used for that. 
 - main test harness script can now be run in debug mode by adding option: --log_level=debug