### PR TITLE
Fix running S[CDS]S testcases under python 3.7 + OpenSSL 1.1.1

### DIFF
--- a/src/harness/certs/generate_short_lived_certs.sh
+++ b/src/harness/certs/generate_short_lived_certs.sh
@@ -44,7 +44,8 @@ function generate_cbsd_short_lived_certificate() {
     openssl_db cbsd_ca ca -in $1.csr -out $1.cert \
         -policy policy_anything -extensions cbsd_req_sign \
         -batch -notext -create_serial -utf8 -days 1185 -md sha384 -enddate $enddate_value
-        return 0
+    cat cbsd_ca.cert >> $1.cert
+    return 0
   fi
   echo "The intermediate CBSD CA file not found."
   return -1
@@ -70,6 +71,7 @@ function generate_dp_short_lived_certificate() {
     openssl_db proxy_ca ca -in $1.csr -out $1.cert \
         -policy policy_anything -extensions oper_req_sign \
         -batch -notext -create_serial -utf8 -days 1185 -md sha384 -enddate $enddate_value
+    cat proxy_ca.cert >> $1.cert
     return 0
   fi
   echo "The intermediate Domain Proxy CA file not found."

--- a/src/harness/request_handler.py
+++ b/src/harness/request_handler.py
@@ -139,9 +139,9 @@ def _Request(url, request, config, is_post_method):
   if is_post_method:
     conn.setopt(conn.POST, True)
     conn.setopt(conn.POSTFIELDS, request)
-    logging.info('POST Request to URL %s :\n%s', url, request)
+    logging.debug('POST Request to URL %s :\n%s', url, request)
   else:
-    logging.info('GET Request to URL %s', url)
+    logging.debug('GET Request to URL %s', url)
 
   error = None
   for attempt_count in range(MAX_REQUEST_ATTEMPT_COUNT):
@@ -166,7 +166,7 @@ def _Request(url, request, config, is_post_method):
   http_code = conn.getinfo(pycurl.HTTP_CODE)
   conn.close()
   body = response.getvalue().decode('utf-8')
-  logging.info('Response:\n' + body)
+  logging.debug('Response:\n' + body)
 
   if not (200 <= http_code <= 299):
     raise HTTPError(http_code)

--- a/src/harness/util_test.py
+++ b/src/harness/util_test.py
@@ -28,6 +28,15 @@ import util
 
 class UtilTest(unittest.TestCase):
 
+  def test_decode_openssl_version(self):
+    self.assertEqual(
+        util._decode_openssl_version('OpenSSL 1.1.1j  16 Feb 2021'), 111)
+    self.assertEqual(
+        util._decode_openssl_version('OpenSSL 1.0.2t  20 Dec 2019'), 102)
+    self.assertEqual(
+        util._decode_openssl_version('OpenSSL 0.9.8f [24 Mar 2010]'), 98)
+    self.assertEqual(util._decode_openssl_version('BoringSSL'), -1)
+
   def test_getFqdnLocalhost(self):
     # Initialize the testConfig with our test data.
     util._test_config = util._GetSharedTestConfig()


### PR DESCRIPTION
Code migration for Python3: ensure S[CDS]S testcases running under python 3.7 and openSSL 1.1.1