### PR TITLE
update if PPA cbsd_reference_id is empty array in sas_test_harness.py generatePpaRecords()

### DIFF
--- a/src/harness/sas_test_harness.py
+++ b/src/harness/sas_test_harness.py
@@ -449,11 +449,9 @@ def generatePpaRecords(ppa_records, cbsd_reference_ids):
   for ppa_record, cbsd_reference_id in \
               zip(ppa_records, cbsd_reference_ids):
 
-    # Check cbsdReferenceID in ppaInfo and add cbsdReferenceID if not present.
-    if not ppa_record['ppaInfo'].has_key('cbsdReferenceId'):
-      ppa_record['ppaInfo'].update({'cbsdReferenceId': cbsd_reference_id})
-    elif len(ppa_record['ppaInfo']['cbsdReferenceId']) == 0:
-      ppa_record['ppaInfo'].update({'cbsdReferenceId': cbsd_reference_id})    
+    # Update cbsdReferenceID in ppaInfo
+    ppa_record['ppaInfo'].update({'cbsdReferenceId': cbsd_reference_id})
+    
     ppa_records_list.append(ppa_record)
 
   return ppa_records_list

--- a/src/harness/sas_test_harness.py
+++ b/src/harness/sas_test_harness.py
@@ -452,6 +452,8 @@ def generatePpaRecords(ppa_records, cbsd_reference_ids):
     # Check cbsdReferenceID in ppaInfo and add cbsdReferenceID if not present.
     if not ppa_record['ppaInfo'].has_key('cbsdReferenceId'):
       ppa_record['ppaInfo'].update({'cbsdReferenceId': cbsd_reference_id})
+    elif len(ppa_record['ppaInfo']['cbsdReferenceId']) == 0:
+      ppa_record['ppaInfo'].update({'cbsdReferenceId': cbsd_reference_id})    
     ppa_records_list.append(ppa_record)
 
   return ppa_records_list


### PR DESCRIPTION
FAD.2 generates default.config with empty "cbsdReferenceId": [].

According to [WINNF-TS-0096 v1.3.0 SAS-SAS Protocol spec](https://workspace.winnforum.org/higherlogic/ws/public/document?document_id=6482), section 8.5.1 PPA Information Object definition mentions that _cbsdReferenceId_ field is a _"List of one or more CBSD Reference IDs in the cluster list of the PPA"_.

So _ppa_record['ppaInfo']['cbsdReferenceId']_ should also be updated if it's an empty array.