### PR TITLE
Fix DPA builder to work with single point in one DPA area.

### DIFF
--- a/src/harness/reference_models/dpa/dpa_builder.py
+++ b/src/harness/reference_models/dpa/dpa_builder.py
@@ -146,8 +146,9 @@ def DpaProtectionPoints(dpa_name, dpa_geometry, protection_points_method=None):
   else:
     mpoint = sgeo.MultiPoint([(pt.longitude, pt.latitude) for pt in protection_points])
     mpoint_inside = dpa_geometry.buffer(0.0005).intersection(mpoint)
-    if len(mpoint) != len(mpoint_inside):
-      raise ValueError('Some points for DPA `%s` are outside zone.' % dpa_name)
+    if (not isinstance(mpoint, sgeo.Point) and not isinstance(mpoint_inside, sgeo.Point)):
+      if len(mpoint) != len(mpoint_inside):
+        raise ValueError('Some points for DPA `%s` are outside zone.' % dpa_name)
 
   if not protection_points:
     raise ValueError('No valid points generated for DPA `%s`.' % dpa_name)

--- a/src/harness/reference_models/dpa/dpa_builder.py
+++ b/src/harness/reference_models/dpa/dpa_builder.py
@@ -146,9 +146,10 @@ def DpaProtectionPoints(dpa_name, dpa_geometry, protection_points_method=None):
   else:
     mpoint = sgeo.MultiPoint([(pt.longitude, pt.latitude) for pt in protection_points])
     mpoint_inside = dpa_geometry.buffer(0.0005).intersection(mpoint)
-    if (not isinstance(mpoint, sgeo.Point) and not isinstance(mpoint_inside, sgeo.Point)):
-      if len(mpoint) != len(mpoint_inside):
-        raise ValueError('Some points for DPA `%s` are outside zone.' % dpa_name)
+    if isinstance(mpoint_inside, sgeo.Point):
+      mpoint_inside = sgeo.MultiPoint([mpoint_inside])
+    if len(mpoint) != len(mpoint_inside):
+      raise ValueError('Some points for DPA `%s` are outside zone.' % dpa_name)
 
   if not protection_points:
     raise ValueError('No valid points generated for DPA `%s`.' % dpa_name)

--- a/src/harness/reference_models/dpa/dpa_mgr_example.py
+++ b/src/harness/reference_models/dpa/dpa_mgr_example.py
@@ -183,6 +183,11 @@ if __name__ == '__main__':
   print '**East3: %dpts' % len(dpa_zone.protected_points)
   print dpa_zone
 
+  dpa_zone = dpa_mgr.BuildDpa('East3',
+                              protection_points_method='default(1,0,0,0)')
+  print '**East3 (single pt): %dpts' % len(dpa_zone.protected_points)
+  print dpa_zone
+
   dpa_portal = dpa_mgr.BuildDpa('BATH')
   print '**BATH: %dpts' % len(dpa_portal.protected_points)
   print dpa_portal


### PR DESCRIPTION
The check routine will raise exception as they assume a MultiPoint.

Note: this is usually not the case that one use a single point for a DPA, except for testing purpose. 
This fix was requested by ITS so they can more easily debug which point create some issue they see.