### PR TITLE
DPA: Fix the CheckInterference loggers for "inside" grants.

### DIFF
--- a/src/harness/reference_models/dpa/dpa_mgr.py
+++ b/src/harness/reference_models/dpa/dpa_mgr.py
@@ -468,7 +468,7 @@ class Dpa(object):
       # used for logging purpose (although it could be passed to the interference
       # check routine for faster operation).
       est_keep_list_uut_managing_sas = ml.getDpaNeighborGrants(
-          sas_uut_active_grants, self.protected_points,
+          sas_uut_active_grants, self.protected_points, self.geometry,
           low_freq=channel[0] * 1e6, high_freq=channel[1] * 1e6,
           neighbor_distances=self.neighbor_distances)
       try:


### PR DESCRIPTION
Previous PR has introduced special code to include all inside grants
in move list and neighbor list.
Unfortunately this let the logger used for analysing DPA margin failures
not perfectly in line. The SAS_UUT active list of grants (reported to
the log only) would not show some of the inside grants.
This PR fixes that.

Note that this PR has no effect whatsoever on the DPA operation, just on
the logging that is used for post analysis (only when required because
of a failure), possibly with provided script:
tools/studies/dpa_margin_sim.py.