### PR TITLE
DPA: properly support grants within  DPA

### DIFF
--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -263,8 +263,9 @@ class Dpa(object):
     # add them into move list for sure later on.
     inside_grants = set()
     if self.geometry and not isinstance(self.geometry, sgeo.Point):
+      dpa_geometry = self.geometry.buffer(1e-6)
       inside_grants = set(g for g in self._grants
-                          if sgeo.Point(g.longitude, g.latitude).within(self.geometry))
+                          if sgeo.Point(g.longitude, g.latitude).within(dpa_geometry))
 
     for chan_idx, (low_freq, high_freq) in enumerate(self._channels):
       moveListConstraint = functools.partial(

--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -263,9 +263,8 @@ class Dpa(object):
     # add them into move list for sure later on.
     inside_grants = set()
     if self.geometry and not isinstance(self.geometry, sgeo.Point):
-      dpa_geometry = self.geometry.buffer(1e-6)
       inside_grants = set(g for g in self._grants
-                          if sgeo.Point(g.longitude, g.latitude).within(dpa_geometry))
+                          if sgeo.Point(g.longitude, g.latitude).intersects(self.geometry))
 
     for chan_idx, (low_freq, high_freq) in enumerate(self._channels):
       moveListConstraint = functools.partial(

--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -45,6 +45,7 @@ import os
 import logging
 
 import numpy as np
+import shapely.geometry as sgeo
 
 from reference_models.geo import zones
 from reference_models.common import data
@@ -109,6 +110,7 @@ class Dpa(object):
 
   Attributes:
     name: The DPA name (informative).
+    geometry: The DPA geometry, as a shapely shape.
     channels: The list of 10MHz channels (freq_min_mhz, freq_max_mhz) to protect for
       that DPA.
     protected_points: A list of namedtuple (latitude, longitude) defining the actual
@@ -155,6 +157,7 @@ class Dpa(object):
     cls.num_iteration = num_iteration
 
   def __init__(self, protected_points,
+               geometry=None,
                name='None',
                threshold=DPA_DEFAULT_THRESHOLD_PER_10MHZ,
                radar_height=DPA_DEFAULT_RADAR_HEIGHT,
@@ -165,6 +168,7 @@ class Dpa(object):
                monitor_type='esc'):
     """Initialize the DPA attributes."""
     self.name = name
+    self.geometry = geometry
     self.protected_points = protected_points
     self.threshold = threshold
     self.radar_height = radar_height
@@ -180,10 +184,11 @@ class Dpa(object):
 
   def __str__(self):
     """Returns the DPA str."""
-    return ('Dpa(protected_points=%r, threshold=%.1f, radar_height=%.1f,'
+    return ('Dpa(protected_points=%r, geometry=%r, threshold=%.1f, radar_height=%.1f,'
             'beamwidth=%.1f, azimuth_range=%r, channels=%r,'
             'neighbor_distances=%r, monitor_type=%r)' % (
-                self.protected_points, self.threshold, self.radar_height,
+                self.protected_points, self.geometry,
+                self.threshold, self.radar_height,
                 self.beamwidth, self.azimuth_range, self._channels,
                 self.neighbor_distances, self.monitor_type))
 
@@ -254,12 +259,22 @@ class Dpa(object):
     logging.debug('  protected points: %s', self.protected_points)
     pool = mpool.Pool()
     self.ResetLists()
+    # Manage inside grants by special processing: always on move list, and
+    # we filter them out from the per point move list process.
+    grants = self._grants
+    inside_grants = set()
+    if self.geometry and not isinstance(self.geometry, sgeo.Point):
+      inside_grants = set(g for g in self._grants
+                          if sgeo.Point(g.longitude, g.latitude).within(self.geometry))
+      if inside_grants:
+        grants = list(set(self._grants).difference(inside_grants))
+
     for chan_idx, (low_freq, high_freq) in enumerate(self._channels):
       moveListConstraint = functools.partial(
           ml.moveListConstraint,
           low_freq=low_freq * 1.e6,
           high_freq=high_freq * 1.e6,
-          grants=self._grants,
+          grants=grants,
           inc_ant_height=self.radar_height,
           num_iter=Dpa.num_iteration,
           threshold=self.threshold,
@@ -273,6 +288,10 @@ class Dpa(object):
       # Combine the individual point move lists
       move_list = set().union(*move_list)
       nbor_list = set().union(*nbor_list)
+      include_grants = ml.filterGrantsForFreqRange(
+          inside_grants, low_freq * 1.e6, high_freq * 1.e6)
+      move_list.update(include_grants)
+      nbor_list.update(include_grants)
       self.move_lists[chan_idx] = move_list
       self.nbor_lists[chan_idx] = nbor_list
 
@@ -831,6 +850,7 @@ def BuildDpa(dpa_name, protection_points_method=None, portal_dpa_filename=None):
                         dpa_zone.catAOOBNeighborhoodDistanceKm,
                         dpa_zone.catBOOBNeighborhoodDistanceKm)
   return Dpa(protection_points,
+             geometry=dpa_zone.geometry,
              name=dpa_name,
              threshold=protection_threshold,
              radar_height=radar_height,

--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -259,22 +259,19 @@ class Dpa(object):
     logging.debug('  protected points: %s', self.protected_points)
     pool = mpool.Pool()
     self.ResetLists()
-    # Manage inside grants by special processing: always on move list, and
-    # we filter them out from the per point move list process.
-    grants = self._grants
+    # Detect the inside "inside grants", which will allow to
+    # add them into move list for sure later on.
     inside_grants = set()
     if self.geometry and not isinstance(self.geometry, sgeo.Point):
       inside_grants = set(g for g in self._grants
                           if sgeo.Point(g.longitude, g.latitude).within(self.geometry))
-      if inside_grants:
-        grants = list(set(self._grants).difference(inside_grants))
 
     for chan_idx, (low_freq, high_freq) in enumerate(self._channels):
       moveListConstraint = functools.partial(
           ml.moveListConstraint,
           low_freq=low_freq * 1.e6,
           high_freq=high_freq * 1.e6,
-          grants=grants,
+          grants=self._grants,
           inc_ant_height=self.radar_height,
           num_iter=Dpa.num_iteration,
           threshold=self.threshold,

--- a/src/harness/reference_models/dpa/move_list.py
+++ b/src/harness/reference_models/dpa/move_list.py
@@ -99,6 +99,22 @@ def findDpaType(low_freq, high_freq):
   raise ValueError('Invalid DPA frequency range')
 
 
+def filterGrantsForFreqRange(grants, low_freq, high_freq):
+  """Returns a list of all grants affecting a protected frequency range.
+
+  Args:
+    grants: A list of |data.CbsdGrantInfo| grants.
+    low_freq: The minimum frequency (Hz).
+    high_freq: The maximum frequency (Hz).
+  """
+  chan_type = findDpaType(low_freq, high_freq)
+  if chan_type == DpaType.OUT_OF_BAND:
+    # All grants affect COCHANNEL, including those higher than 3650MHz.
+    return grants
+  return [g for g in grants
+          if (min(g.high_frequency, high_freq) - max(g.low_frequency, low_freq)) > 0]
+
+
 def findGrantsInsideNeighborhood(grants, constraint,
                                  dpa_type,
                                  neighbor_distances):


### PR DESCRIPTION
Simply make sure that the "inside DPA" grants are included in the proper move list
after the regular processing:
  - for inband channel, include all the grant which overlaps
  - for OOB, include all the grants 

This method insures that we would get same move list results as if we were adding 
protection points exactly under each CBSD. 

Note that initial implementation was proposing to first filter out the grants inside the DPA and then run
the move list on the remaining outside grants. This is somewhat a bit more optimal in theory, 
although we do not expect a major difference in practice. It has the disadvantage of changing 
a bit more the philosophy of the move list algorithm, and thus requires handling a special case.

Adding unit test on the logic implemented. 
And for sake of improving DPA unit test, added some more unit test which was part of
the dpa_mgr_example.py