### PR TITLE
for FAD_1, consider lat and lng equal if same to 6 decimal places ( Fixes #822 )

### DIFF
--- a/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
@@ -57,7 +57,7 @@ class FullActivityDumpTestcase(sas_testcase.SasTestCase):
       attr_value = registration_request[attr_name] if attr_name in registration_request\
         else preloaded_conditionals[attr_name]
       if attr_name in ['latitude', 'longitude']:      
-        self.assertEqual(abs(attr_value-record[attr_name])<1e-6,True)
+        self.assertTrue(abs(attr_value-record[attr_name])<1e-6)
       else:
         self.assertEqual(attr_value, record[attr_name])
 

--- a/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
+++ b/src/harness/testcases/WINNF_FT_S_FAD_testcase.py
@@ -56,7 +56,10 @@ class FullActivityDumpTestcase(sas_testcase.SasTestCase):
       """
       attr_value = registration_request[attr_name] if attr_name in registration_request\
         else preloaded_conditionals[attr_name]
-      self.assertEqual(attr_value, record[attr_name])
+      if attr_name in ['latitude', 'longitude']:      
+        self.assertEqual(abs(attr_value-record[attr_name])<1e-6,True)
+      else:
+        self.assertEqual(attr_value, record[attr_name])
 
 
   def assertCbsdRecord(self, registration_request, grant_request, grant_response, cbsd_dump_data, reg_conditional_data):


### PR DESCRIPTION
Fixes https://github.com/Wireless-Innovation-Forum/Spectrum-Access-System/issues/822

Adhering to [SAS-CBSD specification WINNF-TS-0016, Version V1.2.2, 1 October 2018](https://workspace.winnforum.org/higherlogic/ws/public/download/7279/WINNF-TS-0016-V1.2.2%20SAS%20to%20CBSD%20Technical%20Specification.pdf) which says:
"Latitude of the CBSD antenna location in degrees relative to the WGS 84 datum [n.11]. The allowed range is from -90.000000 to +90.000000. Positive values represent latitudes north of the equator; negative values south of the equator. Values are specified using 6 digits to the right of the decimal point."

This should not affect the latitude or longitude precision elsewhere.