### PR TITLE
fix Leapday bug - Just changing Year does not work for Feb 29

### DIFF
--- a/src/harness/util2.py
+++ b/src/harness/util2.py
@@ -18,7 +18,7 @@ from __future__ import division
 from __future__ import print_function
 
 from collections import defaultdict
-from datetime import datetime
+from datetime import datetime, timedelta
 import inspect
 import json
 import os
@@ -46,9 +46,9 @@ def makePalRecordsConsistent(pal_records, low_frequency, high_frequency,
     Note: The PAL Dictionary must contain censusYear(number) and
           fipsCode(number)
   """
-  start_date = datetime.now().replace(year=datetime.now().year - 1) \
+  start_date = datetime.now() - timedelta(days=365) \
     if start_date is None else start_date
-  end_date = datetime.now().replace(year=datetime.now().year + 1) \
+  end_date = datetime.now() + timedelta(days=365) \
     if end_date is None else end_date
 
   for index, pal_rec in enumerate(pal_records):
@@ -102,8 +102,8 @@ def makePpaAndPalRecordsConsistent(ppa_record, pal_records, low_frequency,
     Note: The PAL Dictionary must contain countyYear(number) and
           fipsCode(number)
   """
-  start_date = datetime.now().replace(year=datetime.now().year - 1)
-  end_date = datetime.now().replace(year=datetime.now().year + 1)
+  start_date = datetime.now() - timedelta(days=365)
+  end_date = datetime.now() + timedelta(days=365)
 
   pal_records = makePalRecordsConsistent(pal_records, low_frequency,
                                          high_frequency, user_id,

--- a/src/harness/util2.py
+++ b/src/harness/util2.py
@@ -26,6 +26,8 @@ import uuid
 
 import jsonschema
 
+DAYS_IN_A_YEAR = 365
+
 def makePalRecordsConsistent(pal_records, low_frequency, high_frequency,
                              user_id, fcc_channel_id="1",
                              start_date=None, end_date=None):
@@ -46,9 +48,9 @@ def makePalRecordsConsistent(pal_records, low_frequency, high_frequency,
     Note: The PAL Dictionary must contain censusYear(number) and
           fipsCode(number)
   """
-  start_date = datetime.now() - timedelta(days=365) \
+  start_date = datetime.now() - timedelta(days = DAYS_IN_A_YEAR) \
     if start_date is None else start_date
-  end_date = datetime.now() + timedelta(days=365) \
+  end_date = datetime.now() + timedelta(days = DAYS_IN_A_YEAR) \
     if end_date is None else end_date
 
   for index, pal_rec in enumerate(pal_records):
@@ -102,8 +104,8 @@ def makePpaAndPalRecordsConsistent(ppa_record, pal_records, low_frequency,
     Note: The PAL Dictionary must contain countyYear(number) and
           fipsCode(number)
   """
-  start_date = datetime.now() - timedelta(days=365)
-  end_date = datetime.now() + timedelta(days=365)
+  start_date = datetime.now() - timedelta(days = DAYS_IN_A_YEAR)
+  end_date = datetime.now() + timedelta(days = DAYS_IN_A_YEAR)
 
   pal_records = makePalRecordsConsistent(pal_records, low_frequency,
                                          high_frequency, user_id,


### PR DESCRIPTION
`util2.py` increments and decrements just the Year for Start and End dates.
However, this fails for Leap Day (Feb. 29) since this date doesn't exist in the preceding and subsequent years.

Suggesting instead to increment and decrement the date by 365 days using timedelta.

fixes #912 