### PR TITLE
Tiny fix to treat not handledFSS Scenario 

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -586,9 +586,9 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
           # Store the IAP results for future comparison.
           self.fss_cochannel_ap_iap_ref_values_list.append(None)
           self.fss_blocking_ap_iap_ref_values_list.append(fss_blocking_ap_iap_ref_values)
-      else:
-        self.fss_cochannel_ap_iap_ref_values_list.append(None)
-        self.fss_blocking_ap_iap_ref_values_list.append(None)
+        else:
+          self.fss_cochannel_ap_iap_ref_values_list.append(None)
+          self.fss_blocking_ap_iap_ref_values_list.append(None)
     # Calculate the interference value for all ESCs.
     if 'escRecords' in self.protected_entity_records:
       for esc_record in self.protected_entity_records['escRecords']:

--- a/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_MCP_testcase.py
@@ -586,7 +586,9 @@ class McpXprCommonTestcase(sas_testcase.SasTestCase):
           # Store the IAP results for future comparison.
           self.fss_cochannel_ap_iap_ref_values_list.append(None)
           self.fss_blocking_ap_iap_ref_values_list.append(fss_blocking_ap_iap_ref_values)
-
+      else:
+        self.fss_cochannel_ap_iap_ref_values_list.append(None)
+        self.fss_blocking_ap_iap_ref_values_list.append(None)
     # Calculate the interference value for all ESCs.
     if 'escRecords' in self.protected_entity_records:
       for esc_record in self.protected_entity_records['escRecords']:


### PR DESCRIPTION
Fix tiny bug for MCP test when the config contains multi FSS at least one of them is for FPR.3 scenario(i.e FSS with TTC false and out of band).
 
spec : [WINNF.FT.S.FPR.3] Multiple CBSDs from Multiple SASs Inside and Outside the Neighborhood of an FSS Station for “FSS Scenario 2” with TT&C Flag = OFF