### PR TITLE
esc_pop_impact: new mode  for computing full pop within neighborhood

### DIFF
--- a/src/lib/geo/README.md
+++ b/src/lib/geo/README.md
@@ -1,0 +1,8 @@
+## Geo modules for WinnForum Propagation
+
+This folders holds the few modules necessary for the Winnforum propagation:
+
+ - extra: extra routines used in various studies. These are usually not used 
+   by the core test harness.
+
+Note:: most geo modules are currently in src/harness/reference_models/geo/

--- a/src/lib/geo/geo_utils_test.py
+++ b/src/lib/geo/geo_utils_test.py
@@ -1,0 +1,90 @@
+#    Copyright 2020 SAS Project Authors. All Rights Reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+
+"""Unit test for the geo_utils.py library."""
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+
+import os
+import unittest
+
+import numpy as np
+import shapely.geometry as sgeo
+
+from geo import geo_utils
+from reference_models.geo import utils
+
+
+class TestGeoUtils(unittest.TestCase):
+
+  def assertSeqAlmostEqual(self, in1, in2, places=7):
+    """Asserts if 2 (possibly nested) sequences are almost equal."""
+    for i1, i2 in zip(in1, in2):
+      try:
+        iter(i1)
+      except TypeError:
+        self.assertAlmostEqual(i1, i2, places)
+      else:
+        for k1, k2 in zip(i1, i2):
+          self.assertAlmostEqual(k1, k2, places)
+
+  def test_buffer_point(self):
+    pt = sgeo.Point(-110, 40)
+    circle = geo_utils.Buffer(pt, 20, resolution=256)
+    area = utils.GeometryArea(circle)
+    self.assertLess(np.abs(area - np.pi*20**2), 0.001 * area)
+
+  def test_buffer_poly(self):
+    pt = sgeo.Point(-110, 40)
+    circle = geo_utils.Buffer(pt, 20, resolution=256)
+    circle = geo_utils.Buffer(circle, 10, resolution=256)
+    area = utils.GeometryArea(circle)
+    self.assertLess(np.abs(area - np.pi*30**2), 0.001 * area)
+
+  def test_shrink_poly(self):
+    pt = sgeo.Point(-110, 40)
+    circle = geo_utils.Buffer(pt, 20, resolution=256)
+    circle = geo_utils.Buffer(circle, -10, resolution=256)
+    area = utils.GeometryArea(circle)
+    self.assertLess(np.abs(area - np.pi*10**2), 0.001 * area)
+
+  def test_buffer_json_poly(self):
+    pt = sgeo.Point(-110, 40)
+    circle = geo_utils.Buffer(pt, 20)
+    json_circle = utils.ToGeoJson(circle)
+    json_circle = geo_utils.Buffer(json_circle, 10)
+    area = utils.GeometryArea(json_circle)
+    self.assertLess(np.abs(area - np.pi*30**2), 0.002 * area)
+
+  def test_grid_polygon_approx(self):
+    poly = sgeo.Polygon([(0, 59), (0, 61), (2, 61), (2, 59)])
+    pts = geo_utils.GridPolygonApprox(poly, res_km=100.)
+    self.assertEqual(len(pts), 4)
+    self.assertSeqAlmostEqual(pts, [(0, 59.4883), (0, 60.3896),
+                                    (1.7442, 59.4883), (1.7442, 60.3896)], 4)
+    pts = geo_utils.GridPolygonApprox(poly, res_km=110.95)
+    self.assertEqual(len(pts), 4)
+    self.assertSeqAlmostEqual(pts, [(0, 59.), (0, 60.),
+                                    (1.935, 59.), (1.935, 60.)], 2)
+
+  def test_sample_line(self):
+    line = sgeo.LineString([(0, 50), (0, 60), (40, 60), (40, 70)])
+    pts = geo_utils.SampleLine(line, 10*110.946)
+    self.assertEqual(len(pts), 5)
+    self.assertSeqAlmostEqual(pts, [(0, 50), (0, 60.),
+                                    (19.933, 60.), (39.866, 60)], 3)
+
+if __name__ == '__main__':
+  unittest.main()

--- a/src/studies/esc_impact_pop/README.md
+++ b/src/studies/esc_impact_pop/README.md
@@ -1,18 +1,32 @@
 # Population-based ESC impact.
 
-This module allows for evaluating the impact of ESC, by counting
+The `esc_pop_impact` module allows for evaluating the impact of ESC sensors, by counting
 the population that falls within a "whisper zone".
 
-The whisper zone is defined as the area for which: if a CBSD was deployed
-then its power would be reduced. An optional `budget_link_offset` can be
-used to scale the whisper zone definition to include those area for which
-a deployed CBSD power reduction would be above that offset. Or it can be
-used to simulate a noise rise, i.e. counting the impact if there was a certain
-number of CBSD deployed.
+The whisper zone is defined as the area such as if a single CBSD was deployed
+then its power would be reduced. 
 
-This is done by gridding the sensor neighborhood area at a given resolution (`grid_arcsec`), 
+## Methodology
+
+The sensor neighborhood area is gridded at a given resolution (`grid_arcsec`), 
 where the neighborhood is defined as all areas within 80km for CatB and 40km for CatA.
-The neighborhood distance can be forced to other value for simulation speedup.
+Note: The neighborhood distance can be forced to other value for simulation speedup.
+
+Path loss and interference reception level is then computed on each cell of this grid. 
+All cell for which the ESC sensor protection level (-109dBm/MHz) is exceeded is then 
+added to derive the so called population impact.
+
+Note that to have uniquely defined whisper zone, some assumptions are done:
+ + CatB: 25m high, 80km radius
+ + CatA outdoor: 6m high, 40km radius
+ + CatA indoor: 5m high, 40km radius
+
+The CBSD antenna is taken as omnidirectional which is a good modeling for both CatA, and multi-sector CatBs.
+
+An optional `budget_link_offset` can be used to scale the whisper zone
+definition to include those area for which a deployed CBSD power reduction
+would be above that offset.  This offset can also be used to simulate a 
+noise rise, i.e. counting the impact of many CBSD deployed. 
 
 
 ## Installation
@@ -58,4 +72,38 @@ Sensors:
     E01_left : 27.252 kpops (1000s)
 ```
 
+
+## Special mode to compute the population neighborhood
+
+This mode allows to compute the population in each sensor neighborhood
+independently of the actual propagation. In other words it computes the full
+population that is present in the 80km (catB) or 40km neighborhoods.
+
+Example
+
+```bash
+python esc_pop_impact.py --esc_fads=testdata/esc_test.json --nbor_pop_only
+```
+
+This shall output:
+
+```
+## Measuring impact of ESC networks
+Loading ESC networks
+** Init population raster: Lazy loading **
+.. done in 0s
+** Evaluating population impact **
+**  SPECIAL MODE: population within neighborhood. **
+ESC Network processing: #0
+... processing: E01_left
+      86428 pops
+*** Network Total: 86428 pops
+.. done in 12s
+** Final results **
+Total Population: 86.428 kpops (1000s)
+Network:
+    0 : 86.428 kpops (1000s)
+Sensors:
+    E01_left : 86.428 kpops (1000s)
+```
 

--- a/src/studies/esc_impact_pop/esc_pop_impact.py
+++ b/src/studies/esc_impact_pop/esc_pop_impact.py
@@ -47,7 +47,6 @@ Notes:
 import argparse
 import ast
 import collections
-import cPickle
 import json
 import os
 import time

--- a/src/studies/esc_impact_pop/esc_pop_impact.py
+++ b/src/studies/esc_impact_pop/esc_pop_impact.py
@@ -60,7 +60,7 @@ from reference_models.geo import utils
 from reference_models.geo import zones
 from reference_models.propagation import wf_itm
 from usgs_pop import usgs_pop_driver
-import geo_utils
+from geo import geo_utils
 
 #----------------------------------------
 # Setup the command line arguments

--- a/src/studies/esc_impact_pop/esc_pop_impact.py
+++ b/src/studies/esc_impact_pop/esc_pop_impact.py
@@ -20,10 +20,10 @@ covered by a whisper zone.
 Usage:
   # Measure ESC impact for category B, in a reasonably "fast mode".
   # (for all sensors in New Jersey and NYC + Long Island)
-  esc_impact --esc_fads=a_fad.json,other_fad.json \
-             --grid_arcsec=10 --category=B \
-             --filter_box="(39, -75, 41, -72)"  \
-             --fast_mode --force_radius_km=50
+  esc_pop_impact --esc_fads=a_fad.json,other_fad.json \
+                 --grid_arcsec=10 --category=B \
+                 --filter_box="(39, -75, 41, -72)"  \
+                 --fast_mode --force_radius_km=50
 
 Notes:
   - One or several ESC fads can be specified. Aggregated statistics will be
@@ -41,6 +41,8 @@ Notes:
     + with force_radius_km: one can specify 50k CatB neighborhood for example
       (instead of regular 80km), as it is usually sufficient to capture the effective
       whisper zones.
+  - A special mode '--nbor_pop_only' allows to compute the total population in the
+    neighborhood, without any consideration of path loss.
 """
 import argparse
 import ast
@@ -90,6 +92,10 @@ parser.add_argument('--lazy_pop', dest='lazy_pop', action='store_true',
 parser.add_argument('--nolazy_pop', dest='lazy_pop', action='store_false',
                     help='Disable lazy population loading - Load all at init.')
 parser.set_defaults(lazy_pop=True)
+
+parser.add_argument('--nbor_pop_only', dest='nbor_pop_only', action='store_true',
+                    help='Only compute neighborhood population.')
+parser.set_defaults(nbor_pop_only=False)
 
 FLAGS = parser.parse_args()
 
@@ -224,7 +230,8 @@ def PopulationImpact(networks,
                      offset_db,
                      popper,
                      filter_box=None,
-                     forced_radius_km=None):
+                     forced_radius_km=None,
+                     nbor_pop_only=False):
   """Analyse some ESC network(s) in terms of population impact.
 
   Args:
@@ -237,6 +244,7 @@ def PopulationImpact(networks,
     filter_box: A tuple (min_lat, min_lon, max_lat, max_lon) defining a bounding
       box for sensors to be processed.
     forced_radius_km: If set, override the regular radius of the CBSD category.
+    nbor_pop_only: If set, computes only the neighborhood population
 
   Returns:
     A tuple (total_pop, pop_per_network, pop_per_sensor) holding:
@@ -289,16 +297,20 @@ def PopulationImpact(networks,
                                                 sensor.longitude,
                                                 nbor_radius_km, res_arcsec)
       lats, lons = np.array(lats), np.array(lons)
-      losses_db, esc_bearings, _ = CalcEscPathLoss(sensor.latitude,
-                                                   sensor.longitude,
-                                                   sensor.height, lats, lons,
-                                                   cbsd_height)
-      masked_losses_db = MaskPathLoss(losses_db, esc_bearings,
-                                      sensor.ant_pattern, sensor.ant_azimuth)
-      sig_level_dbm = cbsd_eirp_dbm_per_mhz - masked_losses_db - extra_loss
+      if not nbor_pop_only:
+        losses_db, esc_bearings, _ = CalcEscPathLoss(sensor.latitude,
+                                                     sensor.longitude,
+                                                     sensor.height, lats, lons,
+                                                     cbsd_height)
+        masked_losses_db = MaskPathLoss(losses_db, esc_bearings,
+                                        sensor.ant_pattern, sensor.ant_azimuth)
+        sig_level_dbm = cbsd_eirp_dbm_per_mhz - masked_losses_db - extra_loss
 
-      # Detect the points that are impacted
-      idxs = np.where(sig_level_dbm >= sensor.protection_level - offset_db)[0]
+        # Detect the points that are impacted
+        idxs = np.where(sig_level_dbm >= sensor.protection_level - offset_db)[0]
+
+      else:
+        idxs = np.arange(len(lats))
 
       # Compute the standalone population impact for that sensor.
       pop_per_sensor[sensor.name] = (
@@ -373,10 +385,12 @@ if __name__ == '__main__':
 
   # Compute the population impact
   print('** Evaluating population impact **')
+  if FLAGS.nbor_pop_only:
+    print('**  SPECIAL MODE: population within neighborhood. **')
   start_time = time.time()
   total_pop, pop_per_network, pop_per_sensor = PopulationImpact(
       networks, FLAGS.category, FLAGS.grid_arcsec, FLAGS.budget_offset_db,
-      popper, filter_box, FLAGS.force_radius_km)
+      popper, filter_box, FLAGS.force_radius_km, FLAGS.nbor_pop_only)
   print('.. done in %ds' % int(time.time() - start_time))
 
   # Ouput final statistics


### PR DESCRIPTION
New mode `--nbor_pop_only' for computing full population in sensor neighborhood, in order to play with various statistics.

Usage:
 python esc_pop_impact.py --esc_fads=testdata/esc_test.json --nbor_pop_only

Also minor cleanup by moving geo_utils in its own library module.